### PR TITLE
Lcc: add -no-libs (also rename -nocrt to -no-crt)

### DIFF
--- a/docs/pages/20_toolchain_settings.md
+++ b/docs/pages/20_toolchain_settings.md
@@ -20,6 +20,8 @@
 -lx	search library `x'
 -N	do not search the standard directories for #include files
 -n	emit code to check for dereferencing zero pointers
+-no-crt do not auto-include the gbdk crt0.o runtime in linker list
+-no-libs do not auto-include the gbdk libs in linker list
 -O	is ignored
 -o file	leave the output in `file'
 -P	print ANSI-style declarations for globals
@@ -39,7 +41,7 @@
 @anchor sdcc-settings
 # sdcc settings
 ```
-SDCC : mcs51/z80/z180/r2k/r2ka/r3ka/gbz80/tlcs90/ez80_z80/z80n/ds390/pic16/pic14/TININative/ds400/hc08/s08/stm8/pdk13/pdk14/pdk15 4.1.0 #12069 (Linux)
+SDCC : mcs51/z80/z180/r2k/r2ka/r3ka/gbz80/tlcs90/ez80_z80/z80n/ds390/pic16/pic14/TININative/ds400/hc08/s08/stm8/pdk13/pdk14/pdk15 4.1.4 #12246 (Linux)
 published under GNU General Public License (GPL)
 Usage : sdcc [options] filename
 Options :-
@@ -168,7 +170,7 @@ Special options for the z80 port:
       --dataseg             <name> use this name for the data segment
       --no-std-crt0         For the z80/gbz80 do not link default crt0.rel
       --reserve-regs-iy     Do not use IY (incompatible with --fomit-frame-pointer)
-      --oldralloc           Use old register allocator
+      --oldralloc           Use old register allocator (deprecated)
       --fno-omit-frame-pointer  Do not omit frame pointer
       --emit-externs        Emit externs list in generated asm
       --legacy-banking      Use legacy method to call banked functions
@@ -183,7 +185,7 @@ Special options for the z180 port:
       --dataseg             <name> use this name for the data segment
       --no-std-crt0         For the z80/gbz80 do not link default crt0.rel
       --reserve-regs-iy     Do not use IY (incompatible with --fomit-frame-pointer)
-      --oldralloc           Use old register allocator
+      --oldralloc           Use old register allocator (deprecated)
       --fno-omit-frame-pointer  Do not omit frame pointer
       --emit-externs        Emit externs list in generated asm
       --legacy-banking      Use legacy method to call banked functions
@@ -198,7 +200,7 @@ Special options for the r2k port:
       --dataseg             <name> use this name for the data segment
       --no-std-crt0         For the z80/gbz80 do not link default crt0.rel
       --reserve-regs-iy     Do not use IY (incompatible with --fomit-frame-pointer)
-      --oldralloc           Use old register allocator
+      --oldralloc           Use old register allocator (deprecated)
       --fno-omit-frame-pointer  Do not omit frame pointer
       --emit-externs        Emit externs list in generated asm
       --legacy-banking      Use legacy method to call banked functions
@@ -213,7 +215,7 @@ Special options for the r2ka port:
       --dataseg             <name> use this name for the data segment
       --no-std-crt0         For the z80/gbz80 do not link default crt0.rel
       --reserve-regs-iy     Do not use IY (incompatible with --fomit-frame-pointer)
-      --oldralloc           Use old register allocator
+      --oldralloc           Use old register allocator (deprecated)
       --fno-omit-frame-pointer  Do not omit frame pointer
       --emit-externs        Emit externs list in generated asm
       --legacy-banking      Use legacy method to call banked functions
@@ -228,7 +230,7 @@ Special options for the r3ka port:
       --dataseg             <name> use this name for the data segment
       --no-std-crt0         For the z80/gbz80 do not link default crt0.rel
       --reserve-regs-iy     Do not use IY (incompatible with --fomit-frame-pointer)
-      --oldralloc           Use old register allocator
+      --oldralloc           Use old register allocator (deprecated)
       --fno-omit-frame-pointer  Do not omit frame pointer
       --emit-externs        Emit externs list in generated asm
       --legacy-banking      Use legacy method to call banked functions
@@ -237,6 +239,7 @@ Special options for the r3ka port:
 Special options for the gbz80 port:
       -bo                   <num> use code bank <num>
       -ba                   <num> use data bank <num>
+      --asm=                Define assembler name (rgbds/asxxxx/isas/z80asm/gas)
       --callee-saves-bc     Force a called function to always save BC
       --codeseg             <name> use this name for the code segment
       --constseg            <name> use this name for the const segment
@@ -253,7 +256,7 @@ Special options for the tlcs90 port:
       --dataseg             <name> use this name for the data segment
       --no-std-crt0         For the z80/gbz80 do not link default crt0.rel
       --reserve-regs-iy     Do not use IY (incompatible with --fomit-frame-pointer)
-      --oldralloc           Use old register allocator
+      --oldralloc           Use old register allocator (deprecated)
       --fno-omit-frame-pointer  Do not omit frame pointer
       --emit-externs        Emit externs list in generated asm
       --legacy-banking      Use legacy method to call banked functions
@@ -268,7 +271,7 @@ Special options for the ez80_z80 port:
       --dataseg             <name> use this name for the data segment
       --no-std-crt0         For the z80/gbz80 do not link default crt0.rel
       --reserve-regs-iy     Do not use IY (incompatible with --fomit-frame-pointer)
-      --oldralloc           Use old register allocator
+      --oldralloc           Use old register allocator (deprecated)
       --fno-omit-frame-pointer  Do not omit frame pointer
       --emit-externs        Emit externs list in generated asm
       --legacy-banking      Use legacy method to call banked functions
@@ -283,7 +286,7 @@ Special options for the z80n port:
       --dataseg             <name> use this name for the data segment
       --no-std-crt0         For the z80/gbz80 do not link default crt0.rel
       --reserve-regs-iy     Do not use IY (incompatible with --fomit-frame-pointer)
-      --oldralloc           Use old register allocator
+      --oldralloc           Use old register allocator (deprecated)
       --fno-omit-frame-pointer  Do not omit frame pointer
       --emit-externs        Emit externs list in generated asm
       --legacy-banking      Use legacy method to call banked functions
@@ -383,6 +386,7 @@ Usage: [-Options] outfile file1 [file2 file3 ...]
   -q   Octal   listing
   -x   Hex     listing (default)
   -g   Undefined symbols made global
+  -n   Don't resolve global assigned value symbols
   -a   All user symbols made global
   -b   Display .define substitutions in listing
   -bb  and display without .define substitutions
@@ -497,7 +501,12 @@ Usage: makebin [options] [<in_file> [<out_file>]]
 Options:
   -p             pack mode: the binary file size will be truncated to the last occupied byte
   -s romsize     size of the binary file (default: rom banks * 16384)
-  -Z             genarate GameBoy format binary file
+  -Z             generate GameBoy format binary file
+  -S             generate Sega Master System format binary file
+SMS format options (applicable only with -S option):
+  -xo n          rom size (0xa-0x2)
+  -xj n          set region code (3-7)
+  -xv n          version number (0-15)
 GameBoy format options (applicable only with -Z option):
   -yo n          number of rom banks (default: 2) (autosize: A)
   -ya n          number of ram banks (default: 0)
@@ -522,9 +531,12 @@ gbcompress [options] infile outfile
 Use: Gbcompress a binary file and write it out.
 
 Options
--h : Show this help screen
--d : Decompress (default is compress)
--v : Verbose output
+-h    : Show this help screen
+-d    : Decompress (default is compress)
+-v    : Verbose output
+-cin  : Read input as .c source format (8 bit char ONLY, uses first array found)
+-cout : Write output in .c / .h source format (8 bit char ONLY) 
+-varname=<NAME> : specify variable name for c source output
 Example: "gbcompress binaryfile.bin compressed.bin"
 Example: "gbcompress -d compressedfile.bin decompressed.bin"
 ```

