### PR TITLE
Lcc fixes and improvements: ihx -> gb, linkerfile, add linkerfile example, -nocrt

### DIFF
--- a/gbdk-lib/examples/gb/linkerfile/Makefile
+++ b/gbdk-lib/examples/gb/linkerfile/Makefile
@@ -5,7 +5,7 @@
 
 # If you move this project you can change the directory 
 # to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
-GBDK_HOME = "../../../"
+GBDK_HOME = ../../../
 
 LCC = $(GBDK_HOME)bin/lcc 
 
@@ -55,7 +55,7 @@ $(OBJDIR)/linkfile.lk:	$(OBJS)
 
 # Link the compiled object files (via linkerfile) into a .gb ROM file
 $(BINS):	$(OBJDIR)/linkfile.lk
-		$(LCC) $(LCCFLAGS) -Wl-yo4 -o $(BINS) -Wl-f$<
+		$(LCC) $(LCCFLAGS) -o $(BINS) -Wl-f$<
 
 prepare:
 	mkdir -p $(OBJDIR)

--- a/gbdk-lib/examples/gb/linkerfile/Makefile
+++ b/gbdk-lib/examples/gb/linkerfile/Makefile
@@ -1,0 +1,67 @@
+#
+# A Makefile that compiles all .c and .s files in "src" and "res" 
+# subdirectories and places the output in a "obj" subdirectory
+#
+
+# If you move this project you can change the directory 
+# to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
+GBDK_HOME = "../../../"
+
+LCC = $(GBDK_HOME)bin/lcc 
+
+# You can set flags for LCC here
+# For example, you can uncomment the line below to turn on debug output
+# LCCFLAGS = -debug
+# LCCFLAGS = -v
+
+# You can set the name of the .gb ROM file here
+PROJECTNAME    = Example
+
+SRCDIR      = src
+OBJDIR      = obj
+RESDIR      = res
+BINS	    = $(OBJDIR)/$(PROJECTNAME).gb
+CSOURCES    = $(foreach dir,$(SRCDIR),$(notdir $(wildcard $(dir)/*.c))) $(foreach dir,$(RESDIR),$(notdir $(wildcard $(dir)/*.c)))
+ASMSOURCES  = $(foreach dir,$(SRCDIR),$(notdir $(wildcard $(dir)/*.s)))
+OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
+
+all:	prepare $(BINS)
+
+make.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > make.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+
+# Compile .c files in "src/" to .o object files
+$(OBJDIR)/%.o:	$(SRCDIR)/%.c
+	$(LCC) $(LCCFLAGS) -c -o $@ $<
+
+# Compile .c files in "res/" to .o object files
+$(OBJDIR)/%.o:	$(RESDIR)/%.c
+	$(LCC) $(LCCFLAGS) -c -o $@ $<
+
+# Compile .s assembly files in "src/" to .o object files
+$(OBJDIR)/%.o:	$(SRCDIR)/%.s
+	$(LCC) $(LCCFLAGS) -c -o $@ $<
+
+# If needed, compile .c files i n"src/" to .s assembly files
+# (not required if .c is compiled directly to .o)
+$(OBJDIR)/%.s:	$(SRCDIR)/%.c
+	$(LCC) $(LCCFLAGS) -S -o $@ $<
+
+
+$(OBJDIR)/linkfile.lk:	$(OBJS)
+	rm -f $(OBJDIR)/linkfile.lk
+	$(foreach O,$(OBJS),echo $O >>$@;)
+
+# Link the compiled object files (via linkerfile) into a .gb ROM file
+$(BINS):	$(OBJDIR)/linkfile.lk
+		$(LCC) $(LCCFLAGS) -Wl-yo4 -o $(BINS) -Wl-f$<
+
+prepare:
+	mkdir -p $(OBJDIR)
+	mkdir -p $(RESDIR)
+
+clean:
+#	rm -f  *.gb *.ihx *.cdb *.adb *.noi *.map
+	rm -f  $(OBJDIR)/*.*
+

--- a/gbdk-lib/examples/gb/linkerfile/Readme.md
+++ b/gbdk-lib/examples/gb/linkerfile/Readme.md
@@ -1,0 +1,18 @@
+
+# Example of how to use a linkerfile
+
+A linkerfile allows storing all the object files to be linked in a
+file which is passed to the linker instead of a list of filenames on
+the command line. This may be useful if your project has filenames 
+that use up more length than will fit on the command line for Windows
+(8191 chars max).
+
+The typical extension for the linkerfile is ".lk". 
+
+It is passed to sdldgb through lcc using `-Wl-f<pathtolinkerfile>`
+If calling sdldgb directly, use `-f<pathtolinkerfile>`
+
+The Makefile is configured to store all the compiled ".o" object files 
+into `obj/linkerfile.lk`.
+
+

--- a/gbdk-lib/examples/gb/linkerfile/src/main.c
+++ b/gbdk-lib/examples/gb/linkerfile/src/main.c
@@ -1,0 +1,14 @@
+#include <gb/gb.h>
+
+
+void main(void)
+{
+    // Loop forever
+    while(1) {
+
+		// Game main loop processing goes here
+
+		// Done processing, yield CPU and wait for start of next frame
+        wait_vbl_done();
+    }
+}

--- a/gbdk-lib/examples/gb/template_minimal/Makefile
+++ b/gbdk-lib/examples/gb/template_minimal/Makefile
@@ -4,7 +4,7 @@
 
 # If you move this project you can change the directory 
 # to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
-GBDK_HOME = "../../../"
+GBDK_HOME = ../../../
 
 LCC = $(GBDK_HOME)bin/lcc 
 

--- a/gbdk-lib/examples/gb/template_subfolders/Makefile
+++ b/gbdk-lib/examples/gb/template_subfolders/Makefile
@@ -5,7 +5,7 @@
 
 # If you move this project you can change the directory 
 # to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
-GBDK_HOME = "../../../"
+GBDK_HOME = ../../../
 
 LCC = $(GBDK_HOME)bin/lcc 
 

--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -68,7 +68,8 @@ static struct {
 		{ "bindir",		GBDKBINDIR },
 #endif
 		{ "ihxcheck", "%bindir%ihxcheck" },
-		{ "mkbin", "%sdccdir%makebin" }
+		{ "mkbin", "%sdccdir%makebin" },
+		{ "crt0dir", "%libdir%%plat%/crt0.o"}
 };
 
 #define NUM_TOKENS	(sizeof(_tokens)/sizeof(_tokens[0]))
@@ -111,7 +112,7 @@ static CLASS classes[] = {
 			"%as% %asdefault% $1 $3 $2",
 			"%bankpack% $1 $2",
 			"%ld% -n -i $1 -k %libdir%%port%/ -l %port%.lib "
-				"-k %libdir%%plat%/ -l %plat%.lib $3 $2",
+				"-k %libdir%%plat%/ -l %plat%.lib $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
 			"%mkbin% -Z $1 $2 $3"
 		},
@@ -124,7 +125,7 @@ static CLASS classes[] = {
 			"%as% %asdefault% $1 $3 $2",
 			"%bankpack% $1 $2",
 			"%ld% -n -- -i $1 -b_CODE=0x8100 -k%libdir%%port%/ -l%port%.lib "
-				"-k%libdir%%plat%/ -l%plat%.lib $3 $2",
+				"-k%libdir%%plat%/ -l%plat%.lib $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
 			"%mkbin% -Z $1 $2 $3"
 		},
@@ -137,7 +138,7 @@ static CLASS classes[] = {
 			"%as% %asdefault% $1 $3 $2",
 			"%bankpack% $1 $2",
 			"%ld% -n -- -i $1 -b_DATA=0x8000 -b_CODE=0x200 -k%libdir%%port%/ -l%port%.lib "
-				"-k%libdir%%plat%/ -l%plat%.lib $3 $2",
+				"-k%libdir%%plat%/ -l%plat%.lib $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
 			"%mkbin% -Z $1 $2 $3"
 		}
@@ -251,7 +252,6 @@ char *ihxcheck[256];
 char *ld[256];
 char *bankpack[256];
 char *mkbin[256];
-char *crt0[256];
 
 const char *starts_with(const char *s1, const char *s2)
 {
@@ -285,6 +285,10 @@ int option(char *arg) {
 		// -S is compile to ASM only
 		// When composing the compile stage, swap in of -S instead of default -c
 		setTokenVal("comflag", "-S");
+	}
+	else if ((tail = starts_with(arg, "-nocrt"))) {
+		// When composing link stage, clear out crt0dir path
+		setTokenVal("crt0dir", "");
 	}
     else if ((tail = starts_with(arg, "-m"))) {
 		/* Split it up into a asm/port pair */
@@ -331,7 +335,6 @@ void finalise(void)
 	buildArgs(ld, _class->ld);
 	buildArgs(ihxcheck, _class->ihxcheck);
 	buildArgs(mkbin, _class->mkbin);
-	buildArgs(crt0, "%libdir%%plat%/crt0.o");
 }
 
 void set_gbdk_dir(char* argv_0)

--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -240,7 +240,7 @@ static void buildArgs(char **args, const char *template)
 	*last = NULL;
 }
 
-char *suffixes[] = { ".c", ".i", ".asm;.s", ".o;.obj", ".ihx;.gb", 0 };
+char *suffixes[] = { ".c", ".i", ".asm;.s", ".o;.obj", ".ihx", ".gb", 0 };
 char inputs[256] = "";
 
 char *cpp[256];

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -60,7 +60,7 @@ static void Fixllist();
 static void list_rewrite_exts(List, char *, char *);
 static void list_duplicate_to_new_exts(List, char *, char *);
 
-extern char *cpp[], *include[], *com[], *as[], *bankpack[], *ld[], *ihxcheck[], *mkbin[], inputs[], *suffixes[], *crt0[];
+extern char *cpp[], *include[], *com[], *as[], *bankpack[], *ld[], *ihxcheck[], *mkbin[], inputs[], *suffixes[];
 extern int option(char *);
 extern void set_gbdk_dir(char*);
 
@@ -71,13 +71,12 @@ static int Eflag;		/* -E specified */
 static int Sflag;		/* -S specified */
 static int cflag;		/* -c specified */
 static int Kflag;		/* -K specified */
-static int fflag;		/* -Wl-f specified (use .lk linker file for sdldgb) */
 static int autobankflag;	/* -K specified */
 static int verbose;		/* incremented for each -v */
 static List bankpack_flags;	/* bankpack flags */
 static List ihxchecklist;	/* ihxcheck flags */
 static List mkbinlist;		/* loader files, flags */
-static List llist[3];		/* [1] = loader files, [0] = flags */
+static List llist[2];		/* [1] = loader files, [0] = flags */
 static List alist;		/* assembler flags */
 List clist;		/* compiler flags */
 static List plist;		/* preprocessor flags */
@@ -267,13 +266,10 @@ int main(int argc, char *argv[]) {
 					}
 				}
 			}
