### PR TITLE
Bankpack: Fix -yt mbc specifier to also accept Decimal to match makebin -yt

### DIFF
--- a/docs/pages/20_toolchain_settings.md
+++ b/docs/pages/20_toolchain_settings.md
@@ -413,7 +413,7 @@ Use: Read .o files and auto-assign areas with bank=255.
 
 Options
 -h           : Show this help
--yt<hexbyte> : Set MBC type per ROM byte 149 in Hex (see pandocs)
+-yt<mbctype> : Set MBC type per ROM byte 149 in Decimal or Hex (0xNN) (see pandocs)
 -mbc=N       : Similar to -yt, but sets MBC type directly to N instead
                of by intepreting ROM byte 149
                mbc1 will exclude banks {0x20,0x40,0x60} max=127, 

--- a/gbdk-lib/examples/gb/banks_autobank/Makefile
+++ b/gbdk-lib/examples/gb/banks_autobank/Makefile
@@ -33,16 +33,16 @@ make.bat: Makefile
 # -Wb-v        : Prints out assigned autobank info (optional)
 # -Wl-yoA      : Have makebin automatically calculate required number of ROM banks (otherwise use -Wl-yo4 in this example)
 # -Wl-ya4      : Use 4 RAM banks
-# -Wl-yt19     : Use MBC5 cartridge type
+# -Wl-yt0x1B   : Use MBC5+RAM+BATTERY cartridge type 
 $(BINS):	$(OBJS)
-	$(LCC) $(CFLAGS) -autobank -Wb-ext=.rel -Wb-v -Wl-yt19 -Wl-yoA -Wl-ya4 -o $(BINS) $(OBJS)
+	$(LCC) $(CFLAGS) -autobank -Wb-ext=.rel -Wb-v -Wl-yt0x1B -Wl-yoA -Wl-ya4 -o $(BINS) $(OBJS)
 
 
 # It's also possible to do all the compiling, autobanking and linking in a single call to lcc
 # with none of the other makefile "targets" above. You can try this target out by using "make onepass".
 # Notice that the input files are the .c and .asm sources instead of the compiled object files.
 onepass:
-		$(LCC) $(CFLAGS) -autobank -Wb-ext=.rel -Wb-v -Wl-yt19 -Wl-yoA -Wl-ya4 -o $(BINS) $(CSOURCES) $(ASMSOURCES)
+		$(LCC) $(CFLAGS) -autobank -Wb-ext=.rel -Wb-v -Wl-yt0x1B -Wl-yoA -Wl-ya4 -o $(BINS) $(CSOURCES) $(ASMSOURCES)
 
 
 clean:
@@ -51,7 +51,8 @@ clean:
 
 # For lcc linker option: -Wl-ytN where N is one of the numbers below
 #
-# ROM Byte 0147: Cartridge type:
+# ROM Byte 0147: Cartridge type 
+#
 # 0-ROM ONLY            12-ROM+MBC3+RAM
 # 1-ROM+MBC1            13-ROM+MBC3+RAM+BATT
 # 2-ROM+MBC1+RAM        19-ROM+MBC5

--- a/gbdk-support/bankpack/bankpack.c
+++ b/gbdk-support/bankpack/bankpack.c
@@ -29,7 +29,7 @@ static void display_help(void) {
        "\n"
        "Options\n"
        "-h           : Show this help\n"
-       "-yt<hexbyte> : Set MBC type per ROM byte 149 in Hex (see pandocs)\n"
+       "-yt<mbctype> : Set MBC type per ROM byte 149 in Decimal or Hex (0xNN) (see pandocs)\n"
        "-mbc=N       : Similar to -yt, but sets MBC type directly to N instead\n"
        "               of by intepreting ROM byte 149\n"
        "               mbc1 will exclude banks {0x20,0x40,0x60} max=127, \n"
@@ -90,7 +90,7 @@ static int handle_args(int argc, char * argv[]) {
             } else if (strstr(argv[i], "-mbc=")) {
                 banks_set_mbc(atoi(argv[i] + 5));
             } else if (strstr(argv[i], "-yt")) {
-                banks_set_mbc_by_rom_byte_149(strtol(argv[i] + 3, NULL, 16));
+                banks_set_mbc_by_rom_byte_149(strtol(argv[i] + 3, NULL, 0));
             } else if (strstr(argv[i], "-v")) {
                 option_set_verbose(true);
             } else if (strstr(argv[i], "-sym=")) {


### PR DESCRIPTION
Makebin -yt accepts both Hex and Decimal (via stroul auto-detect), update bankpack to be the same.
* Correct wrong numeric format used in autobank example makefile, also change it's MBC type to one that has RAM to match the existing -ya4 specifier. 
* Update related toolchain arguments doc