### PR TITLE
Work around segfault when using -Wl-yp

### DIFF
--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -860,8 +860,8 @@ static void opt(char *arg) {
 					sprintf(tmp, "%c%c%c", arg[3], arg[4], arg[5]); //-yo -ya -yt -yl -yk -yn -yp
 					if (!(arg[5] == 'c' || arg[5] == 'C' || arg[5] == 's'  || arg[5] == 'S' || arg[5] == 'j' || arg[5] == 'p')) // Don't add second arg for -yc -yC -ys -yS -yj
 						sprintf(tmp2, "%s", &arg[6]);
-
-					// This flag does erroneously not use space
+					// -yp of SDCC 4.1.0's makebin erroneously does not use a space between flag and it's value
+					// So append trailing values to first arg that would otherwise go in the second arg
 					if (arg[5] == 'p')
 						sprintf(tmp, "%s", &arg[3]);
 

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -858,8 +858,12 @@ static void opt(char *arg) {
 				tmp2[0] = '\0'; // Zero out second arg by default
 				if(arg[4] == 'y') {
 					sprintf(tmp, "%c%c%c", arg[3], arg[4], arg[5]); //-yo -ya -yt -yl -yk -yn -yp
-					if (!(arg[5] == 'c' || arg[5] == 'C' || arg[5] == 's'  || arg[5] == 'S' || arg[5] == 'j')) // Don't add second arg for -yc -yC -ys -yS -yj
+					if (!(arg[5] == 'c' || arg[5] == 'C' || arg[5] == 's'  || arg[5] == 'S' || arg[5] == 'j' || arg[5] == 'p')) // Don't add second arg for -yc -yC -ys -yS -yj
 						sprintf(tmp2, "%s", &arg[6]);
+
+					// This flag does erroneously not use space
+					if (arg[5] == 'p')
+						sprintf(tmp, "%s", &arg[3]);
 
 					// If MBC option is present for makebin (-Wl-yt <n> or -Wm-yt <n>) then make a copy for bankpack to use
 					if (arg[5] == 't')


### PR DESCRIPTION
`-Wl-yp`/`-Wm-yp` currently makes 4.1.0's makebin segfault, which results in lcc emitting:
> lcc: fatal error in /usr/bin//makebin