--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -71,7 +71,8 @@ static struct {
 #endif
 		{ "ihxcheck", "%bindir%ihxcheck" },
 		{ "mkbin", "%sdccdir%makebin" },
-		{ "crt0dir", "%libdir%%plat%/crt0.o"}
+		{ "crt0dir", "%libdir%%plat%/crt0.o"},
+		{ "libs_include", "-k %libdir%%port%/ -l %port%.lib -k %libdir%%plat%/ -l %plat%.lib"}
 };
 
 #define NUM_TOKENS	(sizeof(_tokens)/sizeof(_tokens[0]))
@@ -113,8 +114,7 @@ static CLASS classes[] = {
 			"%com% %comdefault% -Wa%asdefault% -DGB=1 -DGAMEBOY=1 -DINT_16_BITS $1 %comflag% $2 -o $3",
 			"%as% %asdefault% $1 $3 $2",
 			"%bankpack% $1 $2",
-			"%ld% -n -i $1 -k %libdir%%port%/ -l %port%.lib "
-				"-k %libdir%%plat%/ -l %plat%.lib $3 %crt0dir% $2",
+			"%ld% -n -i $1 %libs_include% $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
 			"%mkbin% -Z $1 $2 $3"
 		},
@@ -126,8 +126,7 @@ static CLASS classes[] = {
 			"%com% %comdefault% $1 $2 $3",
 			"%as% %asdefault% $1 $3 $2",
 			"%bankpack% $1 $2",
-			"%ld% -n -- -i $1 -b_CODE=0x8100 -k%libdir%%port%/ -l%port%.lib "
-				"-k%libdir%%plat%/ -l%plat%.lib $3 %crt0dir% $2",
+			"%ld% -n -- -i $1 -b_CODE=0x8100 %libs_include% $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
 			"%mkbin% -Z $1 $2 $3"
 		},