-
-			// Call linker
-			// (fixlist adds required default linker vars if not added by user)
-			Fixllist();
-			llist[2] = append(ihxFile, 0);
-			if (!fflag) llist[2] = append(*crt0, llist[2]);
-			compose(ld, llist[0], llist[1], llist[2]);
+ 			
+			// Call linker (add output ihxfile in compose $3)
+			Fixllist();   // (fixlist adds required default linker vars if not added by user)			
+			compose(ld, llist[0], llist[1], append(ihxFile, 0));
 
 			if (callsys(av))
 				errcnt++;
@@ -780,6 +776,7 @@ static void help(void) {
 "-lx	search library `x'\n",
 "-N	do not search the standard directories for #include files\n",
 "-n	emit code to check for dereferencing zero pointers\n",
+"-nocrt do not auto-include the gbdk crt0.o runtime in linker list\n",
 "-O	is ignored\n",
 "-o file	leave the output in `file'\n",
 "-P	print ANSI-style declarations for globals\n",
@@ -893,25 +890,17 @@ static void opt(char *arg) {
 				if(arg[4] == 'y' && (arg[5] == 't' || arg[5] == 'o' || arg[5] == 'a' || arg[5] == 'p') && (arg[6] != '\0' && arg[6] != ' '))
 					goto makebinoption; //automatically pass -yo -ya -yt -yp options to makebin (backwards compatibility)
 				{
-					// If using .lk linker file for sdldgb (-f file[.lk])
-					if (arg[4] == 'f') {
-						char *tmp = malloc(256);
-						sprintf(tmp, "%c%c", arg[3], arg[4]);  // create "-f". we pass the list as the very last parameter
-						llist[1] = append(tmp, llist[1]);     
-						if(arg[5]){
-							char *tmp2 = malloc(256);
-							sprintf(tmp2, "%s", &arg[5]);      // Append linker file name to list afer -f
-							llist[1] = append(tmp2, llist[1]);
-						}
-						fflag++;  // Set flag to indicate linker file is used
+					// If using linker file for sdldgb (-f file[.lk]). 
+					// Starting at arg[5] should be name of the linkerfile 
+					if ((arg[4] == 'f') && (arg[5])) {
+						llist[1] = append("-f", llist[1]);    // Add -f to file link list 
+						llist[1] = append(&arg[5], llist[1]); // Then add linkerfile as the very next parameter
 					} else {
 						char *tmp = malloc(256);
 						sprintf(tmp, "%c%c", arg[3], arg[4]); //sdldgb requires spaces between -k and the path
 						llist[0] = append(tmp, llist[0]);     //splitting the args into 2 works on Win and Linux
-						if(arg[5]){
-							char *tmp2 = malloc(256);
-							sprintf(tmp2, "%s", &arg[5]);
-							llist[0] = append(tmp2, llist[0]);
+						if (arg[5]) {                            
+							llist[0] = append(&arg[5], llist[0]);  // Add filename separately if present
 						}
 					}
 				}
@@ -980,6 +969,11 @@ static void opt(char *arg) {
 	case 'a':
 		if (strcmp(arg, "-autobank") == 0) {
 			autobankflag++;
+			return;
+		}
+	case 'n':
+		if (strcmp(arg, "-nocrt") == 0) {
+			option(arg);  // Clear crt0 entry in linker compose string
 			return;
 		}
 	case 'B':	/* -Bdir -Bstatic -Bdynamic */


### PR DESCRIPTION
lcc changes:
- Add support for converting .ihx to .gb via lcc (suppress calling linker stages)
  - If a single .ihx input is present, it will only convert .ihx to .gb
  - Warn if source/obj inputs are present when .ihx is present (they won't get compiled / linked)
  - Warn if more than one .ihx input is present (only use last one entered)
  - Split .ihx and .gb appart in the suffixes[] list. This required a bunch of miscellaneous changes
- Separate crt0.o suppression into a new flag (`-nocrt`)
- Tidy up and simplify linker flag (-Wl-...) handling, 
- Add/improve some comments

Examples: 
- Add project showing use of linkerfile
- Path fixes for Windows make.bat output, remove quotes around path  (templates & linkerfile example)

Built and tested on Linux & Windows (build gbdk, then test linkerfile example with make.bat)
