### PR TITLE
 Examples: convert to using stdint.h types instead of non-standard UINT8 / UBYTE / WORD etc Re: #162

### DIFF
--- a/docs/pages/03_using_gbdk.md
+++ b/docs/pages/03_using_gbdk.md
@@ -4,7 +4,7 @@
 # Interrupts
 Interrupts allow execution to jump to a different part of your code as soon as an external event occurs - for example the LCD entering the vertical blank period, serial data arriving or the timer reaching its end count. For an example see the irq.c sample project.
 
-Interrupts in GBDK are handled using the functions @ref disable_interrupts(), @ref enable_interrupts(), @ref set_interrupts(UBYTE ier) and the interrupt service routine (ISR) linkers @ref add_VBL(), @ref add_TIM, @ref add_LCD, @ref add_SIO and @ref add_JOY which add interrupt handlers for the vertical blank, timer, LCD, serial link and joypad interrupts respectively.
+Interrupts in GBDK are handled using the functions @ref disable_interrupts(), @ref enable_interrupts(), @ref set_interrupts(uint8_t ier) and the interrupt service routine (ISR) linkers @ref add_VBL(), @ref add_TIM, @ref add_LCD, @ref add_SIO and @ref add_JOY which add interrupt handlers for the vertical blank, timer, LCD, serial link and joypad interrupts respectively.
 
 Since an interrupt can occur at any time an Interrupt Service Request (ISR) cannot take any arguments or return anything. Its only way of communicating with the greater program is through the global variables. When interacting with those shared ISR global variables from main code outside the interrupt, it is a good idea to wrap them in a `critical {}` section in case the interrupt occurs and modifies the variable while it is being used.
 
@@ -122,8 +122,8 @@ Here is an example of how to mix assembly with C:
 
     main()
     {
-      WORD i;
-      WORD add(WORD, WORD);
+      int16_t i;
+      int16_t add(int16_t, int16_t);
 
       i = add(1, 3);
     }
@@ -131,7 +131,7 @@ Here is an example of how to mix assembly with C:
 `add.s`
 
     .globl _add
-    _add:         ; WORD add(WORD a, WORD b)
+    _add:         ; int16_t add(int16_t a, int16_t b)
                   ; There is no register to save:
                   ;  BC is not used
                   ;  DE is the return register

--- a/docs/pages/04_coding_guidelines.md
+++ b/docs/pages/04_coding_guidelines.md
@@ -43,8 +43,8 @@ If you wish to use the original tools, you must add the `const` keyword every ti
 
   - Prefer unsigned variables to signed ones: The code generated will be generally more efficient, especially when comparing two values.
 
-  - Use explicit types so you always know the size of your variables. `INT8, UINT8, INT16, UINT16, INT32, UINT32` or `BYTE, UBYTE, WORD, UWORD, LWORD, ULWORD`.  
-  Types are defined in @ref asm/types.h and @ref asm/gbz80/types.h
+  - Use explicit types so you always know the size of your variables. `int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t`.  
+  These are standard types defined in `stdint.h` (`#include <stdint.h>`).
 
   - Global and local static variables are generally more efficient than local non-static variables (which go on the stack and are slower and can result in slower code).
 
@@ -52,9 +52,9 @@ If you wish to use the original tools, you must add the `const` keyword every ti
   `const` keyword: Use const for arrays, structs and variables with read-only (constant) data. It will reduce ROM, RAM and CPU usage significantly. Non-`const` values are loaded from ROM into RAM inefficiently, and there is no benefit in loading them into the limited available RAM if they aren't going to be changed.
 
   - Here is how to delcare `const` pointers and variables:
-    - non-const pointer to a const variable: `const UINT8 * some_pointer;`
-    - const pointer to a non-const variable: `UINT8 * const some_pointer;`
-    - const pointer to a const variable: `const UINT8 * const some_pointer;`
+    - non-const pointer to a const variable: `const uint8_t * some_pointer;`
+    - const pointer to a non-const variable: `uint8_t * const some_pointer;`
+    - const pointer to a const variable: `const uint8_t * const some_pointer;`
     - https://codeforwin.org/2017/11/constant-pointer-and-pointer-to-constant-in-c.html
     - https://stackoverflow.com/questions/21476869/constant-pointer-vs-pointer-to-constant
 
@@ -86,7 +86,7 @@ If you wish to use the original tools, you must add the `const` keyword every ti
 
   - Avoid long lists of function parameters. Passing many parameters can add overhead, especially if the function is called often. When applicable globals and local static vars can be used instead.
 
-  - Use inline functions if the function is short. (with the `inline` keyword, such as `inline UINT8 myFunction() { ... }`)
+  - Use inline functions if the function is short. (with the `inline` keyword, such as `inline uint8_t myFunction() { ... }`)
 
   - Do not use recursive functions
 <!-- This entry needs re-work. Signed vs unsigned, current SDCC optimizations...
@@ -178,7 +178,7 @@ For many applications C is fast enough but in intensive functions are sometimes 
 ## Calling convention
 sdcc in common with almost all C compilers prepends a '_' to any function names. For example the function printf(...) begins at the label _printf::. Note that all functions are declared global.
 
-The parameters to a function are pushed in right to left order with no aligning - so a byte takes up a byte on the stack instead of the more natural word. So for example the function int store_byte( UWORD addr, UBYTE byte) would push 'byte' onto the stack first then addr using a total of three bytes. As the return address is also pushed, the stack would contain:
+The parameters to a function are pushed in right to left order with no aligning - so a byte takes up a byte on the stack instead of the more natural word. So for example the function int store_byte( uint16_t addr, uint8_t byte) would push 'byte' onto the stack first then addr using a total of three bytes. As the return address is also pushed, the stack would contain:
 
       At SP+0 - the return address
 

