### PR TITLE
Png2mtspr : empty metasprites and fix for pngs over 255 pixels in height or width

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ VER = 3.00
 
 # Prefix to add to the standard tools.  Usefull for a standard gcc
 # cross-compile.
+# TOOLSPREFIX = i686-w64-mingw32-
 TOOLSPREFIX =
 
 TARGETCC = $(TOOLSPREFIX)gcc

--- a/gbdk-support/png2mtspr/Makefile
+++ b/gbdk-support/png2mtspr/Makefile
@@ -1,7 +1,10 @@
 # *****************************************************
 # Variables to control Makefile operation
- 
-CXX = g++
+
+# Might want when doing linux -> win cross build
+# LFLAGS = -s -static
+
+CXX = $(TOOLSPREFIX)g++
 CXXFLAGS = -Os -Wall -g
 LFLAGS = -g
 


### PR DESCRIPTION
* Turns off suppression of "blank" metapsrite frames (frames composed of entirely transparent sprites). 
* Fix endless loop bug for png files taller than 255 pixels (unsigned char used for x/y coordinates), also tidy a (int) to (long int) comparison warning and harmonize the types a little more (`int` is used most by function params, so that was used)

* Also add missing tools prefix for cross-compile support in Makefile (empty and not used by default)