@@ -139,8 +138,7 @@ static CLASS classes[] = {
 			"%com% %comdefault% $1 $2 $3",
 			"%as% %asdefault% $1 $3 $2",
 			"%bankpack% $1 $2",
-			"%ld% -n -- -i $1 -b_DATA=0x8000 -b_CODE=0x200 -k%libdir%%port%/ -l%port%.lib "
-				"-k%libdir%%plat%/ -l%plat%.lib $3 %crt0dir% $2",
+			"%ld% -n -- -i $1 -b_DATA=0x8000 -b_CODE=0x200 %libs_include% $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
 			"%mkbin% -Z $1 $2 $3"
 		}
@@ -299,11 +297,15 @@ int option(char *arg) {
 		// When composing the compile stage, swap in of -S instead of default -c
 		setTokenVal("comflag", "-S");
 	}
-	else if ((tail = starts_with(arg, "-nocrt"))) {
+	else if ((tail = starts_with(arg, "-no-crt"))) {
 		// When composing link stage, clear out crt0dir path
 		setTokenVal("crt0dir", "");
 	}
-    else if ((tail = starts_with(arg, "-m"))) {
+	else if ((tail = starts_with(arg, "-no-libs"))) {
+		// When composing link stage, clear out crt0dir path
+		setTokenVal("libs_include", "");
+	}
+	else if ((tail = starts_with(arg, "-m"))) {
 		/* Split it up into a asm/port pair */
 		char *slash = strchr(tail, '/');
 		if (slash) {

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -781,7 +781,8 @@ static void help(void) {
 "-lx	search library `x'\n",
 "-N	do not search the standard directories for #include files\n",
 "-n	emit code to check for dereferencing zero pointers\n",
-"-nocrt do not auto-include the gbdk crt0.o runtime in linker list\n",
+"-no-crt do not auto-include the gbdk crt0.o runtime in linker list\n",
+"-no-libs do not auto-include the gbdk libs in linker list\n",
 "-O	is ignored\n",
 "-o file	leave the output in `file'\n",
 "-P	print ANSI-style declarations for globals\n",
@@ -977,8 +978,12 @@ static void opt(char *arg) {
 			return;
 		}
 	case 'n':
-		if (strcmp(arg, "-nocrt") == 0) {
+		if (strcmp(arg, "-no-crt") == 0) {
 			option(arg);  // Clear crt0 entry in linker compose string
+			return;
+		} 
+		else if (strcmp(arg, "-no-libs") == 0) {
+			option(arg);  // Clear libs entry in linker compose string
 			return;
 		}
 	case 'B':	/* -Bdir -Bstatic -Bdynamic */


### PR DESCRIPTION
Adds a `-no-libs` option for lcc.

This removes the following entries from the linker stage:
`-k %libdir%%port%/ -l %port%.lib -k %libdir%%plat%/ -l %plat%.lib`

Updates the toolchain command line arguments markdown file (auto-generated)