### PR TITLE
Support tools: Fix argument handling

### DIFF
--- a/gbdk-support/bankpack/bankpack.c
+++ b/gbdk-support/bankpack/bankpack.c
@@ -70,32 +70,32 @@ static int handle_args(int argc, char * argv[]) {
     for (i = 1; i <= (argc -1); i++ ) {
 
         if (argv[i][0] == '-') {
-            if (strstr(argv[i], "-h")) {
+            if (strstr(argv[i], "-h") == argv[i]) {
                 display_help();
                 return false;  // Don't parse input when -h is used
-            } else if (strstr(argv[i], "-min=")) {
+            } else if (strstr(argv[i], "-min=") == argv[i]) {
                 if (!banks_set_min(atoi(argv[i] + 5))) {
                     printf("BankPack: ERROR: Invalid min bank: %s\n", argv[i] + 5);
                     return false;
                 }
-            } else if (strstr(argv[i], "-max=")) {
+            } else if (strstr(argv[i], "-max=") == argv[i]) {
                 if (!banks_set_max(atoi(argv[i] + 5))) {
                     printf("BankPack: ERROR: Invalid max bank: %s\n", argv[i] + 5);
                     return false;
                 }
-            } else if (strstr(argv[i], "-ext=")) {
+            } else if (strstr(argv[i], "-ext=") == argv[i]) {
                 files_set_out_ext(argv[i] + 5);
-            } else if (strstr(argv[i], "-path=")) {
+            } else if (strstr(argv[i], "-path=") == argv[i]) {
                 files_set_out_path(argv[i] + 6);
-            } else if (strstr(argv[i], "-mbc=")) {
+            } else if (strstr(argv[i], "-mbc=") == argv[i]) {
                 banks_set_mbc(atoi(argv[i] + 5));
-            } else if (strstr(argv[i], "-yt")) {
+            } else if (strstr(argv[i], "-yt") == argv[i]) {
                 banks_set_mbc_by_rom_byte_149(strtol(argv[i] + 3, NULL, 0));
-            } else if (strstr(argv[i], "-v")) {
+            } else if (strstr(argv[i], "-v") == argv[i]) {
                 option_set_verbose(true);
-            } else if (strstr(argv[i], "-sym=")) {
+            } else if (strstr(argv[i], "-sym=") == argv[i]) {
                 symbol_match_add(argv[i] + 5);
-            } else if (strstr(argv[i], "-cartsize")) {
+            } else if (strstr(argv[i], "-cartsize") == argv[i]) {
                 g_option_cartsize = true;
             } else
                 printf("BankPack: Warning: Ignoring unknown option %s\n", argv[i]);

--- a/gbdk-support/gbcompress/main.c
+++ b/gbdk-support/gbcompress/main.c
@@ -59,12 +59,12 @@ int handle_args(int argc, char * argv[]) {
     for (i = 1; i < (argc - 2); i++ ) {
 
         if (argv[i][0] == '-') {
-            if (strstr(argv[i], "-h")) {
+            if (strstr(argv[i], "-h") == argv[i]) {
                 display_help();
                 return false;  // Don't parse input when -h is used
-            } else if (strstr(argv[i], "-v")) {
+            } else if (strstr(argv[i], "-v") == argv[i]) {
                 opt_verbose = true;
-            } else if (strstr(argv[i], "-d")) {
+            } else if (strstr(argv[i], "-d") == argv[i]) {
                 opt_mode_compress = false;
             } else
                 printf("BankPack: Warning: Ignoring unknown option %s\n", argv[i]);

--- a/gbdk-support/ihxcheck/ihxcheck.c
+++ b/gbdk-support/ihxcheck/ihxcheck.c
@@ -50,10 +50,11 @@ int handle_args(int argc, char * argv[]) {
     // Start at first optional argument, argc is zero based
     for (i = 1; i <= (argc -1); i++ ) {
 
-        if (strstr(argv[i], "-h")) {
+        if (strstr(argv[i], "-h") == argv[i]) {
             display_help();
             return false;  // Don't parse input when -h is used
-        } else if (strstr(argv[i], "-e")) {
+
+        } else if (strstr(argv[i], "-e") == argv[i]) {
             set_option_warnings_as_errors(true);
         }
 


### PR DESCRIPTION
Fix argument handling that might accidentally match mid-parameter, but should only match at start of parameter (bankpack, ihxcheck, gbcompress)