### PR TITLE
lcc: make extension handling code easier to understand

### DIFF
--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -243,6 +243,8 @@ static void buildArgs(char **args, const char *template)
 	*last = NULL;
 }
 
+// If order is changed here, file type handling MUST be updated
+// in lcc.c: "switch (suffix(name, suffixes, 5)) {"
 char *suffixes[] = {
     EXT_C,               // 0
     EXT_I,               // 1

--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -10,6 +10,8 @@
 #include <windows.h>
 #endif
 
+#include "gb.h"
+
 #ifndef GBDKLIBDIR
 #define GBDKLIBDIR "\\gbdk\\"
 #endif
@@ -241,7 +243,16 @@ static void buildArgs(char **args, const char *template)
 	*last = NULL;
 }
 
-char *suffixes[] = { ".c", ".i", ".asm;.s", ".o;.obj", ".ihx", ".gb", 0 };
+char *suffixes[] = {
+    EXT_C,               // 0
+    EXT_I,               // 1
+    EXT_ASM ";" EXT_S,   // 2
+    EXT_O   ";" EXT_OBJ, // 3
+    EXT_IHX,             // 4
+    EXT_GB,              // 5
+    0
+};
+
 char inputs[256] = "";
 
 char *cpp[256];

--- a/gbdk-support/lcc/gb.h
+++ b/gbdk-support/lcc/gb.h
@@ -1,0 +1,20 @@
+// gb.h
+
+#ifndef _LCC_GB_H
+#define _LCC_GB_H
+
+#define SUFX_NOMATCH -1
+
+#define EXT_C    ".c"
+#define EXT_I    ".i"
+#define EXT_ASM  ".asm"
+#define EXT_S    ".s"
+#define EXT_O    ".o"
+#define EXT_OBJ  ".obj"
+#define EXT_IHX  ".ihx"
+#define EXT_GB   ".gb"
+
+#endif // _LCC_GB_H
+
+
+

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -132,11 +132,12 @@ int main(int argc, char *argv[]) {
 	for (nf = 0, i = j = 1; i < argc; i++) {
 		if (strcmp(argv[i], "-o") == 0) {
 			if (++i < argc) {
-				// Check if extension is ".c" or ".i"
+				// Don't allow output file to have ".c" or ".i" extension (first two in suffixes[])
 				if (suffix(argv[i], suffixes, 2) != SUFX_NOMATCH) {
 					error("-o would overwrite %s", argv[i]);
 					exit(8);
 				}
+				// Valid output file found
 				outfile = argv[i];
 				continue;
 			}

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -21,6 +21,8 @@ static char rcsid[] = "$Id: lcc.c,v 2.0 " BUILDDATE " " BUILDTIME " gbdk-2020 Ex
 # include <sys/wait.h>
 #endif
 
+#include "gb.h"
+
 #ifndef TEMPDIR
 #define TEMPDIR "/tmp"
 #endif
@@ -130,7 +132,8 @@ int main(int argc, char *argv[]) {
 	for (nf = 0, i = j = 1; i < argc; i++) {
 		if (strcmp(argv[i], "-o") == 0) {
 			if (++i < argc) {
-				if (suffix(argv[i], suffixes, 2) >= 0) {
+				// Check if extension is ".c" or ".i"
+				if (suffix(argv[i], suffixes, 2) != SUFX_NOMATCH) {
 					error("-o would overwrite %s", argv[i]);
 					exit(8);
 				}
@@ -153,10 +156,10 @@ int main(int argc, char *argv[]) {
 		}
 		else if (*argv[i] != '-') {
 			// Count number of (.ihx) files
-			if (suffix(argv[i], suffixes, 5) == 4)
+			if (suffix(argv[i], (char * []){EXT_IHX}, 1) != SUFX_NOMATCH)
 				ihx_inputs++;
 			// Count number of (.c, .i, .asm, .s) files
-			else if (suffix(argv[i], suffixes, 3) >= 0)
+			else if (suffix(argv[i], suffixes, 3) != SUFX_NOMATCH)
 				nf++;
 		}
 		argv[j++] = argv[i];
@@ -199,7 +202,7 @@ int main(int argc, char *argv[]) {
 			char *name = exists(argv[i]);
 			if (name) {
 				if (strcmp(name, argv[i]) != 0
-					|| nf > 1 && suffix(name, suffixes, 3) >= 0)
+					|| nf > 1 && suffix(name, suffixes, 3) != SUFX_NOMATCH) // Does it match: .c, .i, .asm, .s
 					fprintf(stderr, "%s:\n", name);
 				// Send input filename argument to "filename processor"
 				// which will add them to llist[n] in some form most of the time
@@ -226,16 +229,16 @@ int main(int argc, char *argv[]) {
 
 			// if outfile is not specified, set it to "a.gb"
 			if(!outfile)
-				outfile = concat("a", suffixes[5]);
+				outfile = concat("a", EXT_GB);
 		}
 		else {
 			// if outfile is not specified, set it to "a.ihx"
 			if(!outfile)
-				outfile = concat("a", suffixes[4]);
+				outfile = concat("a", EXT_IHX);
 
 			//file.gb to file.ihx (don't use tmpfile because maps and other stuffs are created there)
 			// Check to see if output is a .ihx file
-			target_is_ihx = (suffix(outfile, suffixes, 5) == 4);
+			target_is_ihx = (suffix(outfile, (char *[]){EXT_IHX}, 1) != SUFX_NOMATCH);
 
 			// Build ihx file name from output name
 			int lastP = strrchr(outfile, '.') - outfile;
@@ -260,9 +263,8 @@ int main(int argc, char *argv[]) {
 					// The delete list likely only has temp obj files such
 					// as from a single-pass build: lcc -o out.gb in1.c in2.c
 					if (bankpack_newext[0]) {
-						char * obj_suffix = ".o";
-						list_rewrite_exts(llist[1], obj_suffix, bankpack_newext);
-						list_duplicate_to_new_exts(rmlist, obj_suffix, bankpack_newext);
+						list_rewrite_exts(llist[1], EXT_O, bankpack_newext);
+						list_duplicate_to_new_exts(rmlist, EXT_O, bankpack_newext);
 					}
 				}
 			}
@@ -673,6 +675,8 @@ static int filename(char *name, char *base) {
 
 	if (base == 0)
 		base = basepath(name);
+
+	// Handle all available suffixes except .gb (last in list)
 	switch (suffix(name, suffixes, 5)) {
 	case 0:	/* C source files */
 		{
@@ -680,17 +684,17 @@ static int filename(char *name, char *base) {
 			if ((cflag || Sflag) && outfile)
 				ofile = outfile;
 			else if (cflag)
-				ofile = concat(base, first(suffixes[3]));
+				ofile = concat(base, EXT_O);
 			else if (Sflag) {
 				// When compiling to asm only, set outfile as .asm
-				ofile = concat(base, ".asm");
+				ofile = concat(base, EXT_ASM);
 			}
 			else
 			{
-    			ofile = tempname(first(suffixes[3]));
+				ofile = tempname(EXT_O);
 
 				char* ofileBase = basepath(ofile);
-				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, ".asm"), rmlist);
+				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, EXT_ASM), rmlist);
 				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, ".lst"), rmlist);
 				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, ".sym"), rmlist);
 				rmlist = append(stringf("%s/%s%s", tempdir, ofileBase, ".adb"), rmlist);
@@ -710,9 +714,9 @@ static int filename(char *name, char *base) {
 			if (cflag && outfile)
 				ofile = outfile;
 			else if (cflag)
-				ofile = concat(base, first(suffixes[3]));
+				ofile = concat(base, EXT_O);
 			else
-				ofile = tempname(first(suffixes[3]));
+				ofile = tempname(EXT_O);
 			compose(as, alist, append(name, 0), append(ofile, 0));
 			status = callsys(av);
 			if (!find(ofile, llist[1]))
@@ -988,7 +992,7 @@ static void opt(char *arg) {
 				error("-B overwrites earlier option", 0);
 			path = arg + 2;
 			if (strstr(com[1], "win32") != NULL)
-				com[0] = concat(replace(path, '/', '\\'), concat("rcc", suffixes[4]));
+				com[0] = concat(replace(path, '/', '\\'), concat("rcc", EXT_IHX));
 			else
 				com[0] = concat(path, "rcc");
 			if (path[0] == 0)
@@ -1161,7 +1165,7 @@ int suffix(char *name, char *tails[], int n) {
 				return i;
 		}
 	}
-	return -1;
+	return SUFX_NOMATCH;
 }
 
 /* tempname - generate a temporary file name in tempdir with given suffix */


### PR DESCRIPTION
An attempt to make the extension handling code easier to understand and maintain, while still keeping the definition of extensions centralized. 

Also adds some comments where the code is still harder to read.

It's more readable, but still a little awkward. Feedback or ideas to improve it more?

For example:
From: `ofile = concat(base, first(suffixes[3]));`
To: `ofile = concat(base, EXT_O);`

From: `target_is_ihx = (suffix(outfile, suffixes, 5) == 4);`
To: `target_is_ihx = (suffix(outfile, (char *[]){EXT_IHX}, 1) != SUFX_NOMATCH);`


It doesn't entirely improve code like this: (`Count number of (.c, .i, .asm, .s) files`)
From: `else if (suffix(argv[i], suffixes, 3) >= 0)`
To: `else if (suffix(argv[i], suffixes, 3) != SUFX_NOMATCH)`
    