--- a/docs/pages/05_banking_mbcs.md
+++ b/docs/pages/05_banking_mbcs.md
@@ -140,7 +140,7 @@ It should be:
 void vbl_music_isr(void)
 {
 	// Save the current bank
-    UBYTE _saved_bank = _current_bank;
+    uint8_t _saved_bank = _current_bank;
 
 	// A function which changes the bank and
     // *doesn't* restore it after changing.
@@ -169,18 +169,18 @@ For a source example see the `banks_autobank` project.
 In the source files you want auto-banked, do the following:
   - Set the bank for the source file to `255`: `#pragma bank 255`
   - Create a constant with no value to store the bank number for the source file: `const void __at(255) __bank_<name-for-a-given-source-file>;`.  
-    This constant can then be used for obtaining that files bank number with `(UINT8)&__bank_<name-for-a-given-source-file`.
+    This constant can then be used for obtaining that files bank number with `(uint8_t)&__bank_<name-for-a-given-source-file`.
 
 Example: level_1_map.c
 
         #pragma bank 255
         const void __at(255) __bank_level_1_map;
 
-        const UINT8 my_level_1_map[] = {... some map data here ...};
+        const uint8_t my_level_1_map[] = {... some map data here ...};
 
 Accessing that data: main.c
 
-      SWITCH_ROM_MBC1( (UINT8)&__bank_level_1_map );
+      SWITCH_ROM_MBC1( (uint8_t)&__bank_level_1_map );
       // Do something with my_level_1_map[]
 
 Features and Notes:

--- a/gbdk-lib/examples/broken/banks_farptr/bank2code.c
+++ b/gbdk-lib/examples/broken/banks_farptr/bank2code.c
@@ -1,6 +1,7 @@
 #pragma bank 2
 
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 int local_bank2_proc(int param1, int param2) {

--- a/gbdk-lib/examples/broken/banks_farptr/banks_farptr.c
+++ b/gbdk-lib/examples/broken/banks_farptr/banks_farptr.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <gb/far_ptr.h>
 
 #include <stdio.h>

--- a/gbdk-lib/examples/gb/banks/bank_0.c
+++ b/gbdk-lib/examples/gb/banks/bank_0.c
@@ -1,3 +1,4 @@
 #include <gb/gb.h>
+#include <stdint.h>
 
 int var_0;  /* In external RAM bank 0 */

--- a/gbdk-lib/examples/gb/banks/bank_1.c
+++ b/gbdk-lib/examples/gb/banks/bank_1.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 int var_1;  /* In external RAM bank 1 */

--- a/gbdk-lib/examples/gb/banks/bank_2.c
+++ b/gbdk-lib/examples/gb/banks/bank_2.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 int var_2;  /* In external RAM bank 2 */

--- a/gbdk-lib/examples/gb/banks/bank_3.c
+++ b/gbdk-lib/examples/gb/banks/bank_3.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 int var_3;  /* In external RAM bank 3 */

--- a/gbdk-lib/examples/gb/banks/banks.c
+++ b/gbdk-lib/examples/gb/banks/banks.c
@@ -2,6 +2,7 @@
     as in banked/
  */
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 int var_internal;  /* In internal RAM */
@@ -19,7 +20,7 @@ void bank_fixed(void) NONBANKED
   puts("I'm in fixed ROM");
 }
 
-void print_var(UBYTE bank)
+void print_var(uint8_t bank)
 {
   SWITCH_RAM_MBC1(bank);
   printf("Var_%u is %u\n");

--- a/gbdk-lib/examples/gb/banks_autobank/banks.c
+++ b/gbdk-lib/examples/gb/banks_autobank/banks.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 // Bank number references from the other source files
@@ -8,10 +9,10 @@ extern const void __bank_srcfile3;
 extern const void __bank_srcfile4;  
 
 // Banked const vars from the other source files
-extern const UINT8 some_const_var_1;
-extern const UINT8 some_const_var_2;
-extern const UINT8 some_const_var_3;
-extern const UINT8 some_const_var_4;
+extern const uint8_t some_const_var_1;
+extern const uint8_t some_const_var_2;
+extern const uint8_t some_const_var_3;
+extern const uint8_t some_const_var_4;
 
 // Banked functions from the other source files
 void func_1() BANKED;
@@ -20,7 +21,7 @@ void func_3() BANKED;
 void some_4() BANKED;
 
 // Non-banked const
-const UINT8 some_const_var_0 = 0;
+const uint8_t some_const_var_0 = 0;
 
 // Non-banked function
 void bank_fixed(void) NONBANKED
@@ -46,13 +47,13 @@ void main(void)
   // Print the const vars, unbanked first then the banked ones
   printf("Var0 = %u is unbanked", some_const_var_0);
 
-  SWITCH_ROM_MBC1( (UINT8)&__bank_srcfile1 );
+  SWITCH_ROM_MBC1( (uint8_t)&__bank_srcfile1 );
   printf("Var1 = %u in bank %u\n", some_const_var_1, &(__bank_srcfile1));
-  SWITCH_ROM_MBC1( (UINT8)&__bank_srcfile2 );
+  SWITCH_ROM_MBC1( (uint8_t)&__bank_srcfile2 );
   printf("Var2 = %u in bank %u\n", some_const_var_2, &(__bank_srcfile2));
-  SWITCH_ROM_MBC1( (UINT8)&__bank_srcfile3 );
+  SWITCH_ROM_MBC1( (uint8_t)&__bank_srcfile3 );
   printf("Var3 = %u in bank %u\n", some_const_var_3, &(__bank_srcfile3));
-  SWITCH_ROM_MBC1( (UINT8)&__bank_srcfile4 );
+  SWITCH_ROM_MBC1( (uint8_t)&__bank_srcfile4 );
   printf("Var4 = %u in bank %u\n", some_const_var_4, &(__bank_srcfile4));
 
   printf("\n");

--- a/gbdk-lib/examples/gb/banks_autobank/srcfile_1.c
+++ b/gbdk-lib/examples/gb/banks_autobank/srcfile_1.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 // These two entries are needed to enable auto-banking in the source file
@@ -6,7 +7,7 @@
 const void __at(255) __bank_srcfile1;
 
 
-const UINT8 some_const_var_1 = 1;
+const uint8_t some_const_var_1 = 1;
 
 void func_1() BANKED
 {

--- a/gbdk-lib/examples/gb/banks_autobank/srcfile_2.c
+++ b/gbdk-lib/examples/gb/banks_autobank/srcfile_2.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 // These two entries are needed to enable auto-banking in the source file
@@ -6,7 +7,7 @@
 const void __at(255) __bank_srcfile2; 
 
 
-const UINT8 some_const_var_2 = 2;
+const uint8_t some_const_var_2 = 2;
 
 void func_2() BANKED
 {

--- a/gbdk-lib/examples/gb/banks_autobank/srcfile_3.c
+++ b/gbdk-lib/examples/gb/banks_autobank/srcfile_3.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 // These two entries are needed to enable auto-banking in the source file
@@ -6,7 +7,7 @@
 const void __at(255) __bank_srcfile3;
 
 
-const UINT8 some_const_var_3 = 3;
+const uint8_t some_const_var_3 = 3;
 
 void func_3() BANKED
 {

--- a/gbdk-lib/examples/gb/banks_autobank/srcfile_4_not-autobanked.c
+++ b/gbdk-lib/examples/gb/banks_autobank/srcfile_4_not-autobanked.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 // In this source file a non-auto bank (2) is used (no auto-banking)
@@ -6,7 +7,7 @@
 const void __at(2) __bank_srcfile4;
 
 
-const UINT8 some_const_var_4 = 4;
+const uint8_t some_const_var_4 = 4;
 
 void some_4() BANKED
 {

--- a/gbdk-lib/examples/gb/banks_new/banks_new.c
+++ b/gbdk-lib/examples/gb/banks_new/banks_new.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 // this macro is needed when using RAM banks with MBC1
@@ -62,27 +63,27 @@ void main() {
     SET_BANKS(1, 1);
 
     // say hello
-    for (INT8 i = 0; (hello0[i]); i++) putchar(hello0[i]);  
-    for (INT8 i = 0; (hello1[i]); i++) putchar(hello1[i]);
-    for (INT8 i = 0; (hello2[i]); i++) putchar(hello2[i]);
+    for (int8_t i = 0; (hello0[i]); i++) putchar(hello0[i]);  
+    for (int8_t i = 0; (hello1[i]); i++) putchar(hello1[i]);
+    for (int8_t i = 0; (hello2[i]); i++) putchar(hello2[i]);
 
     // prepare and say hello from rom bank1 to ram bank0
-    for (INT8 i = 0; (i < sizeof(hello1)); i++) hello1_ram[i] = hello1[i];
-    for (INT8 i = 0; (i < 4); i++) hello1_ram[i + 11] = data[i];
-    for (INT8 i = 0; (hello1_ram[i]); i++) putchar(hello1_ram[i]);
+    for (int8_t i = 0; (i < sizeof(hello1)); i++) hello1_ram[i] = hello1[i];
+    for (int8_t i = 0; (i < 4); i++) hello1_ram[i + 11] = data[i];
+    for (int8_t i = 0; (hello1_ram[i]); i++) putchar(hello1_ram[i]);
 
     // prepare and say hello from rom bank1 to ram bank1
-    for (INT8 i = 0; (i < sizeof(hello2)); i++) hello2_ram[i] = hello2[i];
-    for (INT8 i = 0; (i < 4); i++) hello2_ram[i + 11] = data[i];
-    for (INT8 i = 0; (hello2_ram[i]); i++) putchar(hello2_ram[i]);
+    for (int8_t i = 0; (i < sizeof(hello2)); i++) hello2_ram[i] = hello2[i];
+    for (int8_t i = 0; (i < 4); i++) hello2_ram[i + 11] = data[i];
+    for (int8_t i = 0; (hello2_ram[i]); i++) putchar(hello2_ram[i]);
 
     printf("once more...\n");
     // hello again; if we access we just access, don't care
-    for (INT8 i = 0; (hello0[i]); i++) putchar(hello0[i]);  
-    for (INT8 i = 0; (hello1[i]); i++) putchar(hello1[i]);
-    for (INT8 i = 0; (hello2[i]); i++) putchar(hello2[i]);
-    for (INT8 i = 0; (hello1_ram[i]); i++) putchar(hello1_ram[i]);
-    for (INT8 i = 0; (hello2_ram[i]); i++) putchar(hello2_ram[i]);
+    for (int8_t i = 0; (hello0[i]); i++) putchar(hello0[i]);  
+    for (int8_t i = 0; (hello1[i]); i++) putchar(hello1[i]);
+    for (int8_t i = 0; (hello2[i]); i++) putchar(hello2[i]);
+    for (int8_t i = 0; (hello1_ram[i]); i++) putchar(hello1_ram[i]);
+    for (int8_t i = 0; (hello2_ram[i]); i++) putchar(hello2_ram[i]);
 
     printf("once more...\n");
     // if we need an address, then we use a macro switch_to()

--- a/gbdk-lib/examples/gb/bcd/bcd.c
+++ b/gbdk-lib/examples/gb/bcd/bcd.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 
 #include <stdio.h>
 #include <gb/font.h>
@@ -9,7 +10,7 @@ BCD bcd  = MAKE_BCD(10203040);
 BCD bcd2 = MAKE_BCD(05060708);
 BCD bcd3 = MAKE_BCD(11111111);
 
-UBYTE len = 0;
+uint8_t len = 0;
 unsigned char buf[10];
 
 void main() {

--- a/gbdk-lib/examples/gb/bgb_debug/bgb_debug.c
+++ b/gbdk-lib/examples/gb/bgb_debug/bgb_debug.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>      // Just for printf()
 #include <gb/cgb.h>     // Just for the cpu_fast()/slow() calls in CGB 2x example
 

--- a/gbdk-lib/examples/gb/colorbar/colorbar.c
+++ b/gbdk-lib/examples/gb/colorbar/colorbar.c
@@ -1,10 +1,11 @@
 #include <gb/gb.h>
+#include <stdint.h>
 
 #include "bar_c.h"
 #include "bar_c.c"
 #include "bar_m.c"
 
-const UWORD bar_p[] =
+const uint16_t bar_p[] =
 {
   bar_cCGBPal0c0,bar_cCGBPal0c1,bar_cCGBPal0c2,bar_cCGBPal0c3,
   bar_cCGBPal1c0,bar_cCGBPal1c1,bar_cCGBPal1c2,bar_cCGBPal1c3,

--- a/gbdk-lib/examples/gb/comm/comm.c
+++ b/gbdk-lib/examples/gb/comm/comm.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 unsigned char str[] = "Hello World!";
@@ -6,7 +7,7 @@ unsigned char buffer[32];
 
 void main(void)
 {
-    UBYTE i, n = 0;
+    uint8_t i, n = 0;
     unsigned char *s;
 
     puts("Byte");

--- a/gbdk-lib/examples/gb/dscan/dscan.c
+++ b/gbdk-lib/examples/gb/dscan/dscan.c
@@ -5,6 +5,7 @@
  ********************************************************************/
 
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <rand.h>
 
@@ -18,7 +19,7 @@
 
 /* ************************************************************ */
 
-const UWORD bkg_p[] =
+const uint16_t bkg_p[] =
 {
   bkgCGBPal0c0,bkgCGBPal0c1,bkgCGBPal0c2,bkgCGBPal0c3,
   bkgCGBPal1c0,bkgCGBPal1c1,bkgCGBPal1c2,bkgCGBPal1c3,
@@ -30,7 +31,7 @@ const UWORD bkg_p[] =
   bkgCGBPal7c0,bkgCGBPal7c1,bkgCGBPal7c2,bkgCGBPal7c3
 };
 
-const UWORD obj_p[] =
+const uint16_t obj_p[] =
 {
   foreCGBPal0c0,foreCGBPal0c1,foreCGBPal0c2,foreCGBPal0c3,
   foreCGBPal1c0,foreCGBPal1c1,foreCGBPal1c2,foreCGBPal1c3,
@@ -104,17 +105,17 @@ const unsigned char * const msg_gover = "GAMEOVER";
 const unsigned char * const msg_pause = " PAUSE! ";
 const unsigned char * const msg_start = "        ";
 
-UBYTE pf, px, pp, pl;
-UWORD pw;
-UWORD ps;
-UBYTE tf[MAX_TT];
-UBYTE tx[MAX_TT], ty[MAX_TT];
-UBYTE ef[MAX_ET], ex[MAX_ET], ey[MAX_ET];
-UBYTE kf[MAX_KT], kx[MAX_KT], ky[MAX_KT];
-UBYTE rnd_enemy, rnd_kirai;
-UBYTE k_right, k_left;
+uint8_t pf, px, pp, pl;
+uint16_t pw;
+uint16_t ps;
+uint8_t tf[MAX_TT];
+uint8_t tx[MAX_TT], ty[MAX_TT];
+uint8_t ef[MAX_ET], ex[MAX_ET], ey[MAX_ET];
+uint8_t kf[MAX_KT], kx[MAX_KT], ky[MAX_KT];
+uint8_t rnd_enemy, rnd_kirai;
+uint8_t k_right, k_left;
 
-void set_sprite_attrb( UBYTE nb, UBYTE tile )
+void set_sprite_attrb( uint8_t nb, uint8_t tile )
 {
   if( _cpu==CGB_TYPE ) {
     set_sprite_prop( nb, tile );
@@ -122,9 +123,9 @@ void set_sprite_attrb( UBYTE nb, UBYTE tile )
 }
 
 
-void set_bkg_attr( UBYTE x, UBYTE y, UBYTE sx, UBYTE sy, unsigned char *d )
+void set_bkg_attr( uint8_t x, uint8_t y, uint8_t sx, uint8_t sy, unsigned char *d )
 {
-  UBYTE xx, yy;
+  uint8_t xx, yy;
 
   VBK_REG = 1;		/* select palette bank */
   for( yy=0; yy<sy; yy++ ) {
@@ -137,15 +138,15 @@ void set_bkg_attr( UBYTE x, UBYTE y, UBYTE sx, UBYTE sy, unsigned char *d )
   VBK_REG = 0;		/* select data bank */
 }
 
-UBYTE make_rnd( UBYTE i )
+uint8_t make_rnd( uint8_t i )
 {
   return( arand()%(i+1) );
 }
 
-void show_score( UWORD s )
+void show_score( uint16_t s )
 {
-  UWORD m;
-  UBYTE i, n, f;
+  uint16_t m;
+  uint8_t i, n, f;
   unsigned char score[6];
 
   f = 0; m = 10000;
@@ -162,7 +163,7 @@ void show_score( UWORD s )
   set_bkg_tiles( 4, 0, 6, 1, score );
 }
 
-void set_level( UBYTE i )
+void set_level( uint8_t i )
 {
   /* level */
   if( i < 9 ) {
@@ -174,7 +175,7 @@ void set_level( UBYTE i )
   }
 }
 
-void show_level( UBYTE i )
+void show_level( uint8_t i )
 {
   unsigned char level[2];
 
@@ -213,7 +214,7 @@ void init_score()
 
 void init_screen()
 {
-  UBYTE n;
+  uint8_t n;
 
   if( _cpu==CGB_TYPE ) {
     /* Transfer color palette */
@@ -268,7 +269,7 @@ void init_player()
 
 void init_tama()
 {
-  UBYTE i;
+  uint8_t i;
 
   for( i=0; i<MAX_TT; i++ ) {
     tf[i] = 0;
@@ -282,7 +283,7 @@ void init_tama()
 
 void init_enemy()
 {
-  UBYTE i;
+  uint8_t i;
 
   for( i=0; i<MAX_ET; i++ ) {
     ef[i] = 0;
@@ -297,7 +298,7 @@ void init_enemy()
 
 void init_kirai()
 {
-  UBYTE i;
+  uint8_t i;
 
   for( i=0; i<MAX_KT; i++ ) {
     kf[i] = 0;
@@ -311,9 +312,9 @@ void init_kirai()
 /* player */
 void player()
 {
-  UBYTE key;
-  UBYTE i;
-  UINT16 seed;
+  uint8_t key;
+  uint8_t i;
+  uint16_t seed;
 
   key = joypad();
   /* pause */
@@ -322,7 +323,7 @@ void player()
       /* Initialize the random number generator */
       seed = DIV_REG;
       waitpadup();
-      seed |= ((UINT16)DIV_REG << 8);
+      seed |= ((uint16_t)DIV_REG << 8);
       initarand(seed);
       hide_msg();
       init_score();
@@ -430,7 +431,7 @@ void player()
 /* bombs */
 void bombs()
 {
-   UBYTE i;
+   uint8_t i;
 
    for( i=0; i<MAX_TT; i++ ) {
     if( tf[i] != 0 ) {
@@ -450,7 +451,7 @@ void bombs()
 /* enemys */
 void enemys()
 {
-  UBYTE i, j;
+  uint8_t i, j;
 
   for( i=0; i<MAX_ET; i++ ) {
     if( ef[i] == 1 ) {
@@ -689,7 +690,7 @@ void enemys()
 /* kirai */
 void kirai()
 {
-  UBYTE i;
+  uint8_t i;
 
   for( i=0; i<MAX_KT; i++ ) {
     if( kf[i] != 0 ) {
@@ -725,7 +726,7 @@ void main()
   disable_interrupts();
   DISPLAY_OFF;
 
-  initarand(((UINT16)DIV_REG << 8));
+  initarand(((uint16_t)DIV_REG << 8));
 
   init_screen();
   init_score();

--- a/gbdk-lib/examples/gb/filltest/filltest.c
+++ b/gbdk-lib/examples/gb/filltest/filltest.c
@@ -2,9 +2,10 @@
 /* Jon Fuge jonny@q-continuum.demon.co.uk */
 
 #include <gb/gb.h>
+#include <stdint.h>
 #include <gb/drawing.h>
 
-void linetest(UBYTE x, UBYTE y, UBYTE w) {
+void linetest(uint8_t x, uint8_t y, uint8_t w) {
     color(DKGREY,WHITE,SOLID);
 	for (int i = -w; i <= w; i++) line(x,y,x+i,y-w);
 	for (int i = -w; i <= w; i++) line(x,y,x+w,y+i);
@@ -14,7 +15,7 @@ void linetest(UBYTE x, UBYTE y, UBYTE w) {
 
 void main(void)
 {
-    UBYTE  a,b,c,d,e;
+    uint8_t  a,b,c,d,e;
     c=0;
     /* Draw many characters on the screen with different fg and bg colours */
     for (a=0; a<=15; a++) {

--- a/gbdk-lib/examples/gb/fprpn/fprpn.c
+++ b/gbdk-lib/examples/gb/fprpn/fprpn.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <ctype.h>
 
@@ -5,11 +6,11 @@
 #define NUMBER    '0'
 #define STACKSIZE 40
 
-UBYTE sp;
+uint8_t sp;
 float stack[STACKSIZE];
 
 char s[MAXOP];
-UBYTE pos;
+uint8_t pos;
 float f;
 
 void push(float f)
@@ -38,7 +39,7 @@ float top()
   return 0.0;
 }
 
-BYTE read_op()
+int8_t read_op()
 {
   if(pos == 0) {
     gets(s);
@@ -57,18 +58,18 @@ BYTE read_op()
 
   f = s[pos] - '0';
   while(isdigit(s[++pos])) {
-    BYTE i = s[pos] - '0';
+    int8_t i = s[pos] - '0';
     f = 10.0 * f;
     f += (float)i;
   }
-/*     f = 10.0 * f + (float)(BYTE)(s[pos] - '0'); */
+/*     f = 10.0 * f + (float)(int8_t)(s[pos] - '0'); */
 
   return NUMBER;
 }
 
 void main()
 {
-  BYTE type;
+  int8_t type;
   float op2;
 
   puts("FP RPN Calculator");

--- a/gbdk-lib/examples/gb/galaxy/galaxy.c
+++ b/gbdk-lib/examples/gb/galaxy/galaxy.c
@@ -24,6 +24,7 @@
  */
 
 #include <gb/gb.h>
+#include <stdint.h>
 
 const unsigned char std_data[] = {
 
@@ -366,11 +367,11 @@ const unsigned char * const film[] = {
 #define OPENED  0x02
 #define CLOSING 0x03
 
-static UBYTE time = 0;  /* Global "time" value (counter) */
-UBYTE doorstate = 0;    /* State of the door (OPENED, CLOSED...) */
-UBYTE doorpos = 0;      /* Current position in the door animation */
-static UBYTE color = 0; /* Current color for fading effect */
-UBYTE sframe = 0;       /* Current frame of the sprite */
+static uint8_t time = 0;  /* Global "time" value (counter) */
+uint8_t doorstate = 0;    /* State of the door (OPENED, CLOSED...) */
+uint8_t doorpos = 0;      /* Current position in the door animation */
+static uint8_t color = 0; /* Current color for fading effect */
+uint8_t sframe = 0;       /* Current frame of the sprite */
 fixed bposx, bposy; /* Background position (fixed point) */
 fixed bspx, bspy;   /* Background speed (fixed point) */
 fixed wposx, wposy; /* Window position (fixed point) */
@@ -426,22 +427,22 @@ void scroll()
   if(wposx.b.h >= MAXWINX) {
     wposx.b.h = MAXWINX;
     /* Invert speed */
-    wspx.w = -(WORD)wspx.w;
+    wspx.w = -(int16_t)wspx.w;
   } else if(wposx.b.h <= MINWINX) {
     wposx.b.h = MINWINX;
     /* Invert speed */
-    wspx.w = -(WORD)wspx.w;
+    wspx.w = -(int16_t)wspx.w;
   }
   WX_REG = wposx.b.h;
   /* Y position */
   if(wposy.b.h >= MAXWINY) {
     wposy.b.h = MAXWINY;
     /* Invert speed */
-    wspy.w = -(WORD)wspy.w;
+    wspy.w = -(int16_t)wspy.w;
   } else if(wposy.b.h <= MINWINY) {
     wposy.b.h = MINWINY;
     /* Invert speed */
-    wspy.w = -(WORD)wspy.w;
+    wspy.w = -(int16_t)wspy.w;
   }
   WY_REG = wposy.b.h;
 
@@ -483,7 +484,7 @@ void animate_sprite()
 /* Set sprite tiles */
 void tile_sprite()
 {
-  UBYTE s;
+  uint8_t s;
 
   s = sframe<<1;
   set_sprite_tile(0, earth_tiles[s]);
@@ -499,7 +500,7 @@ void place_sprite()
 
 void main()
 {
-  UBYTE i, j;
+  uint8_t i, j;
 
   disable_interrupts();
   DISPLAY_OFF;

--- a/gbdk-lib/examples/gb/gb-dtmf/gb-dtmf.c
+++ b/gbdk-lib/examples/gb/gb-dtmf/gb-dtmf.c
@@ -5,6 +5,7 @@
 /* ---------------------------------------- */
 
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -184,9 +185,9 @@ void init_dial()
 }
 
 /* sound engine for DTMF */
-void dialtone(UWORD dtmf_on, UWORD dtmf_off, char str[20])
+void dialtone(uint16_t dtmf_on, uint16_t dtmf_off, char str[20])
 {
-	UBYTE i = 0;
+	uint8_t i = 0;
 
 	while(str[i]){
 		switch(str[i]){
@@ -281,9 +282,9 @@ void dialtone(UWORD dtmf_on, UWORD dtmf_off, char str[20])
 
 
 /* Display looks like 7-SEGMENT LED */
-void disp_lcd(UBYTE len, char str[MAX_DTMF])
+void disp_lcd(uint8_t len, char str[MAX_DTMF])
 {
-	UBYTE i,j;
+	uint8_t i,j;
 
 	j = len;
 
@@ -375,8 +376,8 @@ void clr_disp()
 */
 void disp(const char *str)
 {
-	UBYTE no, left_pos;
-	UBYTE i, start_ch, end_ch;
+	uint8_t no, left_pos;
+	uint8_t i, start_ch, end_ch;
 	char work[MAX_DTMF];
 
 	clr_disp();
@@ -405,7 +406,7 @@ void disp(const char *str)
 	set_bkg_tiles(left_pos, 2, end_ch, LCD_HIGHT, disp_tile);
 }
 
-void press_button(UBYTE x, UBYTE y)
+void press_button(uint8_t x, uint8_t y)
 {
 	if(x <= 3 && y <= 3){
 		set_bkg_tiles(x * 3 + 1, y * 3 + 5, 3, 3, press_tile);
@@ -418,7 +419,7 @@ void press_button(UBYTE x, UBYTE y)
 	}
 }
 
-void break_button(UBYTE x, UBYTE y)
+void break_button(uint8_t x, uint8_t y)
 {
 	if(x <= 3 && y <= 3){
 		set_bkg_tiles(x * 3 + 1, y * 3 + 5, 3, 3, break_tile);
@@ -434,7 +435,7 @@ void break_button(UBYTE x, UBYTE y)
 
 void init_key()
 {
-	UBYTE key_x, key_y, i;
+	uint8_t key_x, key_y, i;
 
 	/* To make numeric KeyPad */
 	set_sprite_data(0, 24, key_num);
@@ -514,7 +515,7 @@ void init_background()
 
 void init_cursor()
 {
-	UBYTE i;
+	uint8_t i;
 
 	/* Setup the cursor data*/
 	set_sprite_data(23, 8, cursor_data);
@@ -524,7 +525,7 @@ void init_cursor()
 	}
 }
 
-void move_cursor(UBYTE x, UBYTE y)
+void move_cursor(uint8_t x, uint8_t y)
 {
 	move_sprite(23, x, y);
 	move_sprite(24, x, y+8);
@@ -534,9 +535,9 @@ void move_cursor(UBYTE x, UBYTE y)
 
 void main()
 {
-	UBYTE key1, key2, i, j, pos_x, pos_y, ch_pos;
-	UBYTE non_flick = OFF;
-	UWORD on_time, off_time;
+	uint8_t key1, key2, i, j, pos_x, pos_y, ch_pos;
+	uint8_t non_flick = OFF;
+	uint16_t on_time, off_time;
 
 	char str[MAX_DTMF];
 	char str_ms[10];

--- a/gbdk-lib/examples/gb/gbdecompress/main.c
+++ b/gbdk-lib/examples/gb/gbdecompress/main.c
@@ -1,6 +1,6 @@
 #include <gb/gb.h>
-#include <gb/gbdecompress.h>
 #include <stdint.h>
+#include <gb/gbdecompress.h>
 #include <stdbool.h>
 
 // Include graphics data

--- a/gbdk-lib/examples/gb/irq/irq.c
+++ b/gbdk-lib/examples/gb/irq/irq.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <gb/console.h>
 #include <stdio.h>
 #include <string.h>

--- a/gbdk-lib/examples/gb/large_map/large_map.c
+++ b/gbdk-lib/examples/gb/large_map/large_map.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 
 #include "bigmap_map.h"
 #include "bigmap_tiles.h"
@@ -8,20 +9,20 @@
 
 #define MIN(A,B) ((A)<(B)?(A):(B))
 
-UBYTE joy;
+uint8_t joy;
 
 // current and old positions of the camera in pixels
-UWORD camera_x, camera_y, old_camera_x, old_camera_y;
+uint16_t camera_x, camera_y, old_camera_x, old_camera_y;
 // current and old position of the map in tiles
-UBYTE map_pos_x, map_pos_y, old_map_pos_x, old_map_pos_y;
+uint8_t map_pos_x, map_pos_y, old_map_pos_x, old_map_pos_y;
 // redraw flag, indicates that camera position was changed
-UBYTE redraw;
+uint8_t redraw;
 
 void set_camera() {
     // update hardware scroll position
     SCY_REG = camera_y; SCX_REG = camera_x; 
     // up or down
-    map_pos_y = (UBYTE)(camera_y >> 3u);
+    map_pos_y = (uint8_t)(camera_y >> 3u);
     if (map_pos_y != old_map_pos_y) { 
         if (camera_y < old_camera_y) {
             set_bkg_submap(map_pos_x, map_pos_y, MIN(21u, bigmap_mapWidth-map_pos_x), 1, bigmap_map, bigmap_mapWidth);
@@ -31,7 +32,7 @@ void set_camera() {
         old_map_pos_y = map_pos_y; 
     }
     // left or right
-    map_pos_x = (UBYTE)(camera_x >> 3u);
+    map_pos_x = (uint8_t)(camera_x >> 3u);
     if (map_pos_x != old_map_pos_x) {
         if (camera_x < old_camera_x) {
             set_bkg_submap(map_pos_x, map_pos_y, 1, MIN(19u, bigmap_mapHeight - map_pos_y), bigmap_map, bigmap_mapWidth);     

--- a/gbdk-lib/examples/gb/lcd_isr_wobble/lcd_isr_wobble.c
+++ b/gbdk-lib/examples/gb/lcd_isr_wobble/lcd_isr_wobble.c
@@ -1,13 +1,14 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include <gb/bgb_emu.h>
 
-const UBYTE scanline_offsets_tbl[] = {0, 1, 2, 3, 3, 2, 1, 0, 0, 1, 2, 3, 3, 2, 1, 0};
-const UBYTE * scanline_offsets = scanline_offsets_tbl;
+const uint8_t scanline_offsets_tbl[] = {0, 1, 2, 3, 3, 2, 1, 0, 0, 1, 2, 3, 3, 2, 1, 0};
+const uint8_t * scanline_offsets = scanline_offsets_tbl;
 
 void scanline_isr() {
-    SCX_REG = scanline_offsets[LY_REG & (UBYTE)7];
+    SCX_REG = scanline_offsets[LY_REG & (uint8_t)7];
 }
 
 
@@ -22,6 +23,6 @@ void main() {
 
     while (1) {
         wait_vbl_done();        
-        scanline_offsets = &scanline_offsets_tbl[(UBYTE)(sys_time >> 2) & 0x07u];
+        scanline_offsets = &scanline_offsets_tbl[(uint8_t)(sys_time >> 2) & 0x07u];
     }
 }

--- a/gbdk-lib/examples/gb/linkerfile/src/main.c
+++ b/gbdk-lib/examples/gb/linkerfile/src/main.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 
 
 void main(void)

--- a/gbdk-lib/examples/gb/metasprites/metasprites.c
+++ b/gbdk-lib/examples/gb/metasprites/metasprites.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <gb/sgb.h>
 #include <gb/metasprites.h>
 
@@ -18,11 +19,11 @@ joypads_t joypads;
 #define TILE_NUM_START 0
 
 // sprite coords
-UINT16 PosX, PosY;
-INT16 SpdX, SpdY;
-UINT8 PosF;
-UINT8 hide, jitter;
-UINT8 idx, rot;
+uint16_t PosX, PosY;
+int16_t SpdX, SpdY;
+uint8_t PosF;
+uint8_t hide, jitter;
+uint8_t idx, rot;
 
 // main funxction
 void main(void) {
@@ -106,7 +107,7 @@ void main(void) {
 
         PosX += SpdX, PosY += SpdY; 
 
-        UBYTE hiwater = 0;
+        uint8_t hiwater = 0;
 	
 		// NOTE: In a real game it would be better to only call the move_metasprite..()
         //       functions if something changed (such as movement or rotation). That
@@ -126,7 +127,7 @@ void main(void) {
             };
 
         // Hide rest of the hardware sprites, because amount of sprites differ between animation frames.
-        for (UBYTE i = hiwater; i < 40; i++) shadow_OAM[i].y = 0;
+        for (uint8_t i = hiwater; i < 40; i++) shadow_OAM[i].y = 0;
 
         // Y Axis: update velocity (reduce speed) if no U/D button pressed
         if (!(PosF & ACC_Y)) {

--- a/gbdk-lib/examples/gb/paint/paint.c
+++ b/gbdk-lib/examples/gb/paint/paint.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <gb/drawing.h>
 
 #define NB_TOOLS 18
@@ -23,17 +24,17 @@
 
 typedef struct icon_info_
 {
-  UBYTE data_idx; /* Index of data in the data array */
-  UBYTE x, y, w, h; /* Position and size (in tiles) */
-  UBYTE up, down, left, right; /* Index of next icons (for cursor movements) */
-  UBYTE cursor; /* Cursor associated with icon */
+  uint8_t data_idx; /* Index of data in the data array */
+  uint8_t x, y, w, h; /* Position and size (in tiles) */
+  uint8_t up, down, left, right; /* Index of next icons (for cursor movements) */
+  uint8_t cursor; /* Cursor associated with icon */
 } icon_info;
 
 typedef struct cursor_info_
 {
-  UBYTE data_idx; /* Index of data in the data array */
-  UBYTE w, h; /* Size (in tiles) */
-  UBYTE hot_x, hot_y; /* Position of hot point, relatice to top-left of sprite (in pixels) */
+  uint8_t data_idx; /* Index of data in the data array */
+  uint8_t w, h; /* Size (in tiles) */
+  uint8_t hot_x, hot_y; /* Position of hot point, relatice to top-left of sprite (in pixels) */
 } cursor_info;
 
 const icon_info icons[] =
@@ -246,21 +247,21 @@ const unsigned char cursors_data[][0x10] = {
 
 unsigned char data_buffer[NB_DATA_TILES][0x10];
 
-const UBYTE colors[] = { WHITE, DKGREY, LTGREY, BLACK };
-const UBYTE modes[] = { SOLID, OR, XOR, AND };
+const uint8_t colors[] = { WHITE, DKGREY, LTGREY, BLACK };
+const uint8_t modes[] = { SOLID, OR, XOR, AND };
 
-UBYTE current_tool;
-UBYTE current_color;
-UBYTE current_mode;
-UBYTE current_cursor;
-UBYTE menu_cursor_pos;
+uint8_t current_tool;
+uint8_t current_color;
+uint8_t current_mode;
+uint8_t current_cursor;
+uint8_t menu_cursor_pos;
 
-UBYTE cursor_x;
-UBYTE cursor_y;
+uint8_t cursor_x;
+uint8_t cursor_y;
 
 void set_cursor()
 {
-    UBYTE x, y, i;
+    uint8_t x, y, i;
 
     i = 0;
     for(x = 0; x < cursors[current_cursor].w; x++)
@@ -280,7 +281,7 @@ void set_cursor()
 
 void move_cursor()
 {
-  UBYTE x, y;
+  uint8_t x, y;
 
   for(x = 0; x < cursors[current_cursor].w; x++)
     for(y = 0; y < cursors[current_cursor].h; y++)
@@ -296,13 +297,13 @@ void move_menu_cursor()
 	      ((icons[menu_cursor_pos].y+icons[menu_cursor_pos].h)<<3) + 12);
 }
 
-void set_icon(UBYTE icon, UBYTE selected)
+void set_icon(uint8_t icon, uint8_t selected)
 {
-    UBYTE x, y;
+    uint8_t x, y;
 
     for(x = 0; x < icons[icon].w; x++)
 	for(y = 0; y < icons[icon].h; y++) {
-	    UWORD index = icons[icon].data_idx+((UWORD)x<<1)+y;
+	    uint16_t index = icons[icon].data_idx+((uint16_t)x<<1)+y;
 	    switch_data(icons[icon].x + x,
 			icons[icon].y + y,
 			selected ? selected_data[index] : data[index],
@@ -310,23 +311,23 @@ void set_icon(UBYTE icon, UBYTE selected)
 	}
 }
 
-void change_icon(UBYTE icon, UBYTE selected)
+void change_icon(uint8_t icon, uint8_t selected)
 {
-  UBYTE x, y;
+  uint8_t x, y;
 
   for(x = 0; x < icons[icon].w; x++)
     for(y = 0; y < icons[icon].h; y++)
       switch_data(icons[icon].x + x,
 		  icons[icon].y + y,
 		  (selected ?
-		   selected_data[icons[icon].data_idx+((UWORD)x<<1)+y] :
-		   data[icons[icon].data_idx+((UWORD)x<<1)+y]),
+		   selected_data[icons[icon].data_idx+((uint16_t)x<<1)+y] :
+		   data[icons[icon].data_idx+((uint16_t)x<<1)+y]),
 		  NULL);
 }
 
-void reset_icon(UBYTE icon)
+void reset_icon(uint8_t icon)
 {
-  UBYTE x, y;
+  uint8_t x, y;
 
   for(x = 0; x < icons[icon].w; x++)
     for(y = 0; y < icons[icon].h; y++)
@@ -338,7 +339,7 @@ void reset_icon(UBYTE icon)
 
 void splash()
 {
-  UBYTE x, y;
+  uint8_t x, y;
 
   cursor_x = 40;
   cursor_y = 50;
@@ -382,9 +383,9 @@ void splash()
 
 void menu()
 {
-  UBYTE i, key;
-  UBYTE slowdown;
-  UBYTE cursor;
+  uint8_t i, key;
+  uint8_t slowdown;
+  uint8_t cursor;
 
   slowdown = 50;
 
@@ -452,9 +453,9 @@ void menu()
 
 void run()
 {
-  UBYTE key;
-  UBYTE slowdown;
-  UBYTE drawn, erased;
+  uint8_t key;
+  uint8_t slowdown;
+  uint8_t drawn, erased;
 
   slowdown = 10;
   drawn = erased = 0;

--- a/gbdk-lib/examples/gb/ram_function/ram_fn.c
+++ b/gbdk-lib/examples/gb/ram_function/ram_fn.c
@@ -1,8 +1,9 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-UWORD counter = 0;
+uint16_t counter = 0;
 
 // inc() must be a relocatable function, be careful!
 void inc() {
@@ -34,8 +35,8 @@ void print_counter() {
 
 void main() {
     // copy inc() function to it's new destinations: hiram_buffer and ram_buffer
-    hiramcpy((UBYTE)&hiram_buffer, (void *)&inc, (UBYTE)object_distance(inc, inc_end));
-    memcpy(&ram_buffer, (void *)&inc, (UWORD)object_distance(inc, inc_end));
+    hiramcpy((uint8_t)&hiram_buffer, (void *)&inc, (uint8_t)object_distance(inc, inc_end));
+    memcpy(&ram_buffer, (void *)&inc, (uint16_t)object_distance(inc, inc_end));
 
     // print initial counter state
     puts("Program Start...");

--- a/gbdk-lib/examples/gb/rand/rand.c
+++ b/gbdk-lib/examples/gb/rand/rand.c
@@ -11,18 +11,19 @@
  **************************************************************************/
 
 #include <gb/gb.h>
+#include <stdint.h>
 #include <rand.h>
 #include <gb/drawing.h>
 #include <stdio.h>
 #include <string.h>
 
-UBYTE accu[80];
-UBYTE accua[80];
+uint8_t accu[80];
+uint8_t accua[80];
 
 void main(void)
 {
-  UBYTE r, s, t = 0, u = 0;
-  UWORD seed;
+  uint8_t r, s, t = 0, u = 0;
+  uint16_t seed;
 
   memset(accu, 0, sizeof(accu));
   memset(accua, 0, sizeof(accua));
@@ -36,7 +37,7 @@ void main(void)
   puts("Push any key (2)");
   waitpad(0xFF);
   waitpadup();
-  seed |= (UWORD)DIV_REG << 8;
+  seed |= (uint16_t)DIV_REG << 8;
 
   /* initarand() calls initrand() */
   initarand(seed);

--- a/gbdk-lib/examples/gb/rpn/rpn.c
+++ b/gbdk-lib/examples/gb/rpn/rpn.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <ctype.h>
 
@@ -5,14 +6,14 @@
 #define NUMBER    '0'
 #define STACKSIZE 40
 
-UBYTE sp;
-WORD stack[STACKSIZE];
+uint8_t sp;
+int16_t stack[STACKSIZE];
 
 char s[MAXOP];
-UBYTE pos;
-WORD n;
+uint8_t pos;
+int16_t n;
 
-void push(WORD l)
+void push(int16_t l)
 {
   if(sp < STACKSIZE)
     stack[sp++] = l;
@@ -20,7 +21,7 @@ void push(WORD l)
     puts("Stack full");
 }
 
-WORD pop(void)
+int16_t pop(void)
 {
   if(sp > 0)
     return stack[--sp];
@@ -29,7 +30,7 @@ WORD pop(void)
   return 0;
 }
 
-WORD top(void)
+int16_t top(void)
 {
   if(sp > 0)
     return stack[sp-1];
@@ -38,7 +39,7 @@ WORD top(void)
   return 0;
 }
 
-BYTE read_op(void)
+int8_t read_op(void)
 {
     if(pos == 0) {
 	gets(s);
@@ -64,8 +65,8 @@ BYTE read_op(void)
 
 void main(void)
 {
-  BYTE type;
-  WORD op2;
+  int8_t type;
+  int16_t op2;
 
   puts("RPN Calculator");
   sp = 0;

--- a/gbdk-lib/examples/gb/samptest/samptest.c
+++ b/gbdk-lib/examples/gb/samptest/samptest.c
@@ -4,11 +4,12 @@
  */
 
 #include <gb/gb.h>
+#include <stdint.h>
 #include <gb/sample.h>
 #include <stdio.h>
 
 #define SAMPLES 25768
-extern const UBYTE sample[];
+extern const uint8_t sample[];
 
 void main()
 {
@@ -22,7 +23,7 @@ void main()
 	}
 }
 
-const UBYTE sample[] =
+const uint8_t sample[] =
 {
 0x86,0x98,0x65,0x97,0x7b,0x79,0x66,0x77,
 0x87,0x76,0x88,0x89,0x88,0x68,0x88,0x99,

--- a/gbdk-lib/examples/gb/scroller/text_scroller.c
+++ b/gbdk-lib/examples/gb/scroller/text_scroller.c
@@ -1,16 +1,17 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include <gb/bgb_emu.h>
 
-const UBYTE scanline_offsets_tbl[] = {0, 1, 2, 3, 3, 2, 1, 0, 0, 1, 2, 3, 3, 2, 1, 0};
-const UBYTE * scanline_offsets = scanline_offsets_tbl;
+const uint8_t scanline_offsets_tbl[] = {0, 1, 2, 3, 3, 2, 1, 0, 0, 1, 2, 3, 3, 2, 1, 0};
+const uint8_t * scanline_offsets = scanline_offsets_tbl;
 
 #define SCROLL_POS 15
 #define SCROLL_POS_PIX_START (SCROLL_POS * 8) - 1
 #define SCROLL_POS_PIX_END ((SCROLL_POS + 1) * 8) - 1
 
-UBYTE scroller_x = 0;
+uint8_t scroller_x = 0;
 
 void scanline_isr() {
     switch (LYC_REG) {
@@ -28,14 +29,14 @@ void scanline_isr() {
     }
 }
 
-const UBYTE scroller_text[] = "This is a text scroller demo for GBDK-2020. You can use ideas, that are "\
+const uint8_t scroller_text[] = "This is a text scroller demo for GBDK-2020. You can use ideas, that are "\
 "shown in this demo, to make different parallax effects, scrolling of tilemaps which are larger than 32x32 "\
 "tiles and TEXT SCROLLERS, of course! Need to write something else to make this text longer than 256 characters. "\
 "The quick red fox jumps over the lazy brown dog. 0123456789.          ";
 
-const UBYTE * scroller_next_char = scroller_text;
-UBYTE * scroller_vram_addr;
-UWORD base, limit;
+const uint8_t * scroller_next_char = scroller_text;
+uint8_t * scroller_vram_addr;
+uint16_t base, limit;
 
 void main() {
     printf("Scrolling %d chars", sizeof(scroller_text) - 1);
@@ -49,7 +50,7 @@ void main() {
     scroller_vram_addr = get_bkg_xy_addr(20, SCROLL_POS);
     set_vram_byte(scroller_vram_addr, *scroller_next_char - 0x20);
     
-    base = (UWORD) scroller_vram_addr & 0xffe0;
+    base = (uint16_t) scroller_vram_addr & 0xffe0;
     limit = base + 0x20;
     
     while (1) {
@@ -61,7 +62,7 @@ void main() {
             
             // next vram position
             scroller_vram_addr++;
-            if (scroller_vram_addr == (UBYTE *)limit) scroller_vram_addr = (UBYTE *)base;
+            if (scroller_vram_addr == (uint8_t *)limit) scroller_vram_addr = (uint8_t *)base;
             
             // put next char
             set_vram_byte(scroller_vram_addr, *scroller_next_char - 0x20);

--- a/gbdk-lib/examples/gb/sgb_border/border.c
+++ b/gbdk-lib/examples/gb/sgb_border/border.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include "sgb_border.h"
 
 #include "border_data.h"

--- a/gbdk-lib/examples/gb/sgb_border/border_data.h
+++ b/gbdk-lib/examples/gb/sgb_border/border_data.h
@@ -2,6 +2,7 @@
 #define __SGB_BORDER_DATA_H_INCLUDE
 
 #include <gb/gb.h>
+#include <stdint.h>
 
 extern const unsigned char border_chr[];
 extern const unsigned int border_chr_size;

--- a/gbdk-lib/examples/gb/sgb_border/sgb_border.c
+++ b/gbdk-lib/examples/gb/sgb_border/sgb_border.c
@@ -1,6 +1,7 @@
 #include "sgb_border.h"
 
 #include <gb/gb.h>
+#include <stdint.h>
 #include <gb/sgb.h>
 #include <string.h>
 
@@ -24,15 +25,15 @@ void set_sgb_border(unsigned char * tiledata, size_t tiledata_size,
         BGP_REG = OBP0_REG = OBP1_REG = 0xE4U;
         SCX_REG = SCY_REG = 0U;
 
-        UBYTE tmp_lcdc = LCDC_REG;
+        uint8_t tmp_lcdc = LCDC_REG;
 
         HIDE_SPRITES, HIDE_WIN, SHOW_BKG;
         DISPLAY_ON;
         // prepare tilemap for SGB_BORDER_CHR_TRN (should display all 256 tiles)
-        UBYTE i = 0U;
-        for (UBYTE y = 0; y != 14U; ++y) {
-            UBYTE * dout = map_buf;
-            for (UBYTE x = 0U; x != 20U; ++x) {
+        uint8_t i = 0U;
+        for (uint8_t y = 0; y != 14U; ++y) {
+            uint8_t * dout = map_buf;
+            for (uint8_t x = 0U; x != 20U; ++x) {
                 *dout++ = i++;
             }
             set_bkg_tiles(0, y, 20, 1, map_buf);
@@ -40,7 +41,7 @@ void set_sgb_border(unsigned char * tiledata, size_t tiledata_size,
         memset(map_buf, 0, sizeof(map_buf));
 
         // transfer tile data
-        UBYTE ntiles = (tiledata_size > 256 * 32) ? 0 : tiledata_size >> 5;
+        uint8_t ntiles = (tiledata_size > 256 * 32) ? 0 : tiledata_size >> 5;
         if ((!ntiles) || (ntiles > 128U)) { 
             set_bkg_data(0, 0, tiledata); 
             SGB_TRANSFER((SGB_CHR_TRN << 3) | 1, SGB_CHR_BLOCK0);
@@ -54,8 +55,8 @@ void set_sgb_border(unsigned char * tiledata, size_t tiledata_size,
         }
 
         // transfer map and palettes
-        set_bkg_data(0, (UBYTE)(tilemap_size >> 4), tilemap);
-        set_bkg_data(128, (UBYTE)(palette_size >> 4), palette);
+        set_bkg_data(0, (uint8_t)(tilemap_size >> 4), tilemap);
+        set_bkg_data(128, (uint8_t)(palette_size >> 4), palette);
         SGB_TRANSFER((SGB_PCT_TRN << 3) | 1, 0);
 
         LCDC_REG = tmp_lcdc;

--- a/gbdk-lib/examples/gb/sgb_border/sgb_border.h
+++ b/gbdk-lib/examples/gb/sgb_border/sgb_border.h
@@ -2,8 +2,9 @@
 #define __SGB_BORDER_H_INCLUDE
 
 #include <gb/gb.h>
+#include <stdint.h>
 
-#define SNES_RGB(R,G,B) (UINT16)((B) << 10 | (G) << 5 | (R))
+#define SNES_RGB(R,G,B) (uint16_t)((B) << 10 | (G) << 5 | (R))
 
 /** sets SGB border */
 

--- a/gbdk-lib/examples/gb/sgb_multiplayer/sgb_multiplayer.c
+++ b/gbdk-lib/examples/gb/sgb_multiplayer/sgb_multiplayer.c
@@ -1,7 +1,8 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <gb/sgb.h>
 
-UINT8 sprite_data[] = { 
+uint8_t sprite_data[] = {
     0x3C,0x3C,0x42,0x7E,0x99,0xFF,0xA9,0xFF,0x89,0xFF,0x89,0xFF,0x42,0x7E,0x3C,0x3C,
     0x3C,0x3C,0x42,0x7E,0xB9,0xFF,0x89,0xFF,0x91,0xFF,0xB9,0xFF,0x42,0x7E,0x3C,0x3C,
     0x3C,0x3C,0x42,0x7E,0x99,0xFF,0x89,0xFF,0x99,0xFF,0x89,0xFF,0x5A,0x7E,0x3C,0x3C,
@@ -13,7 +14,7 @@ joypads_t joypads;
 void main(void) {
     BGP_REG = OBP0_REG = OBP1_REG = 0xE4;
     set_sprite_data(0, 4, sprite_data);
-    for (UINT8 i = 0; i < 4; i++) {
+    for (uint8_t i = 0; i < 4; i++) {
         set_sprite_tile(i, i);
         move_sprite(i, (i << 3) + 64, 64);
     }
@@ -26,8 +27,8 @@ void main(void) {
         // poll joypads
         joypad_ex(&joypads);
         // iterate joypads, move sprites
-        for (UINT8 i = 0; i < joypads.npads; i++) {
-            UINT8 joy = joypads.joypads[i];
+        for (uint8_t i = 0; i < joypads.npads; i++) {
+            uint8_t joy = joypads.joypads[i];
             if (joy & J_LEFT) scroll_sprite(i, -1, 0);
             if (joy & J_RIGHT) scroll_sprite(i, 1, 0);
             if (joy & J_UP) scroll_sprite(i, 0, -1);
@@ -35,7 +36,7 @@ void main(void) {
         }
         // start on joypad 1 resets position
         if (joypads.joy0 & J_START) {
-            for (UINT8 i = 0; i < 4; i++) move_sprite(i, (i << 3) + 64, 64);
+            for (uint8_t i = 0; i < 4; i++) move_sprite(i, (i << 3) + 64, 64);
         }
         wait_vbl_done();
     }

--- a/gbdk-lib/examples/gb/sgb_pong/sgb_pong.c
+++ b/gbdk-lib/examples/gb/sgb_pong/sgb_pong.c
@@ -1,10 +1,11 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <gb/sgb.h>
 
 #include <stdio.h>
 #include <gb/console.h>
 
-UINT8 sprite_data[] = { 
+uint8_t sprite_data[] = {
     0x3C,0x3C,0x42,0x7E,0x99,0xFF,0xA9,0xFF,0x89,0xFF,0x89,0xFF,0x42,0x7E,0x3C,0x3C,
     0x3C,0x3C,0x42,0x7E,0xB9,0xFF,0x89,0xFF,0x91,0xFF,0xB9,0xFF,0x42,0x7E,0x3C,0x3C,
     0x3C,0x3C,0x42,0x7E,0x99,0xFF,0x89,0xFF,0x99,0xFF,0x89,0xFF,0x5A,0x7E,0x3C,0x3C,
@@ -13,14 +14,14 @@ UINT8 sprite_data[] = {
 };
 
 // initializes sprites for pad. every pad uses 3 sprites which id's are aligned by 4
-void init_pad(UINT8 n) {
+void init_pad(uint8_t n) {
     set_sprite_tile(n << 2, n);
     set_sprite_tile((n << 2) + 1, n);
     set_sprite_tile((n << 2) + 2, n);
 }
 
 // inline function for moving pads; code of this function will be inlined with the code of main()
-inline void draw_pad(UINT8 n, UINT8 x, UINT8 y) {
+inline void draw_pad(uint8_t n, uint8_t x, uint8_t y) {
     move_sprite(n << 2, x, y);
     move_sprite((n << 2) + 1, x, y + 8);
     move_sprite((n << 2) + 2, x, y + 16);
@@ -29,18 +30,18 @@ inline void draw_pad(UINT8 n, UINT8 x, UINT8 y) {
 joypads_t joypads;
 
 // absolute Y coordinates of player 1 & 2
-UINT8 player1, player2;
-UINT16 player1_score, player2_score;
+uint8_t player1, player2;
+uint16_t player1_score, player2_score;
 
 // player constraints
 #define YMIN 28
 #define YMAX 100
 #define PLAYER1_X 16
-#define PLAYER2_X (UINT8)((20 * 8) - 8)
+#define PLAYER2_X (uint8_t)((20 * 8) - 8)
 
 // coordinates and speeds of ball
-UINT8 ballX, ballY;
-INT8 spd_ballX, spd_ballY;
+uint8_t ballX, ballY;
+int8_t spd_ballX, spd_ballY;
 
 #define INITBALLX 80 + 4 
 #define INITBALLY 64 + 8

--- a/gbdk-lib/examples/gb/sound/sound.c
+++ b/gbdk-lib/examples/gb/sound/sound.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <gb/console.h>
 
@@ -21,16 +22,16 @@
 
 #define UNSIGNED 0
 
-UBYTE previous_keys = 0;
-BYTE keys = 0;
+uint8_t previous_keys = 0;
+int8_t keys = 0;
 #define UPDATE_KEYS() previous_keys = keys; keys = joypad()
 #define KEY_PRESSED(K) (keys & (K))
 #define KEY_TICKED(K) ((keys & (K)) && !(previous_keys & (K)))
 
-void show_register_channel(UBYTE mode);
+void show_register_channel(uint8_t mode);
 
 void clss()  {
-	UINT8 i = 0;
+	uint8_t i = 0;
 	for(i = 0; i < 18; ++i) {
 		gotoxy(0, i);
 		printf("                    ");
@@ -42,7 +43,7 @@ void print(const char* str) {
 }
 
 const char hex[] = "0123456789ABCDEF";
-void printn(UWORD n, UINT8 base, UINT8 sign) {
+void printn(uint16_t n, uint8_t base, uint8_t sign) {
 	(void) sign;
 	if(base == 16u) {
 		printf("%c", hex[0x000Fu & (n >> 4u)]);
@@ -53,7 +54,7 @@ void printn(UWORD n, UINT8 base, UINT8 sign) {
 }
 
 
-void println(UWORD n, UINT8 base, UINT8 sign) {
+void println(uint16_t n, uint8_t base, uint8_t sign) {
 	printn(n, base, sign);
 	printf("\n");
 }
@@ -68,7 +69,7 @@ enum notes {
   SILENCE, END
 };
 
-const UWORD frequencies[] = {
+const uint16_t frequencies[] = {
   44, 156, 262, 363, 457, 547, 631, 710, 786, 854, 923, 986,
   1046, 1102, 1155, 1205, 1253, 1297, 1339, 1379, 1417, 1452, 1486, 1517,
   1546, 1575, 1602, 1627, 1650, 1673, 1694, 1714, 1732, 1750, 1767, 1783,
@@ -77,7 +78,7 @@ const UWORD frequencies[] = {
   1985, 1988, 1992, 1995, 1998, 2001, 2004, 2006, 2009, 2011, 2013, 2015
 };
 
-const UBYTE music[] = {
+const uint8_t music[] = {
   C3, C3, G3, G3, A3, A3, G3, SILENCE,
   F3, F3, E3, E3, D3, D3, C3, SILENCE,
   G3, G3, F3, F3, E3, E3, D3, D3,
@@ -89,7 +90,7 @@ const UBYTE music[] = {
 
 struct Params {
   char *name;
-  UWORD max;
+  uint16_t max;
 };
 
 const struct Params params_0[] = {
@@ -177,120 +178,120 @@ const struct Params *params;
 struct SoundReg {
   struct {
     //NR10 0xFF10
-    UINT16 sweepShifts     ;//: 3;
-    UINT16 sweepMode       ;//: 1;
-    UINT16 sweepTime       ;//: 3;
-    UINT16 unused_1        ;//: 1;
+    uint16_t sweepShifts     ;//: 3;
+    uint16_t sweepMode       ;//: 1;
+    uint16_t sweepTime       ;//: 3;
+    uint16_t unused_1        ;//: 1;
 
     //NR11 0xFF11
-    UINT16 soundLength     ;//: 6;
-    UINT16 patternDuty     ;//: 2;
+    uint16_t soundLength     ;//: 6;
+    uint16_t patternDuty     ;//: 2;
 
     //NR12 0xFF12
-    UINT16 envNbSweep      ;//: 3;
-    UINT16 envMode         ;//: 1;
-    UINT16 envInitialValue ;//: 4;
+    uint16_t envNbSweep      ;//: 3;
+    uint16_t envMode         ;//: 1;
+    uint16_t envInitialValue ;//: 4;
 
     //NR13 0xFF13
-    UINT16 frequencyLow;
+    uint16_t frequencyLow;
 
     //NR14 0xFF14
-    UINT16 frequencyHigh   ;//: 3;
-    UINT16 unused_2        ;//: 3;
-    UINT16 counter_ConsSel ;//: 1;
-    UINT16 restart         ;//: 1;
+    uint16_t frequencyHigh   ;//: 3;
+    uint16_t unused_2        ;//: 3;
+    uint16_t counter_ConsSel ;//: 1;
+    uint16_t restart         ;//: 1;
   } mode1;
   struct {
     //NR20 0xFF15
-    UINT16 unused_1;
+    uint16_t unused_1;
 
     //NR21 0xFF16
-    UINT16 soundLength     ;//: 6;
-    UINT16 patternDuty     ;//: 2;
+    uint16_t soundLength     ;//: 6;
+    uint16_t patternDuty     ;//: 2;
 
     //NR22 0xFF17
-    UINT16 envNbStep       ;//: 3;
-    UINT16 envMode         ;//: 1;
-    UINT16 envInitialValue ;//: 4;
+    uint16_t envNbStep       ;//: 3;
+    uint16_t envMode         ;//: 1;
+    uint16_t envInitialValue ;//: 4;
 
     //NR23 0xFF18
-    UINT16 frequencyLow;
+    uint16_t frequencyLow;
 
     //NR24 0xFF19
-    UINT16 frequencyHigh   ;//: 3;
-    UINT16 unused_2        ;//: 3;
-    UINT16 counter_ConsSel ;//: 1;
-    UINT16 restart         ;//: 1;
+    uint16_t frequencyHigh   ;//: 3;
+    uint16_t unused_2        ;//: 3;
+    uint16_t counter_ConsSel ;//: 1;
+    uint16_t restart         ;//: 1;
   } mode2;
   struct {
     //NR30 0xFF1A
-    UINT16 unused_1        ;//: 7;
-    UINT16 on_Off          ;//: 1;
+    uint16_t unused_1        ;//: 7;
+    uint16_t on_Off          ;//: 1;
 
     //NR31 0xFF1B
-    UINT16 soundLength;
+    uint16_t soundLength;
 
     //NR32 0xFF1C
-    UINT16 unused_2        ;//: 5;
-    UINT16 selOutputLevel  ;//: 2;
-    UINT16 unused_3        ;//: 1;
+    uint16_t unused_2        ;//: 5;
+    uint16_t selOutputLevel  ;//: 2;
+    uint16_t unused_3        ;//: 1;
 
     //NR33 0xFF1D
-    UINT16 frequencyLow;
+    uint16_t frequencyLow;
 
     //NR34 0xFF1E
-    UINT16 frequencyHigh   ;//: 3;
-    UINT16 unused_4        ;//: 3;
-    UINT16 counter_ConsSel ;//: 1;
-    UINT16 restart         ;//: 1;
+    uint16_t frequencyHigh   ;//: 3;
+    uint16_t unused_4        ;//: 3;
+    uint16_t counter_ConsSel ;//: 1;
+    uint16_t restart         ;//: 1;
   } mode3;
   struct {
     //NR40 0xFF1F
-    UINT16 unused_1;
+    uint16_t unused_1;
 
     //NR41 0xFF20
-    UINT16 soundLength     ;//: 6;
-    UINT16 unused_2        ;//: 2;
+    uint16_t soundLength     ;//: 6;
+    uint16_t unused_2        ;//: 2;
 
     //NR42 0xFF21
-    UINT16 envNbStep       ;//: 3;
-    UINT16 envMode         ;//: 1;
-    UINT16 envInitialValue ;//: 4;
+    uint16_t envNbStep       ;//: 3;
+    uint16_t envMode         ;//: 1;
+    uint16_t envInitialValue ;//: 4;
 
     //NR43 0xFF22
-    UINT16 polyCounterDiv  ;//: 3;
-    UINT16 polyCounterStep ;//: 1;
-    UINT16 polyCounterFreq ;//: 4;
+    uint16_t polyCounterDiv  ;//: 3;
+    uint16_t polyCounterStep ;//: 1;
+    uint16_t polyCounterFreq ;//: 4;
 
     //NR44 0xFF23
-    UINT16 unused_3        ;//: 6;
-    UINT16 counter_ConsSel ;//: 1;
-    UINT16 restart         ;//: 1;
+    uint16_t unused_3        ;//: 6;
+    uint16_t counter_ConsSel ;//: 1;
+    uint16_t restart         ;//: 1;
   } mode4;
   struct {
     // NR50 0xFF24
-    UINT16 SO1_OutputLevel ;//: 3;
-    UINT16 Vin_SO1         ;//: 1;
-    UINT16 SO2_OutputLevel ;//: 3;
-    UINT16 Vin_SO2         ;//: 1;
+    uint16_t SO1_OutputLevel ;//: 3;
+    uint16_t Vin_SO1         ;//: 1;
+    uint16_t SO2_OutputLevel ;//: 3;
+    uint16_t Vin_SO2         ;//: 1;
 
     // NR51 0xFF25
-    UINT16 Sound1_To_SO1   ;//: 1;
-    UINT16 Sound2_To_SO1   ;//: 1;
-    UINT16 Sound3_To_SO1   ;//: 1;
-    UINT16 Sound4_To_SO1   ;//: 1;
-    UINT16 Sound1_To_SO2   ;//: 1;
-    UINT16 Sound2_To_SO2   ;//: 1;
-    UINT16 Sound3_To_SO2   ;//: 1;
-    UINT16 Sound4_To_SO2   ;//: 1;
+    uint16_t Sound1_To_SO1   ;//: 1;
+    uint16_t Sound2_To_SO1   ;//: 1;
+    uint16_t Sound3_To_SO1   ;//: 1;
+    uint16_t Sound4_To_SO1   ;//: 1;
+    uint16_t Sound1_To_SO2   ;//: 1;
+    uint16_t Sound2_To_SO2   ;//: 1;
+    uint16_t Sound3_To_SO2   ;//: 1;
+    uint16_t Sound4_To_SO2   ;//: 1;
 
     // NR52 0xFF26
-    UINT16 Sound1_On_Off   ;//: 1;
-    UINT16 Sound2_On_Off   ;//: 1;
-    UINT16 Sound3_On_Off   ;//: 1;
-    UINT16 Sound4_On_Off   ;//: 1;
-    UINT16 unused_1        ;//: 3;
-    UINT16 global_On_Off   ;//: 1;
+    uint16_t Sound1_On_Off   ;//: 1;
+    uint16_t Sound2_On_Off   ;//: 1;
+    uint16_t Sound3_On_Off   ;//: 1;
+    uint16_t Sound4_On_Off   ;//: 1;
+    uint16_t unused_1        ;//: 3;
+    uint16_t global_On_Off   ;//: 1;
   } control;
 };
 
@@ -322,99 +323,99 @@ struct SoundReg s = {
 	  0, 0, 0, 0, 0, 1 }
 };
 
-UBYTE NR10() {
+uint8_t NR10() {
 	return soundReg->mode1.sweepShifts | (soundReg->mode1.sweepMode << 3) | (soundReg->mode1.sweepTime << 4);
 }
 
-UBYTE NR11() {
+uint8_t NR11() {
 	return soundReg->mode1.soundLength | (soundReg->mode1.patternDuty << 6);
 }
 
-UBYTE NR12() {
+uint8_t NR12() {
 	return soundReg->mode1.envNbSweep | (soundReg->mode1.envMode << 3) | (soundReg->mode1.envInitialValue << 4);
 }
 
-UBYTE NR13() {
+uint8_t NR13() {
 	return soundReg->mode1.frequencyLow;
 }
 
-UBYTE NR14() {
+uint8_t NR14() {
 	return soundReg->mode1.frequencyHigh | (soundReg->mode1.counter_ConsSel << 6) | (soundReg->mode1.restart << 7);
 }
 
 //--------------------------
-UBYTE NR21() {
+uint8_t NR21() {
 	return soundReg->mode2.soundLength | (soundReg->mode2.patternDuty << 6);
 }
 
-UBYTE NR22() {
+uint8_t NR22() {
 	return soundReg->mode2.envNbStep | (soundReg->mode2.envMode << 3) | (soundReg->mode2.envInitialValue << 4);
 }
 
-UBYTE NR23() {
+uint8_t NR23() {
 	return soundReg->mode2.frequencyLow;
 }
 
-UBYTE NR24() {
+uint8_t NR24() {
 	return soundReg->mode2.frequencyHigh | (soundReg->mode2.counter_ConsSel << 6) | (soundReg->mode2.restart << 7);
 }
 
 //-------------------------------
-UBYTE NR30() {
+uint8_t NR30() {
 	return soundReg->mode3.on_Off << 7;
 }
 
-UBYTE NR31() {
+uint8_t NR31() {
 	return soundReg->mode3.soundLength;
 }
 
-UBYTE NR32() {
+uint8_t NR32() {
 	return soundReg->mode3.selOutputLevel << 5;
 }
 
-UBYTE NR33() {
+uint8_t NR33() {
 	return soundReg->mode3.frequencyLow;
 }
 
-UBYTE NR34() {
+uint8_t NR34() {
 	return soundReg->mode3.frequencyHigh | (soundReg->mode3.counter_ConsSel << 6) | (soundReg->mode3.restart << 7);
 }
 
 //-------------------------------
-UBYTE NR41() {
+uint8_t NR41() {
 	return soundReg->mode4.soundLength;
 }
 
-UBYTE NR42() {
+uint8_t NR42() {
 	return soundReg->mode4.envNbStep | (soundReg->mode4.envMode << 3) | (soundReg->mode4.envInitialValue << 4);
 }
 
-UBYTE NR43() {
+uint8_t NR43() {
 	return soundReg->mode4.polyCounterDiv | (soundReg->mode4.polyCounterStep << 3) | (soundReg->mode4.polyCounterFreq << 4);
 }
 
-UBYTE NR44() {
+uint8_t NR44() {
 	return (soundReg->mode4.counter_ConsSel << 6) | (soundReg->mode4.restart << 7);
 }
 
 //-------------------------------
-UBYTE NR50() {
+uint8_t NR50() {
 	return soundReg->control.SO1_OutputLevel | (soundReg->control.Vin_SO1 << 3u) | (soundReg->control.SO2_OutputLevel << 4u) |
 	           (soundReg->control.Vin_SO2 << 7u);
 }
 
-UBYTE NR51() {
+uint8_t NR51() {
 	return soundReg->control.Sound1_To_SO1 | (soundReg->control.Sound2_To_SO1 << 1) | (soundReg->control.Sound3_To_SO1 << 2) |
 	          (soundReg->control.Sound4_To_SO1 << 3) | (soundReg->control.Sound1_To_SO2 << 4) | (soundReg->control.Sound2_To_SO2 << 5) |
 			  (soundReg->control.Sound3_To_SO2 << 6)| (soundReg->control.Sound4_To_SO2 << 7);
 }
 
-UBYTE NR52() {
+uint8_t NR52() {
 	return soundReg->control.global_On_Off << 7;
 }
 
 //---------------------------------------------------------------------------------
-UWORD current_value(UBYTE mode, UBYTE line)
+uint16_t current_value(uint8_t mode, uint8_t line)
 {
   if(mode == 0) {
     switch(line)
@@ -537,7 +538,7 @@ UWORD current_value(UBYTE mode, UBYTE line)
   return 0;
 }
 
-void update_value(UBYTE mode, UBYTE line, UWORD value)
+void update_value(uint8_t mode, uint8_t line, uint16_t value)
 {
   if(mode == 0) {
     switch(line)
@@ -804,9 +805,9 @@ void update_value(UBYTE mode, UBYTE line, UWORD value)
   }
 }
 
-UBYTE draw_screen(UBYTE mode)
+uint8_t draw_screen(uint8_t mode)
 {
-  UBYTE i;
+  uint8_t i;
 
   clss();
   gotoxy(FIRST_X, TITLE_Y);
@@ -823,9 +824,9 @@ UBYTE draw_screen(UBYTE mode)
 }
 
 
-void play_music(UBYTE mode)
+void play_music(uint8_t mode)
 {
-  UBYTE i = 0;
+  uint8_t i = 0;
 
   while(music[i] != END) {
     if(music[i] != SILENCE) {
@@ -838,7 +839,7 @@ void play_music(UBYTE mode)
 }
 
 
-void show_register_channel(UBYTE mode) {
+void show_register_channel(uint8_t mode) {
 
     switch (mode) {
         case 1:
@@ -931,11 +932,11 @@ void dump_registers()
 	print("NR52:");println(NR52(), 16, UNSIGNED);
 }
 
-void wait_event(UBYTE mode)
+void wait_event(uint8_t mode)
 {
-  UBYTE y, last_y;
-  UWORD l = 0;
-  UWORD m = 0;
+  uint8_t y, last_y;
+  uint16_t l = 0;
+  uint16_t m = 0;
 
   while(1) {
     params = params_array[mode];

--- a/gbdk-lib/examples/gb/template_minimal/main.c
+++ b/gbdk-lib/examples/gb/template_minimal/main.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 
 
 void main(void)

--- a/gbdk-lib/examples/gb/template_subfolders/src/main.c
+++ b/gbdk-lib/examples/gb/template_subfolders/src/main.c
@@ -1,4 +1,5 @@
 #include <gb/gb.h>
+#include <stdint.h>
 #include "../res/dungeon_map.h"
 #include "../res/dungeon_tiles.h"
 


### PR DESCRIPTION
Many users will follow the pattern set by the examples. It's been suggested (and I agree) that it's better to use standard types instead of custom ones.

(UBYTE|UINT8)  -> uint8_t 
(BYTE|INT8) -> int8_t 

(UWORD|UINT16) -> uint16_t 
(WORD|INT16) -> int16_t 

Samples all build and run.

Includes a couple updates for docs.

OK with this change?
