### PR TITLE
Lib: convert to using stdint.h types instead of UINT8 / UBYTE / WORD etc Re: #162

### DIFF
--- a/gbdk-lib/include/bcd.h
+++ b/gbdk-lib/include/bcd.h
@@ -1,6 +1,7 @@
 #ifndef __BCD_H_INCLUDE
 #define __BCD_H_INCLUDE
 
+#include <stdint.h>
 #include <asm/types.h>
 
 /** @file bcd.h
@@ -55,6 +56,6 @@ void bcd_sub(BCD * sour, const BCD * value);
     \li It can also be set to the ascii value for character '0'
     so that the buffer is a normal string that can be passed to @ref printf.
 */
-UBYTE bcd2text(const BCD * bcd, UBYTE tile_offset, unsigned char * buffer);
+uint8_t bcd2text(const BCD * bcd, uint8_t tile_offset, unsigned char * buffer);
 
 #endif

--- a/gbdk-lib/include/bcd.h
+++ b/gbdk-lib/include/bcd.h
@@ -19,13 +19,13 @@
 */
 #define MAKE_BCD(v) BCD_HEX(0x ## v)
 
-typedef unsigned long BCD;
+typedef uint32_t BCD;
 
 /** Converts integer __i__ into BCD format (Binary Coded Decimal)
     @param i      Numeric value to convert
     @param value  Pointer to a BCD variable to store the converted result
 */
-void uint2bcd(unsigned int i, BCD * value);
+void uint2bcd(uint16_t i, BCD * value);
 
 /** Adds two numbers in BCD format: __sour__ += __value__
     @param sour   Pointer to a BCD value to add to (and where the result is stored)
@@ -56,6 +56,6 @@ void bcd_sub(BCD * sour, const BCD * value);
     \li It can also be set to the ascii value for character '0'
     so that the buffer is a normal string that can be passed to @ref printf.
 */
-uint8_t bcd2text(const BCD * bcd, uint8_t tile_offset, unsigned char * buffer);
+uint8_t bcd2text(const BCD * bcd, uint8_t tile_offset, uint8_t * buffer);
 
 #endif

--- a/gbdk-lib/include/gb/cgb.h
+++ b/gbdk-lib/include/gb/cgb.h
@@ -18,6 +18,7 @@
 #define _CGB_H
 
 #include <types.h>
+#include <stdint.h>
 
 /** Macro to create a CGB palette color entry out of the color components.
 
@@ -30,7 +31,7 @@
     @see set_bkg_palette(), set_sprite_palette()
  */
 #define RGB(r, g, b) \
-  ((((UINT16)(b) & 0x1f) << 10) | (((UINT16)(g) & 0x1f) << 5) | (((UINT16)(r) & 0x1f) << 0))
+  ((((uint16_t)(b) & 0x1f) << 10) | (((uint16_t)(g) & 0x1f) << 5) | (((uint16_t)(r) & 0x1f) << 0))
 
 /** Common colors based on the EGA default palette.
  */
@@ -72,9 +73,9 @@
     @see RGB(), set_bkg_palette_entry()
  */
 void
-set_bkg_palette(UINT8 first_palette,
-                UINT8 nb_palettes,
-                UINT16 *rgb_data) NONBANKED;
+set_bkg_palette(uint8_t first_palette,
+                uint8_t nb_palettes,
+                uint16_t *rgb_data) NONBANKED;
 
 /** Set CGB sprite palette(s).
 
@@ -92,9 +93,9 @@ set_bkg_palette(UINT8 first_palette,
     @see RGB(), set_sprite_palette_entry()
  */
 void
-set_sprite_palette(UINT8 first_palette,
-                   UINT8 nb_palettes,
-                   UINT16 *rgb_data) NONBANKED;
+set_sprite_palette(uint8_t first_palette,
+                   uint8_t nb_palettes,
+                   uint16_t *rgb_data) NONBANKED;
 
 /** Sets a single color in the specified CGB background palette.
 
@@ -106,9 +107,9 @@ set_sprite_palette(UINT8 first_palette,
  */
 
 void
-set_bkg_palette_entry(UINT8 palette,
-                      UINT8 entry,
-                      UINT16 rgb_data);
+set_bkg_palette_entry(uint8_t palette,
+                      uint8_t entry,
+                      uint16_t rgb_data);
 
 /** Sets a single color in the specified CGB sprite palette.
 
@@ -119,9 +120,9 @@ set_bkg_palette_entry(UINT8 palette,
     @see set_sprite_palette(), RGB()
  */
 void
-set_sprite_palette_entry(UINT8 palette,
-                         UINT8 entry,
-                         UINT16 rgb_data);
+set_sprite_palette_entry(uint8_t palette,
+                         uint8_t entry,
+                         uint16_t rgb_data);
 
 /** Set CPU speed to slow (Normal Speed) operation.
 

--- a/gbdk-lib/include/gb/console.h
+++ b/gbdk-lib/include/gb/console.h
@@ -7,25 +7,26 @@
 #define _CONSOLE_H
 
 #include <types.h>
+#include <stdint.h>
 
 /** Move the cursor to an absolute position at __x, y__.
 
     __x__ and __y__ have units of tiles (8 pixels per unit)
     @see setchar()
  */
-void gotoxy(UINT8 x, UINT8 y);
+void gotoxy(uint8_t x, uint8_t y);
 
 /** Returns the current X position of the cursor.
 
     @see gotoxy()
  */
-UINT8 posx(void);
+uint8_t posx(void);
 
 /** Returns the current Y position of the cursor.
 
     @see gotoxy()
  */
-UINT8 posy(void);
+uint8_t posy(void);
 
 /** Writes out a single character at the current cursor
     position.

--- a/gbdk-lib/include/gb/drawing.h
+++ b/gbdk-lib/include/gb/drawing.h
@@ -120,11 +120,11 @@ void
     is saved in dst. Both src and dst may be NULL - saving or copying to screen is
     not performed in this case. */
 void
-	switch_data(uint8_t x, uint8_t y, unsigned char *src, unsigned char *dst) NONBANKED;
+	switch_data(uint8_t x, uint8_t y, uint8_t *src, uint8_t *dst) NONBANKED;
 
 /** Draw a full screen image at __data__ */
 void
-	draw_image(unsigned char *data) NONBANKED;
+	draw_image(uint8_t *data) NONBANKED;
 
 /** Draw a line in the current drawing mode and colour from __x1,y1__ to __x2,y2__ */
 void

--- a/gbdk-lib/include/gb/drawing.h
+++ b/gbdk-lib/include/gb/drawing.h
@@ -29,6 +29,8 @@
 #ifndef __DRAWING_H
 #define __DRAWING_H
 
+#include <stdint.h>
+
 /** Size of the screen in pixels */
 #define GRAPHICS_WIDTH	160
 #define GRAPHICS_HEIGHT 144
@@ -78,14 +80,14 @@ void
     @see gotogxy()
 */
 void
-	gprintln(INT16 number, INT8 radix, INT8 signed_value);
+	gprintln(int16_t number, int8_t radix, int8_t signed_value);
 
 /** Print 8 bit __number__ in  __radix__ (base) in the default font at the current text position.
 
     @see gprintln(), gotogxy()
 */
 void
-	gprintn(INT8 number, INT8 radix, INT8 signed_value);
+	gprintn(int8_t number, int8_t radix, int8_t signed_value);
 
 /** Print the string and arguments given by __fmt__ with arguments __...__
 
@@ -95,30 +97,30 @@ void
     Currently supported:
     \li \%c (character)
     \li \%u (int)
-    \li \%d (INT8)
-    \li \%o (INT8 as octal)
-    \li \%x (INT8 as hex)
+    \li \%d (int8_t)
+    \li \%o (int8_t as octal)
+    \li \%x (int8_t as hex)
     \li \%s (string)
 
     @return Returns the number of items printed, or -1 if there was an error.
     @see gotogxy()
 */
-INT8
+int8_t
 	gprintf(char *fmt,...) NONBANKED;
 
 /** Old style plot - try @ref plot_point() */
 void
-	plot(UINT8 x, UINT8 y, UINT8 colour, UINT8 mode);
+	plot(uint8_t x, uint8_t y, uint8_t colour, uint8_t mode);
 
 /** Plot a point in the current drawing mode and colour at __x,y__ */
 void
-	plot_point(UINT8 x, UINT8 y);
+	plot_point(uint8_t x, uint8_t y);
 
 /** Exchanges the tile on screen at x,y with the tile pointed by src, original tile
     is saved in dst. Both src and dst may be NULL - saving or copying to screen is
     not performed in this case. */
 void
-	switch_data(UINT8 x, UINT8 y, unsigned char *src, unsigned char *dst) NONBANKED;
+	switch_data(uint8_t x, uint8_t y, unsigned char *src, unsigned char *dst) NONBANKED;
 
 /** Draw a full screen image at __data__ */
 void
@@ -126,21 +128,21 @@ void
 
 /** Draw a line in the current drawing mode and colour from __x1,y1__ to __x2,y2__ */
 void
-	line(UINT8 x1, UINT8 y1, UINT8 x2, UINT8 y2);
+	line(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2);
 
 /** Draw a box (rectangle) with corners __x1,y1__ and __x2,y2__ using fill mode
    __style__ (one of NOFILL or FILL) */
 void
-	box(UINT8 x1, UINT8 y1, UINT8 x2, UINT8 y2, UINT8 style);
+	box(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2, uint8_t style);
 
 /** Draw a circle with centre at __x,y__ and __radius__ using fill mode
    __style__  (one of NOFILL or FILL)*/
 void
-	circle(UINT8 x, UINT8 y, UINT8 radius, UINT8 style);
+	circle(uint8_t x, uint8_t y, uint8_t radius, uint8_t style);
 
 /** Returns the current colour of the pixel at __x,y__ */
-UINT8
-	getpix(UINT8 x, UINT8 y);
+uint8_t
+	getpix(uint8_t x, uint8_t y);
 
 /** Prints the character __chr__ in the default font at the current text position.
 
@@ -154,10 +156,10 @@ void
     Note: __x__ and __y__ have units of tiles (8 pixels per unit)
     @see wrtchr() */
 void
-	gotogxy(UINT8 x, UINT8 y);
+	gotogxy(uint8_t x, uint8_t y);
 
 /** Set the current __foreground__ colour (for pixels), __background__ colour, and
    draw __mode__ */
-void	color(UINT8 forecolor, UINT8 backcolor, UINT8 mode);
+void	color(uint8_t forecolor, uint8_t backcolor, uint8_t mode);
 
 #endif /* __DRAWING_H */

--- a/gbdk-lib/include/gb/far_ptr.h
+++ b/gbdk-lib/include/gb/far_ptr.h
@@ -24,7 +24,7 @@
 /** Macro to get the Segment (Bank) number of a far pointer
     @param ptr    A far pointer (type @ref  FAR_PTR)
 
-    @returns Segment (Bank) of the far pointer (type unsigned int)
+    @returns Segment (Bank) of the far pointer (type uint16_t)
 */
 #define FAR_SEG(ptr) (((union __far_ptr *)&ptr)->segofs.seg)
 
@@ -46,12 +46,12 @@
     \code{.c}
     // A function in bank 2
     #pragma bank 2
-    int some_function(int param1, int param2) __banked {  return 1; };
+    uint16_t some_function(uint16_t param1, uint16_t param2) __banked {  return 1; };
 
     ...
     // Code elsewhere, such as unbanked main()
     // This type declaration should match the above function
-    typedef int (*some_function_t)(int, int) __banked;
+    typedef uint16_t (*some_function_t)(uint16_t, uint16_t) __banked;
 
     // Using FAR_CALL() with the above as *ptr*, *typ*, and two parameters.
     result = FAR_CALL(some_function, some_function_t, 100, 50);
@@ -63,7 +63,7 @@
 
 /** Type for storing a FAR_PTR
 */
-typedef unsigned long FAR_PTR;
+typedef uint32_t FAR_PTR;
 
 /** Union for working with members of a FAR_PTR
 */
@@ -71,17 +71,17 @@ union __far_ptr {
     FAR_PTR ptr;
     struct {
         void * ofs;
-        unsigned int seg;
+        uint16_t seg;
     } segofs;
     struct {
         void (*fn)();
-        unsigned int seg;
+        uint16_t seg;
     } segfn;
 };
 
 extern volatile FAR_PTR __call_banked_ptr;
 extern volatile void * __call_banked_addr;
-extern volatile unsigned char __call_banked_bank;
+extern volatile uint8_t __call_banked_bank;
 
 void __call__banked();
 
@@ -91,6 +91,6 @@ void __call__banked();
 
     @returns A far pointer (type @ref FAR_PTR)
 */
-long to_far_ptr(void* ofs, int seg);
+int32_t to_far_ptr(void* ofs, int16_t seg);
 
 #endif

--- a/gbdk-lib/include/gb/font.h
+++ b/gbdk-lib/include/gb/font.h
@@ -7,6 +7,7 @@
 #define __FONT_H
 
 #include <gb/gb.h>
+#include <stdint.h>
 
 /** Various flags in the font header.
  */
@@ -20,7 +21,7 @@
 
 /** font_t is a handle to a font loaded by font_load().
     It can be used with @ref font_set() */
-typedef UINT16 font_t;
+typedef uint16_t font_t;
 
 
 /*! \defgroup gbdk_fonts List of gbdk fonts
@@ -28,10 +29,10 @@ typedef UINT16 font_t;
 */
 
 /** The default fonts */
-extern UINT8 font_spect[], font_italic[], font_ibm[], font_min[];
+extern uint8_t font_spect[], font_italic[], font_ibm[], font_min[];
 
 /** Backwards compatible font */
-extern UINT8 font_ibm_fixed[];
+extern uint8_t font_ibm_fixed[];
 
  /*! @} End of gbdk_fonts */
 
@@ -67,7 +68,7 @@ typedef struct sfont_handle *pmfont_handle;
 /** Font handle structure
 */
 struct sfont_handle {
-    UINT8 first_tile;		/**< First tile used for font */
+    uint8_t first_tile;		/**< First tile used for font */
     void *font;			/**< Pointer to the base of the font */
 };
 

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -355,29 +355,29 @@ __REG _current_bank;
     @param b   ROM bank to switch to
 */
 #define SWITCH_ROM_MBC1(b) \
-  _current_bank = (b), *(unsigned char *)0x2000 = (b)
+  _current_bank = (b), *(uint8_t *)0x2000 = (b)
 
 /** Switches SRAM bank on MBC1 and other compaticle MBCs
     @param b   SRAM bank to switch to
 */
 #define SWITCH_RAM_MBC1(b) \
-  *(unsigned char *)0x4000 = (b)
+  *(uint8_t *)0x4000 = (b)
 
 /** Enables SRAM on MBC1
 */
 #define ENABLE_RAM_MBC1 \
-  *(unsigned char *)0x0000 = 0x0A
+  *(uint8_t *)0x0000 = 0x0A
 
 /** Disables SRAM on MBC1
 */
 #define DISABLE_RAM_MBC1 \
-  *(unsigned char *)0x0000 = 0x00
+  *(uint8_t *)0x0000 = 0x00
 
 #define SWITCH_16_8_MODE_MBC1 \
-  *(unsigned char *)0x6000 = 0x00
+  *(uint8_t *)0x6000 = 0x00
 
 #define SWITCH_4_32_MODE_MBC1 \
-  *(unsigned char *)0x6000 = 0x01
+  *(uint8_t *)0x6000 = 0x01
 
 /** Makes MBC5 switch to the active ROM bank; only 4M roms are supported, @see SWITCH_ROM_MBC5_8M()
     @param b   ROM bank to switch to
@@ -386,8 +386,8 @@ __REG _current_bank;
 */
 #define SWITCH_ROM_MBC5(b) \
   _current_bank = (b), \
-  *(unsigned char *)0x3000 = 0, \
-  *(unsigned char *)0x2000 = (b)
+  *(uint8_t *)0x3000 = 0, \
+  *(uint8_t *)0x2000 = (b)
 
 /** Makes MBC5 to switch the active ROM bank; active bank number is not tracked by _current_bank if you use this macro
     @see _current_bank
@@ -396,24 +396,24 @@ __REG _current_bank;
     Note the order used here. Writing the other way around on a MBC1 always selects bank 1
 */
 #define SWITCH_ROM_MBC5_8M(b) \
-  *(unsigned char *)0x3000 = ((uint16_t)(b) >> 8), \
-  *(unsigned char *)0x2000 = (b)
+  *(uint8_t *)0x3000 = ((uint16_t)(b) >> 8), \
+  *(uint8_t *)0x2000 = (b)
 
 /** Switches SRAM bank on MBC5
     @param b   SRAM bank to switch to
 */
 #define SWITCH_RAM_MBC5(b) \
-  *(unsigned char *)0x4000 = (b)
+  *(uint8_t *)0x4000 = (b)
 
 /** Enables SRAM on MBC5
 */
 #define ENABLE_RAM_MBC5 \
-  *(unsigned char *)0x0000 = 0x0A
+  *(uint8_t *)0x0000 = 0x0A
 
 /** Disables SRAM on MBC5
 */
 #define DISABLE_RAM_MBC5 \
-  *(unsigned char *)0x0000 = 0x00
+  *(uint8_t *)0x0000 = 0x00
 
 
 
@@ -655,7 +655,7 @@ uint8_t * get_bkg_xy_addr(uint8_t x, uint8_t y) __preserves_regs(b, c);
 */
 void set_bkg_data(uint8_t first_tile,
          uint8_t nb_tiles,
-         const unsigned char *data) NONBANKED __preserves_regs(b, c);
+         const uint8_t *data) NONBANKED __preserves_regs(b, c);
 
 
 /** Sets VRAM Tile Pattern data for the Background / Window using 1bpp source data
@@ -676,7 +676,7 @@ void set_bkg_data(uint8_t first_tile,
 */
 void set_bkg_1bit_data(uint8_t first_tile,
          uint8_t nb_tiles,
-         const unsigned char *data,
+         const uint8_t *data,
          uint8_t color) NONBANKED __preserves_regs(b, c);
 
 
@@ -696,7 +696,7 @@ void set_bkg_1bit_data(uint8_t first_tile,
 */
 void get_bkg_data(uint8_t first_tile,
          uint8_t nb_tiles,
-         unsigned char *data) NONBANKED __preserves_regs(b, c);
+         uint8_t *data) NONBANKED __preserves_regs(b, c);
 
 
 /** Sets a rectangular region of Background Tile Map.
@@ -755,7 +755,7 @@ void set_bkg_tiles(uint8_t x,
           uint8_t y,
           uint8_t w,
           uint8_t h,
-          const unsigned char *tiles) NONBANKED __preserves_regs(b, c);
+          const uint8_t *tiles) NONBANKED __preserves_regs(b, c);
 
 
 /** Sets a rectangular area of the Background Tile Map using a sub-region 
@@ -786,7 +786,7 @@ void set_bkg_tiles(uint8_t x,
     @see SHOW_BKG
     @see set_bkg_data, set_bkg_tiles, set_win_submap
 */
-void set_bkg_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const unsigned char *map, uint8_t map_w);
+void set_bkg_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *map, uint8_t map_w);
 
 
 /** Copies a rectangular region of Background Tile Map entries into a buffer.
@@ -809,7 +809,7 @@ void get_bkg_tiles(uint8_t x,
           uint8_t y,
           uint8_t w,
           uint8_t h,
-          unsigned char *tiles) NONBANKED __preserves_regs(b, c);
+          uint8_t *tiles) NONBANKED __preserves_regs(b, c);
 
 
 /**
@@ -884,7 +884,7 @@ uint8_t * get_win_xy_addr(uint8_t x, uint8_t y) __preserves_regs(b, c);
 */
 void set_win_data(uint8_t first_tile,
           uint8_t nb_tiles,
-          const unsigned char *data) NONBANKED __preserves_regs(b, c);
+          const uint8_t *data) NONBANKED __preserves_regs(b, c);
 
 
 /** Sets VRAM Tile Pattern data for the Window / Background using 1bpp source data
@@ -900,7 +900,7 @@ void set_win_data(uint8_t first_tile,
 */
 void set_win_1bit_data(uint8_t first_tile,
           uint8_t nb_tiles,
-          const unsigned char *data) NONBANKED __preserves_regs(b, c);
+          const uint8_t *data) NONBANKED __preserves_regs(b, c);
 
 
 /** Copies from Window / Background VRAM Tile Pattern data into a buffer
@@ -916,7 +916,7 @@ void set_win_1bit_data(uint8_t first_tile,
 */
 void get_win_data(uint8_t first_tile,
           uint8_t nb_tiles,
-          unsigned char *data) NONBANKED __preserves_regs(b, c);
+          uint8_t *data) NONBANKED __preserves_regs(b, c);
 
 
 /** Sets a rectangular region of the Window Tile Map.
@@ -954,7 +954,7 @@ void set_win_tiles(uint8_t x,
           uint8_t y,
           uint8_t w,
           uint8_t h,
-          const unsigned char *tiles) NONBANKED __preserves_regs(b, c);
+          const uint8_t *tiles) NONBANKED __preserves_regs(b, c);
 
 
 /** Sets a rectangular area of the Window Tile Map using a sub-region 
@@ -987,7 +987,7 @@ void set_win_tiles(uint8_t x,
 
     @see SHOW_WIN, HIDE_WIN, set_win_tiles, set_bkg_submap, set_bkg_tiles, set_bkg_data
 **/
-void set_win_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const unsigned char *map, uint8_t map_w);
+void set_win_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *map, uint8_t map_w);
 
 
 /** Copies a rectangular region of Window Tile Map entries into a buffer.
@@ -1009,7 +1009,7 @@ void get_win_tiles(uint8_t x,
           uint8_t y,
           uint8_t w,
           uint8_t h,
-          unsigned char *tiles) NONBANKED __preserves_regs(b, c);
+          uint8_t *tiles) NONBANKED __preserves_regs(b, c);
 
 
 /**
@@ -1079,7 +1079,7 @@ inline void scroll_win(int8_t x, int8_t y) {
 */
 void set_sprite_data(uint8_t first_tile,
           uint8_t nb_tiles,
-          const unsigned char *data) NONBANKED __preserves_regs(b, c);
+          const uint8_t *data) NONBANKED __preserves_regs(b, c);
 
 
 /** Sets VRAM Tile Pattern data for Sprites using 1bpp source data
@@ -1099,7 +1099,7 @@ void set_sprite_data(uint8_t first_tile,
 */
 void set_sprite_1bit_data(uint8_t first_tile,
           uint8_t nb_tiles,
-          const unsigned char *data) NONBANKED __preserves_regs(b, c);
+          const uint8_t *data) NONBANKED __preserves_regs(b, c);
 
 
 /** Copies from Sprite VRAM Tile Pattern data into a buffer
@@ -1116,7 +1116,7 @@ void set_sprite_1bit_data(uint8_t first_tile,
 */
 void get_sprite_data(uint8_t first_tile,
           uint8_t nb_tiles,
-          unsigned char *data) NONBANKED __preserves_regs(b, c);
+          uint8_t *data) NONBANKED __preserves_regs(b, c);
 
 
 /** Sprite Attributes structure
@@ -1289,8 +1289,8 @@ inline void hide_sprite(uint8_t nb) {
     \li VBK_REG=0 indicates the first bank
     \li VBK_REG=1 indicates the second
 */
-void set_data(unsigned char *vram_addr,
-          const unsigned char *data,
+void set_data(uint8_t *vram_addr,
+          const uint8_t *data,
           uint16_t len) NONBANKED __preserves_regs(b, c);
 
 
@@ -1306,8 +1306,8 @@ void set_data(unsigned char *vram_addr,
     \li VBK_REG=0 indicates the first bank
     \li VBK_REG=1 indicates the second
 */
-void get_data(unsigned char *data,
-          unsigned char *vram_addr,
+void get_data(uint8_t *data,
+          uint8_t *vram_addr,
           uint16_t len) NONBANKED __preserves_regs(b, c);
 
 
@@ -1335,8 +1335,8 @@ void set_tiles(uint8_t x,
           uint8_t y,
           uint8_t w,
           uint8_t h,
-          unsigned char *vram_addr,
-          const unsigned char *tiles) NONBANKED __preserves_regs(b, c);
+          uint8_t *vram_addr,
+          const uint8_t *tiles) NONBANKED __preserves_regs(b, c);
 
 /** Sets VRAM Tile Pattern data starting from given base address
 
@@ -1347,7 +1347,7 @@ void set_tiles(uint8_t x,
 */
 void set_tile_data(uint8_t first_tile,
           uint8_t nb_tiles,
-          const unsigned char *data,
+          const uint8_t *data,
 		  uint8_t base) NONBANKED __preserves_regs(b, c);
 
 /** Copies a rectangular region of Tile Map entries from a given VRAM Address into a buffer.
@@ -1372,8 +1372,8 @@ void get_tiles(uint8_t x,
           uint8_t y,
           uint8_t w,
           uint8_t h,
-		  unsigned char *vram_addr,
-          unsigned char *tiles) NONBANKED __preserves_regs(b, c);
+		  uint8_t *vram_addr,
+          uint8_t *tiles) NONBANKED __preserves_regs(b, c);
 
 
 

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -7,6 +7,7 @@
 #define __GBDK_VERSION 402
 
 #include <types.h>
+#include <stdint.h>
 #include <gb/hardware.h>
 #include <gb/sgb.h>
 #include <gb/cgb.h>
@@ -16,7 +17,7 @@
     functions.  For example, to see if the B button is pressed
     try
 
-    UINT8 keys;
+    uint8_t keys;
     keys = joypad();
     if (keys & J_B) {
     	...
@@ -269,19 +270,19 @@ void wait_int_handler(void) NONBANKED;
 
     @see M_DRAWING, M_TEXT_OUT, M_TEXT_INOUT, M_NO_SCROLL, M_NO_INTERP
 */
-void mode(UINT8 m) NONBANKED;
+void mode(uint8_t m) NONBANKED;
 
 /** Returns the current mode
 
     @see M_DRAWING, M_TEXT_OUT, M_TEXT_INOUT, M_NO_SCROLL, M_NO_INTERP
 */
-UINT8 get_mode(void) NONBANKED __preserves_regs(b, c);
+uint8_t get_mode(void) NONBANKED __preserves_regs(b, c);
 
 /** GB CPU type
 
     @see DMG_TYPE, MGB_TYPE, CGB_TYPE, cpu_fast(), cpu_slow()
 */
-extern UINT8 _cpu;
+extern uint8_t _cpu;
 
 /** Hardware Model: Original GB or Super GB. @see _cpu
 */
@@ -299,7 +300,7 @@ extern UINT8 _cpu;
 
     Will wrap around every ~18 minutes (unsigned 16 bits = 65535 / 60 / 60 = 18.2)
 */
-extern volatile UINT16 sys_time;
+extern volatile uint16_t sys_time;
 
 
 
@@ -322,15 +323,15 @@ void send_byte(void);
 void receive_byte(void);
 
 /** Serial Link: Current IO Status. An OR of IO_* */
-extern volatile UINT8 _io_status;
+extern volatile uint8_t _io_status;
 
 /** Serial Link: Byte just read after calling @ref receive_byte()
 */
-extern volatile UINT8 _io_in;
+extern volatile uint8_t _io_in;
 
 /** Serial Link: Write byte to send here before calling @ref send_byte()
 */
-extern volatile UINT8 _io_out;
+extern volatile uint8_t _io_out;
 
 /* Status codes */
 /** Serial Link IO is completed */
@@ -395,7 +396,7 @@ __REG _current_bank;
     Note the order used here. Writing the other way around on a MBC1 always selects bank 1
 */
 #define SWITCH_ROM_MBC5_8M(b) \
-  *(unsigned char *)0x3000 = ((UINT16)(b) >> 8), \
+  *(unsigned char *)0x3000 = ((uint16_t)(b) >> 8), \
   *(unsigned char *)0x2000 = (b)
 
 /** Switches SRAM bank on MBC5
@@ -420,7 +421,7 @@ __REG _current_bank;
     Uses no timers or interrupts, and can be called with
     interrupts disabled (why nobody knows :)
  */
-void delay(UINT16 d) NONBANKED;
+void delay(uint16_t d) NONBANKED;
 
 
 
@@ -434,7 +435,7 @@ void delay(UINT16 d) NONBANKED;
 
     @see J_START, J_SELECT, J_A, J_B, J_UP, J_DOWN, J_LEFT, J_RIGHT
 */
-UINT8 joypad(void) NONBANKED __preserves_regs(b, c, h, l);
+uint8_t joypad(void) NONBANKED __preserves_regs(b, c, h, l);
 
 /** Waits until at least one of the buttons given in mask are pressed.
 
@@ -448,7 +449,7 @@ UINT8 joypad(void) NONBANKED __preserves_regs(b, c, h, l);
     @see joypad
     @see J_START, J_SELECT, J_A, J_B, J_UP, J_DOWN, J_LEFT, J_RIGHT
 */
-UINT8 waitpad(UINT8 mask) NONBANKED __preserves_regs(b, c);
+uint8_t waitpad(uint8_t mask) NONBANKED __preserves_regs(b, c);
 
 /** Waits for the directional pad and all buttons to be released.
 
@@ -463,12 +464,12 @@ void waitpadup(void) NONBANKED __preserves_regs(a, b, c, d, e, h, l);
     may be used to poll all avaliable joypads with @ref joypad_ex()
 */
 typedef struct {
-    UINT8 npads;
+    uint8_t npads;
     union {
         struct {
-            UINT8 joy0, joy1, joy2, joy3;
+            uint8_t joy0, joy1, joy2, joy3;
         };
-        UINT8 joypads[4];
+        uint8_t joypads[4];
     };
 } joypads_t;
 
@@ -481,7 +482,7 @@ typedef struct {
     @returns number of joypads avaliable
     @see joypad_ex(), joypads_t
 */
-UINT8 joypad_init(UINT8 npads, joypads_t * joypads);
+uint8_t joypad_init(uint8_t npads, joypads_t * joypads);
 
 /** Polls all avaliable joypads (for the GB and ones connected via SGB)
     @param joypads	pointer to joypads_t structure to be filled with joypad statuses,
@@ -513,7 +514,7 @@ void disable_interrupts(void) NONBANKED __preserves_regs(a, b, c, d, e, h, l);
     @see enable_interrupts(), disable_interrupts()
     @see VBL_IFLAG, LCD_IFLAG, TIM_IFLAG, SIO_IFLAG, JOY_IFLAG
 */
-void set_interrupts(UINT8 flags) NONBANKED __preserves_regs(b, c, d, e);
+void set_interrupts(uint8_t flags) NONBANKED __preserves_regs(b, c, d, e);
 
 /** Performs a warm reset by reloading the CPU value
     then jumping to the start of crt0 (0x0150)
@@ -546,9 +547,9 @@ void display_off(void) NONBANKED __preserves_regs(b, c, d, e, h, l);
     @param src		Area to copy from
     @param n		Number of bytes to copy.
 */
-void hiramcpy(UINT8 dst,
+void hiramcpy(uint8_t dst,
           const void *src,
-          UINT8 n) NONBANKED __preserves_regs(b, c);
+          uint8_t n) NONBANKED __preserves_regs(b, c);
 
 
 
@@ -620,7 +621,7 @@ void hiramcpy(UINT8 dst,
  * @param addr address to write to
  * @param v value
  */
-void set_vram_byte(UBYTE * addr, UINT8 v) __preserves_regs(b, c);
+void set_vram_byte(uint8_t * addr, uint8_t v) __preserves_regs(b, c);
 
 /**
  * Get byte from vram at given memory location
@@ -628,13 +629,13 @@ void set_vram_byte(UBYTE * addr, UINT8 v) __preserves_regs(b, c);
  * @param addr address to read from
  * @return read value
  */
-UINT8 get_vram_byte(UBYTE * addr) __preserves_regs(b, c);
+uint8_t get_vram_byte(uint8_t * addr) __preserves_regs(b, c);
 
 
 /**
  * Get address of X,Y tile of background map
  */
-UINT8 * get_bkg_xy_addr(UINT8 x, UINT8 y) __preserves_regs(b, c);
+uint8_t * get_bkg_xy_addr(uint8_t x, uint8_t y) __preserves_regs(b, c);
 
 
 /** Sets VRAM Tile Pattern data for the Background / Window
@@ -652,8 +653,8 @@ UINT8 * get_bkg_xy_addr(UINT8 x, UINT8 y) __preserves_regs(b, c);
     \li VBK_REG=0 indicates the first bank
     \li VBK_REG=1 indicates the second
 */
-void set_bkg_data(UINT8 first_tile,
-         UINT8 nb_tiles,
+void set_bkg_data(uint8_t first_tile,
+         uint8_t nb_tiles,
          const unsigned char *data) NONBANKED __preserves_regs(b, c);
 
 
@@ -673,10 +674,10 @@ void set_bkg_data(UINT8 first_tile,
 
     @see SHOW_BKG, HIDE_BKG, set_bkg_tiles
 */
-void set_bkg_1bit_data(UINT8 first_tile,
-         UINT8 nb_tiles,
+void set_bkg_1bit_data(uint8_t first_tile,
+         uint8_t nb_tiles,
          const unsigned char *data,
-         UINT8 color) NONBANKED __preserves_regs(b, c);
+         uint8_t color) NONBANKED __preserves_regs(b, c);
 
 
 /** Copies from Background / Window VRAM Tile Pattern data into a buffer
@@ -693,8 +694,8 @@ void set_bkg_1bit_data(UINT8 first_tile,
 
     @see get_win_data
 */
-void get_bkg_data(UINT8 first_tile,
-         UINT8 nb_tiles,
+void get_bkg_data(uint8_t first_tile,
+         uint8_t nb_tiles,
          unsigned char *data) NONBANKED __preserves_regs(b, c);
 
 
@@ -750,10 +751,10 @@ void get_bkg_data(UINT8 first_tile,
     @see SHOW_BKG
     @see set_bkg_data, set_bkg_submap
 */
-void set_bkg_tiles(UINT8 x,
-          UINT8 y,
-          UINT8 w,
-          UINT8 h,
+void set_bkg_tiles(uint8_t x,
+          uint8_t y,
+          uint8_t w,
+          uint8_t h,
           const unsigned char *tiles) NONBANKED __preserves_regs(b, c);
 
 
@@ -785,7 +786,7 @@ void set_bkg_tiles(UINT8 x,
     @see SHOW_BKG
     @see set_bkg_data, set_bkg_tiles, set_win_submap
 */
-void set_bkg_submap(UINT8 x, UINT8 y, UINT8 w, UINT8 h, const unsigned char *map, UINT8 map_w);
+void set_bkg_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const unsigned char *map, uint8_t map_w);
 
 
 /** Copies a rectangular region of Background Tile Map entries into a buffer.
@@ -804,10 +805,10 @@ void set_bkg_submap(UINT8 x, UINT8 y, UINT8 w, UINT8 h, const unsigned char *map
 
     The buffer pointed to by __tiles__ should be at least __x__ x __y__ bytes in size.
 */
-void get_bkg_tiles(UINT8 x,
-          UINT8 y,
-          UINT8 w,
-          UINT8 h,
+void get_bkg_tiles(uint8_t x,
+          uint8_t y,
+          uint8_t w,
+          uint8_t h,
           unsigned char *tiles) NONBANKED __preserves_regs(b, c);
 
 
@@ -818,7 +819,7 @@ void get_bkg_tiles(UINT8 x,
  * @param t tile index
  * @return returns the address of tile, so you may use faster set_vram_byte() later
  */ 
-UINT8 * set_bkg_tile_xy(UBYTE x, UBYTE y, UBYTE t) __preserves_regs(b, c);
+uint8_t * set_bkg_tile_xy(uint8_t x, uint8_t y, uint8_t t) __preserves_regs(b, c);
 
 
 /**
@@ -827,7 +828,7 @@ UINT8 * set_bkg_tile_xy(UBYTE x, UBYTE y, UBYTE t) __preserves_regs(b, c);
  * @param y Y-coordinate
  * @return returns tile index
  */ 
-UINT8 get_bkg_tile_xy(UBYTE x, UBYTE y) __preserves_regs(b, c);
+uint8_t get_bkg_tile_xy(uint8_t x, uint8_t y) __preserves_regs(b, c);
 
 
 /** Moves the Background Layer to the position specified in __x__ and __y__ in pixels.
@@ -843,7 +844,7 @@ UINT8 get_bkg_tile_xy(UBYTE x, UBYTE y) __preserves_regs(b, c);
 
     @see SHOW_BKG, HIDE_BKG
 */
-inline void move_bkg(UINT8 x, UINT8 y) {
+inline void move_bkg(uint8_t x, uint8_t y) {
     SCX_REG=x, SCY_REG=y;
 }
 
@@ -857,7 +858,7 @@ inline void move_bkg(UINT8 x, UINT8 y) {
 
     @see move_bkg
 */
-inline void scroll_bkg(INT8 x, INT8 y) {
+inline void scroll_bkg(int8_t x, int8_t y) {
     SCX_REG+=x, SCY_REG+=y;
 }
 
@@ -866,7 +867,7 @@ inline void scroll_bkg(INT8 x, INT8 y) {
 /**
  * Get address of X,Y tile of window map
  */
-UINT8 * get_win_xy_addr(UINT8 x, UINT8 y) __preserves_regs(b, c);
+uint8_t * get_win_xy_addr(uint8_t x, uint8_t y) __preserves_regs(b, c);
 
 /** Sets VRAM Tile Pattern data for the Window / Background
 
@@ -881,8 +882,8 @@ UINT8 * get_win_xy_addr(UINT8 x, UINT8 y) __preserves_regs(b, c);
     @see set_win_tiles
     @see SHOW_WIN, HIDE_WIN
 */
-void set_win_data(UINT8 first_tile,
-          UINT8 nb_tiles,
+void set_win_data(uint8_t first_tile,
+          uint8_t nb_tiles,
           const unsigned char *data) NONBANKED __preserves_regs(b, c);
 
 
@@ -897,8 +898,8 @@ void set_win_data(UINT8 first_tile,
 
     @see set_bkg_data, set_bkg_1bit_data, set_win_data
 */
-void set_win_1bit_data(UINT8 first_tile,
-          UINT8 nb_tiles,
+void set_win_1bit_data(uint8_t first_tile,
+          uint8_t nb_tiles,
           const unsigned char *data) NONBANKED __preserves_regs(b, c);
 
 
@@ -913,8 +914,8 @@ void set_win_1bit_data(UINT8 first_tile,
 
     @see get_bkg_data
 */
-void get_win_data(UINT8 first_tile,
-          UINT8 nb_tiles,
+void get_win_data(uint8_t first_tile,
+          uint8_t nb_tiles,
           unsigned char *data) NONBANKED __preserves_regs(b, c);
 
 
@@ -949,10 +950,10 @@ void get_win_data(UINT8 first_tile,
 
     @see SHOW_WIN, HIDE_WIN, set_win_submap, set_bkg_tiles, set_bkg_data
 */
-void set_win_tiles(UINT8 x,
-          UINT8 y,
-          UINT8 w,
-          UINT8 h,
+void set_win_tiles(uint8_t x,
+          uint8_t y,
+          uint8_t w,
+          uint8_t h,
           const unsigned char *tiles) NONBANKED __preserves_regs(b, c);
 
 
@@ -986,7 +987,7 @@ void set_win_tiles(UINT8 x,
 
     @see SHOW_WIN, HIDE_WIN, set_win_tiles, set_bkg_submap, set_bkg_tiles, set_bkg_data
 **/
-void set_win_submap(UINT8 x, UINT8 y, UINT8 w, UINT8 h, const unsigned char *map, UINT8 map_w);
+void set_win_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const unsigned char *map, uint8_t map_w);
 
 
 /** Copies a rectangular region of Window Tile Map entries into a buffer.
@@ -1004,10 +1005,10 @@ void set_win_submap(UINT8 x, UINT8 y, UINT8 w, UINT8 h, const unsigned char *map
 
     The buffer pointed to by __tiles__ should be at least __x__ x __y__ bytes in size.
 */
-void get_win_tiles(UINT8 x,
-          UINT8 y,
-          UINT8 w,
-          UINT8 h,
+void get_win_tiles(uint8_t x,
+          uint8_t y,
+          uint8_t w,
+          uint8_t h,
           unsigned char *tiles) NONBANKED __preserves_regs(b, c);
 
 
@@ -1018,7 +1019,7 @@ void get_win_tiles(UINT8 x,
  * @param t tile index
  * @return returns the address of tile, so you may use faster set_vram_byte() later
  */ 
-UINT8 * set_win_tile_xy(UBYTE x, UBYTE y, UBYTE t) __preserves_regs(b, c);
+uint8_t * set_win_tile_xy(uint8_t x, uint8_t y, uint8_t t) __preserves_regs(b, c);
 
 
 /**
@@ -1027,7 +1028,7 @@ UINT8 * set_win_tile_xy(UBYTE x, UBYTE y, UBYTE t) __preserves_regs(b, c);
  * @param y Y-coordinate
  * @return returns the tile index
  */ 
-UINT8 get_win_tile_xy(UBYTE x, UBYTE y) __preserves_regs(b, c);
+uint8_t get_win_tile_xy(uint8_t x, uint8_t y) __preserves_regs(b, c);
 
 
 /** Moves the Window to the __x__, __y__ position on the screen.
@@ -1041,7 +1042,7 @@ UINT8 get_win_tile_xy(UBYTE x, UBYTE y) __preserves_regs(b, c);
 
     @see SHOW_WIN, HIDE_WIN
 */
-inline void move_win(UINT8 x, UINT8 y) {
+inline void move_win(uint8_t x, uint8_t y) {
     WX_REG=x, WY_REG=y;
 }
 
@@ -1055,7 +1056,7 @@ inline void move_win(UINT8 x, UINT8 y) {
 
     @see move_win
 */
-inline void scroll_win(INT8 x, INT8 y) {
+inline void scroll_win(int8_t x, int8_t y) {
     WX_REG+=x, WY_REG+=y;
 }
 
@@ -1076,8 +1077,8 @@ inline void scroll_win(INT8 x, INT8 y) {
     \li VBK_REG=0 indicates the first bank
     \li VBK_REG=1 indicates the second
 */
-void set_sprite_data(UINT8 first_tile,
-          UINT8 nb_tiles,
+void set_sprite_data(uint8_t first_tile,
+          uint8_t nb_tiles,
           const unsigned char *data) NONBANKED __preserves_regs(b, c);
 
 
@@ -1096,8 +1097,8 @@ void set_sprite_data(UINT8 first_tile,
 
     @see SHOW_SPRITES, HIDE_SPRITES, set_sprite_tile
 */
-void set_sprite_1bit_data(UINT8 first_tile,
-          UINT8 nb_tiles,
+void set_sprite_1bit_data(uint8_t first_tile,
+          uint8_t nb_tiles,
           const unsigned char *data) NONBANKED __preserves_regs(b, c);
 
 
@@ -1113,8 +1114,8 @@ void set_sprite_1bit_data(UINT8 first_tile,
     Each Tile is 16 bytes, so the buffer pointed to by __data__
     should be at least __nb_tiles__ x 16 bytes in size.
 */
-void get_sprite_data(UINT8 first_tile,
-          UINT8 nb_tiles,
+void get_sprite_data(uint8_t first_tile,
+          uint8_t nb_tiles,
           unsigned char *data) NONBANKED __preserves_regs(b, c);
 
 
@@ -1125,9 +1126,9 @@ void get_sprite_data(UINT8 first_tile,
     @param prop  OAM Property Flags (see @ref set_sprite_prop)
 */
 typedef struct OAM_item_t {
-    UINT8 y, x;  //< X, Y Coordinates of the sprite on screen
-    UINT8 tile;  //< Sprite tile number
-    UINT8 prop;  //< OAM Property Flags
+    uint8_t y, x;  //< X, Y Coordinates of the sprite on screen
+    uint8_t tile;  //< Sprite tile number
+    uint8_t prop;  //< OAM Property Flags
 } OAM_item_t;
 
 
@@ -1147,12 +1148,12 @@ __REG _shadow_OAM_base;
 /** Enable OAM DMA copy each VBlank and set it to transfer default shadow_OAM array
 */
 #define ENABLE_OAM_DMA \
-    _shadow_OAM_base = (UBYTE)((UWORD)&shadow_OAM >> 8)
+    _shadow_OAM_base = (uint8_t)((uint16_t)&shadow_OAM >> 8)
 
 /** Enable OAM DMA copy each VBlank and set it to transfer any 256-byte aligned array
 */
 inline void SET_SHADOW_OAM_ADDRESS(void * address) {
-    _shadow_OAM_base = (UBYTE)((UWORD)address >> 8);
+    _shadow_OAM_base = (uint8_t)((uint16_t)address >> 8);
 }
 
 /** Sets sprite number __nb__in the OAM to display tile number __tile__.
@@ -1171,7 +1172,7 @@ inline void SET_SHADOW_OAM_ADDRESS(void * address) {
         the lower 8x8 tile is (__tile__ | 0x01).
     \li See: @ref SPRITES_8x16
 */
-inline void set_sprite_tile(UINT8 nb, UINT8 tile) {
+inline void set_sprite_tile(uint8_t nb, uint8_t tile) {
     shadow_OAM[nb].tile=tile;
 }
 
@@ -1182,7 +1183,7 @@ inline void set_sprite_tile(UINT8 nb, UINT8 tile) {
 
 @see set_sprite_tile for more details
 */
-inline UINT8 get_sprite_tile(UINT8 nb) {
+inline uint8_t get_sprite_tile(uint8_t nb) {
     return shadow_OAM[nb].tile;
 }
 
@@ -1217,7 +1218,7 @@ inline UINT8 get_sprite_tile(UINT8 nb) {
     \li Bit 0 - GBC only. Bits 0-2 indicate which of the 7 OBJ colour palettes the
               sprite is assigned.
 */
-inline void set_sprite_prop(UINT8 nb, UINT8 prop){
+inline void set_sprite_prop(uint8_t nb, uint8_t prop){
     shadow_OAM[nb].prop=prop;
 }
 
@@ -1227,7 +1228,7 @@ inline void set_sprite_prop(UINT8 nb, UINT8 prop){
     @param nb    Sprite number, range 0 - 39
     @see set_sprite_prop for property bitfield settings
 */
-inline UINT8 get_sprite_prop(UINT8 nb){
+inline uint8_t get_sprite_prop(uint8_t nb){
     return shadow_OAM[nb].prop;
 }
 
@@ -1244,7 +1245,7 @@ inline UINT8 get_sprite_prop(UINT8 nb){
 
     Moving the sprite to 0,0 (or similar off-screen location) will hide it.
 */
-inline void move_sprite(UINT8 nb, UINT8 x, UINT8 y) {
+inline void move_sprite(uint8_t nb, uint8_t x, uint8_t y) {
     OAM_item_t * itm = &shadow_OAM[nb];
     itm->y=y, itm->x=x;
 }
@@ -1260,7 +1261,7 @@ inline void move_sprite(UINT8 nb, UINT8 x, UINT8 y) {
 
     @see move_sprite for more details about the X and Y position
  */
-inline void scroll_sprite(UINT8 nb, INT8 x, INT8 y) {
+inline void scroll_sprite(uint8_t nb, int8_t x, int8_t y) {
     OAM_item_t * itm = &shadow_OAM[nb];
     itm->y+=y, itm->x+=x;
 }
@@ -1270,7 +1271,7 @@ inline void scroll_sprite(UINT8 nb, INT8 x, INT8 y) {
 
     @param nb  Sprite number, range 0 - 39
  */
-inline void hide_sprite(UINT8 nb) {
+inline void hide_sprite(uint8_t nb) {
     shadow_OAM[nb].y = 0;
 }
 
@@ -1290,7 +1291,7 @@ inline void hide_sprite(UINT8 nb) {
 */
 void set_data(unsigned char *vram_addr,
           const unsigned char *data,
-          UINT16 len) NONBANKED __preserves_regs(b, c);
+          uint16_t len) NONBANKED __preserves_regs(b, c);
 
 
 /** Copies Tile Pattern data from an address in VRAM into a buffer
@@ -1307,7 +1308,7 @@ void set_data(unsigned char *vram_addr,
 */
 void get_data(unsigned char *data,
           unsigned char *vram_addr,
-          UINT16 len) NONBANKED __preserves_regs(b, c);
+          uint16_t len) NONBANKED __preserves_regs(b, c);
 
 
 /** Sets a rectangular region of Tile Map entries at a given VRAM Address.
@@ -1330,10 +1331,10 @@ void get_data(unsigned char *data,
     \li VBK_REG=0 Tile Numbers are written
     \li VBK_REG=1 Tile Attributes are written
 */
-void set_tiles(UINT8 x,
-          UINT8 y,
-          UINT8 w,
-          UINT8 h,
+void set_tiles(uint8_t x,
+          uint8_t y,
+          uint8_t w,
+          uint8_t h,
           unsigned char *vram_addr,
           const unsigned char *tiles) NONBANKED __preserves_regs(b, c);
 
@@ -1344,10 +1345,10 @@ void set_tiles(UINT8 x,
     @param data        Pointer to (2 bpp) source Tile Pattern data.
 	@param base        MSB of the destination address in VRAM (usually 0x80 or 0x90 which gives 0x8000 or 0x9000)
 */
-void set_tile_data(UINT8 first_tile,
-          UINT8 nb_tiles,
+void set_tile_data(uint8_t first_tile,
+          uint8_t nb_tiles,
           const unsigned char *data,
-		  UINT8 base) NONBANKED __preserves_regs(b, c);
+		  uint8_t base) NONBANKED __preserves_regs(b, c);
 
 /** Copies a rectangular region of Tile Map entries from a given VRAM Address into a buffer.
 
@@ -1367,10 +1368,10 @@ void set_tile_data(UINT8 first_tile,
 
     The buffer pointed to by __tiles__ should be at least __x__ x __y__ bytes in size.
 */
-void get_tiles(UINT8 x,
-          UINT8 y,
-          UINT8 w,
-          UINT8 h,
+void get_tiles(uint8_t x,
+          uint8_t y,
+          uint8_t w,
+          uint8_t h,
 		  unsigned char *vram_addr,
           unsigned char *tiles) NONBANKED __preserves_regs(b, c);
 
@@ -1382,14 +1383,14 @@ void get_tiles(UINT8 x,
 
     Note: This function avoids writes during modes 2 & 3
 */
-void init_win(UINT8 c) NONBANKED __preserves_regs(b, c);
+void init_win(uint8_t c) NONBANKED __preserves_regs(b, c);
 
 /** Initializes the entire Background Tile Map with Tile Number __c__
     @param c   Tile number to fill with
 
     Note: This function avoids writes during modes 2 & 3
 */
-void init_bkg(UINT8 c) NONBANKED __preserves_regs(b, c);
+void init_bkg(uint8_t c) NONBANKED __preserves_regs(b, c);
 
 /** Fills the VRAM memory region __s__ of size __n__ with Tile Number __c__
     @param s   Start address in VRAM
@@ -1398,7 +1399,7 @@ void init_bkg(UINT8 c) NONBANKED __preserves_regs(b, c);
 
     Note: This function avoids writes during modes 2 & 3
 */
-void vmemset (void *s, UINT8 c, size_t n) NONBANKED __preserves_regs(b, c);
+void vmemset (void *s, uint8_t c, size_t n) NONBANKED __preserves_regs(b, c);
 
 
 
@@ -1410,7 +1411,7 @@ void vmemset (void *s, UINT8 c, size_t n) NONBANKED __preserves_regs(b, c);
     @param h      Height of area to set in tiles. Range 0 - 31
     @param tile   Fill value
 */
-void fill_bkg_rect(UINT8 x, UINT8 y, UINT8 w, UINT8 h, UINT8 tile) NONBANKED __preserves_regs(b, c);
+void fill_bkg_rect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t tile) NONBANKED __preserves_regs(b, c);
 
 /** Fills a rectangular region of Tile Map entries for the Window layer with tile.
 
@@ -1420,6 +1421,6 @@ void fill_bkg_rect(UINT8 x, UINT8 y, UINT8 w, UINT8 h, UINT8 tile) NONBANKED __p
     @param h      Height of area to set in tiles. Range 0 - 31
     @param tile   Fill value
 */
-void fill_win_rect(UINT8 x, UINT8 y, UINT8 w, UINT8 h, UINT8 tile) NONBANKED __preserves_regs(b, c);
+void fill_win_rect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t tile) NONBANKED __preserves_regs(b, c);
 
 #endif /* _GB_H */

--- a/gbdk-lib/include/gb/gbdecompress.h
+++ b/gbdk-lib/include/gb/gbdecompress.h
@@ -16,7 +16,7 @@
 
     @see gb_decompress_bkg_data, gb_decompress_win_data, gb_decompress_sprite_data
  */
-void gb_decompress(const unsigned char * sour, unsigned char * dest) __preserves_regs(b, c);
+void gb_decompress(const uint8_t * sour, uint8_t * dest) __preserves_regs(b, c);
 
 
 /** gb-decompress background tiles into VRAM
@@ -28,7 +28,7 @@ void gb_decompress(const unsigned char * sour, unsigned char * dest) __preserves
 
     @see gb_decompress_bkg, gb_decompress_win_data, gb_decompress_sprite_data
 */
-void gb_decompress_bkg_data(uint8_t first_tile, const unsigned char * sour) __preserves_regs(b, c);
+void gb_decompress_bkg_data(uint8_t first_tile, const uint8_t * sour) __preserves_regs(b, c);
 
 
 /** gb-decompress window tiles into VRAM
@@ -43,7 +43,7 @@ void gb_decompress_bkg_data(uint8_t first_tile, const unsigned char * sour) __pr
 
     @see gb_decompress, gb_decompress_bkg_data, gb_decompress_sprite_data
  */
-void gb_decompress_win_data(uint8_t first_tile, const unsigned char * sour) __preserves_regs(b, c);
+void gb_decompress_win_data(uint8_t first_tile, const uint8_t * sour) __preserves_regs(b, c);
 
 
 /** gb-decompress sprite tiles into VRAM
@@ -55,6 +55,6 @@ void gb_decompress_win_data(uint8_t first_tile, const unsigned char * sour) __pr
 
     @see gb_decompress, gb_decompress_bkg_data, gb_decompress_win_data
  */
-void gb_decompress_sprite_data(uint8_t first_tile, const unsigned char * sour) __preserves_regs(b, c);
+void gb_decompress_sprite_data(uint8_t first_tile, const uint8_t * sour) __preserves_regs(b, c);
 
 #endif

--- a/gbdk-lib/include/gb/gbdecompress.h
+++ b/gbdk-lib/include/gb/gbdecompress.h
@@ -7,6 +7,8 @@
 #ifndef __GBDECOMPRESS_H_INCLUDE
 #define __GBDECOMPRESS_H_INCLUDE
 
+#include <stdint.h>
+
 /** gb-decompress data from sour into dest
 
     @param sour   Pointer to source gb-compressed data
@@ -26,7 +28,7 @@ void gb_decompress(const unsigned char * sour, unsigned char * dest) __preserves
 
     @see gb_decompress_bkg, gb_decompress_win_data, gb_decompress_sprite_data
 */
-void gb_decompress_bkg_data(UINT8 first_tile, const unsigned char * sour) __preserves_regs(b, c);
+void gb_decompress_bkg_data(uint8_t first_tile, const unsigned char * sour) __preserves_regs(b, c);
 
 
 /** gb-decompress window tiles into VRAM
@@ -41,7 +43,7 @@ void gb_decompress_bkg_data(UINT8 first_tile, const unsigned char * sour) __pres
 
     @see gb_decompress, gb_decompress_bkg_data, gb_decompress_sprite_data
  */
-void gb_decompress_win_data(UINT8 first_tile, const unsigned char * sour) __preserves_regs(b, c);
+void gb_decompress_win_data(uint8_t first_tile, const unsigned char * sour) __preserves_regs(b, c);
 
 
 /** gb-decompress sprite tiles into VRAM
@@ -53,6 +55,6 @@ void gb_decompress_win_data(UINT8 first_tile, const unsigned char * sour) __pres
 
     @see gb_decompress, gb_decompress_bkg_data, gb_decompress_win_data
  */
-void gb_decompress_sprite_data(UINT8 first_tile, const unsigned char * sour) __preserves_regs(b, c);
+void gb_decompress_sprite_data(uint8_t first_tile, const unsigned char * sour) __preserves_regs(b, c);
 
 #endif

--- a/gbdk-lib/include/gb/malloc.h
+++ b/gbdk-lib/include/gb/malloc.h
@@ -8,6 +8,7 @@
 #define __SYS_MALLOC_H
 
 #include <types.h>
+#include <stdint.h>
 
 /* The various constants */
 /** The malloc hunk flags
@@ -25,14 +26,14 @@ typedef struct smalloc_hunk	mmalloc_hunk;
 typedef struct smalloc_hunk *	pmmalloc_hunk;
 
 struct smalloc_hunk {
-    UBYTE 		magic;		/* Magic number - indicates valid hunk header */
+    uint8_t 		magic;		/* Magic number - indicates valid hunk header */
     pmmalloc_hunk	next;		/* Pointer to the next hunk */
-    UWORD 		size;		/* Size in bytes of this region */
+    uint16_t 		size;		/* Size in bytes of this region */
     int 		status;		/* One of MALLOC_FREE or MALLOC_USED */
 };
 
 /** Start of free memory, as defined by the linker */
-extern UBYTE malloc_heap_start;
+extern uint8_t malloc_heap_start;
 
 /** First hunk */
 extern pmmalloc_hunk malloc_first;

--- a/gbdk-lib/include/gb/malloc.h
+++ b/gbdk-lib/include/gb/malloc.h
@@ -29,7 +29,7 @@ struct smalloc_hunk {
     uint8_t 		magic;		/* Magic number - indicates valid hunk header */
     pmmalloc_hunk	next;		/* Pointer to the next hunk */
     uint16_t 		size;		/* Size in bytes of this region */
-    int 		status;		/* One of MALLOC_FREE or MALLOC_USED */
+    int16_t 		status;		/* One of MALLOC_FREE or MALLOC_USED */
 };
 
 /** Start of free memory, as defined by the linker */

--- a/gbdk-lib/include/gb/malloc.h
+++ b/gbdk-lib/include/gb/malloc.h
@@ -8,7 +8,6 @@
 #define __SYS_MALLOC_H
 
 #include <types.h>
-#include <stdint.h>
 
 /* The various constants */
 /** The malloc hunk flags
@@ -26,10 +25,10 @@ typedef struct smalloc_hunk	mmalloc_hunk;
 typedef struct smalloc_hunk *	pmmalloc_hunk;
 
 struct smalloc_hunk {
-    uint8_t 		magic;		/* Magic number - indicates valid hunk header */
-    pmmalloc_hunk	next;		/* Pointer to the next hunk */
-    uint16_t 		size;		/* Size in bytes of this region */
-    int16_t 		status;		/* One of MALLOC_FREE or MALLOC_USED */
+	unsigned char	magic;		/* Magic number - indicates valid hunk header */
+	pmmalloc_hunk	next;		/* Pointer to the next hunk */
+	unsigned int	size;		/* Size in bytes of this region */
+	int				status;		/* One of MALLOC_FREE or MALLOC_USED */
 };
 
 /** Start of free memory, as defined by the linker */

--- a/gbdk-lib/include/gb/metasprites.h
+++ b/gbdk-lib/include/gb/metasprites.h
@@ -35,7 +35,7 @@
     // Hide rest of the hardware sprites, because amount
     // of sprites differ between animation frames.
     // (where hiwater == last hardware sprite used + 1)
-    for (UBYTE i = hiwater; i < 40; i++) shadow_OAM[i].y = 0;
+    for (uint8_t i = hiwater; i < 40; i++) shadow_OAM[i].y = 0;
     \endcode
 
     @anchor metasprite_and_sprite_properties
@@ -60,11 +60,13 @@
 #ifndef _METASPRITES_H_INCLUDE
 #define _METASPRITES_H_INCLUDE
 
+#include <stdint.h>
+
 /** Metasprite sub-item structure
-    @param dy        (INT8)  Y coordinate of the sprite relative to the metasprite origin (pivot)
-    @param dx        (INT8)  X coordinate of the sprite relative to the metasprite origin (pivot)
-    @param dtile     (UINT8) Start tile relative to the metasprites own set of tiles
-    @param props     (UINT8) Property Flags
+    @param dy        (int8_t)  Y coordinate of the sprite relative to the metasprite origin (pivot)
+    @param dx        (int8_t)  X coordinate of the sprite relative to the metasprite origin (pivot)
+    @param dtile     (uint8_t) Start tile relative to the metasprites own set of tiles
+    @param props     (uint8_t) Property Flags
 
     Metasprites are built from multiple metasprite_t items (one for each sub-sprite)
     and a pool of tiles they reference. If a metasprite has multiple frames then each
@@ -72,23 +74,23 @@
     on how many sprites are required for that particular frame).
 */
 typedef struct metasprite_t {
-    INT8  dy, dx;
-    UINT8 dtile;
-    UINT8 props;
+    int8_t  dy, dx;
+    uint8_t dtile;
+    uint8_t props;
 } metasprite_t;
 
 #define metasprite_end -128 
 
 extern const void * __current_metasprite;
-extern UBYTE __current_base_tile;
-extern UBYTE __render_shadow_OAM;
+extern uint8_t __current_base_tile;
+extern uint8_t __render_shadow_OAM;
 
 
-static UBYTE __move_metasprite(UINT8 id, UINT8 x, UINT8 y);
-static UBYTE __move_metasprite_vflip(UINT8 id, UINT8 x, UINT8 y);
-static UBYTE __move_metasprite_hflip(UINT8 id, UINT8 x, UINT8 y);
-static UBYTE __move_metasprite_hvflip(UINT8 id, UINT8 x, UINT8 y);
-static void __hide_metasprite(UINT8 id);
+static uint8_t __move_metasprite(uint8_t id, uint8_t x, uint8_t y);
+static uint8_t __move_metasprite_vflip(uint8_t id, uint8_t x, uint8_t y);
+static uint8_t __move_metasprite_hflip(uint8_t id, uint8_t x, uint8_t y);
+static uint8_t __move_metasprite_hvflip(uint8_t id, uint8_t x, uint8_t y);
+static void __hide_metasprite(uint8_t id);
 
 
 /** Moves metasprite to the absolute position x and y
@@ -113,7 +115,7 @@ static void __hide_metasprite(UINT8 id);
 
     @return Number of hardware sprites used to draw this metasprite
  */
-inline UBYTE move_metasprite(const metasprite_t * metasprite, UINT8 base_tile, UINT8 base_sprite, UINT8 x, UINT8 y) {
+inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
     __current_metasprite = metasprite; 
     __current_base_tile = base_tile;
     return __move_metasprite(base_sprite, x, y); 
@@ -140,7 +142,7 @@ inline UBYTE move_metasprite(const metasprite_t * metasprite, UINT8 base_tile, U
 
     @see move_metasprite()
 */
-inline UBYTE move_metasprite_vflip(const metasprite_t * metasprite, UINT8 base_tile, UINT8 base_sprite, UINT8 x, UINT8 y) {
+inline uint8_t move_metasprite_vflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
     __current_metasprite = metasprite; 
     __current_base_tile = base_tile;
     return __move_metasprite_vflip(base_sprite, x - 8, y); 
@@ -168,7 +170,7 @@ inline UBYTE move_metasprite_vflip(const metasprite_t * metasprite, UINT8 base_t
 
     @see move_metasprite()
 */
-inline UBYTE move_metasprite_hflip(const metasprite_t * metasprite, UINT8 base_tile, UINT8 base_sprite, UINT8 x, UINT8 y) {
+inline uint8_t move_metasprite_hflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
     __current_metasprite = metasprite; 
     __current_base_tile = base_tile;
     return __move_metasprite_hflip(base_sprite, x, y - ((LCDC_REG & 0x04U) ? 16 : 8) ); 
@@ -195,7 +197,7 @@ inline UBYTE move_metasprite_hflip(const metasprite_t * metasprite, UINT8 base_t
 
     @see move_metasprite()
 */
-inline UBYTE move_metasprite_hvflip(const metasprite_t * metasprite, UINT8 base_tile, UINT8 base_sprite, UINT8 x, UINT8 y) {
+inline uint8_t move_metasprite_hvflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
     __current_metasprite = metasprite; 
     __current_base_tile = base_tile;
     return __move_metasprite_hvflip(base_sprite, x - 8, y - ((LCDC_REG & 0x04U) ? 16 : 8)); 
@@ -210,7 +212,7 @@ inline UBYTE move_metasprite_hvflip(const metasprite_t * metasprite, UINT8 base_
     \li __current_metasprite = metasprite;
 
  **/
-inline void hide_metasprite(const metasprite_t * metasprite, UINT8 base_sprite) {
+inline void hide_metasprite(const metasprite_t * metasprite, uint8_t base_sprite) {
     __current_metasprite = metasprite; 
     __hide_metasprite(base_sprite);
 }

--- a/gbdk-lib/include/gb/sample.h
+++ b/gbdk-lib/include/gb/sample.h
@@ -10,9 +10,11 @@
 #ifndef _SAMPLE_H
 #define _SAMPLE_H
 
+#include <stdint.h>
+
 /** Play the given, appropriatly formatted sample.
  */
 void
-play_sample(UINT8 *start, UINT16 len) NONBANKED;
+play_sample(uint8_t *start, uint16_t len) NONBANKED;
 
 #endif /* _SAMPLE_H */

--- a/gbdk-lib/include/gb/sgb.h
+++ b/gbdk-lib/include/gb/sgb.h
@@ -50,6 +50,6 @@ uint8_t sgb_check(void) __preserves_regs(b, c);
 
     @see sgb_check()
 */
-void sgb_transfer(unsigned char * packet) __preserves_regs(b, c);
+void sgb_transfer(uint8_t * packet) __preserves_regs(b, c);
 
 #endif /* _SGB_H */

--- a/gbdk-lib/include/gb/sgb.h
+++ b/gbdk-lib/include/gb/sgb.h
@@ -6,6 +6,8 @@
 #ifndef _SGB_H
 #define _SGB_H
 
+#include <stdint.h>
+
 #define SGB_PAL_01 0x00U    /**< SGB Command: Set SGB Palettes 0 & 1 */
 #define SGB_PAL_23 0x01U    /**< SGB Command: Set SGB Palettes 2 & 3 */
 #define SGB_PAL_03 0x02U    /**< SGB Command: Set SGB Palettes 0 & 3 */
@@ -34,7 +36,7 @@
 
 
 /** Returns a non-null value if running on Super GameBoy */
-UINT8 sgb_check(void) __preserves_regs(b, c);
+uint8_t sgb_check(void) __preserves_regs(b, c);
 
 /** Transfer a SGB packet
 

--- a/gbdk-lib/include/rand.h
+++ b/gbdk-lib/include/rand.h
@@ -7,6 +7,7 @@
 #define RAND_INCLUDE
 
 #include <types.h>
+#include <stdint.h>
 
 /** Initalise the pseudo-random number generator.
 
@@ -24,20 +25,20 @@
     @see rand(), randw()
 */
 void
-initrand(UINT16 seed) NONBANKED; /* Non-banked as called from asm in arand.s */
+initrand(uint16_t seed) NONBANKED; /* Non-banked as called from asm in arand.s */
 
 /** Returns a random byte (8 bit) value.
 
     @ref initrand() should be used to initialize the random number generator before using rand()
  */
-INT8
+int8_t
 rand(void);
 
 /** Returns a random word (16 bit) value.
 
     @ref initrand() should be used to initialize the random number generator before using rand()
  */
-UINT16
+uint16_t
 randw(void);
 
 /** Random generator using the linear lagged additive method
@@ -50,13 +51,13 @@ randw(void);
     @see initrand() for suggestions about seed values, arand()
 */
 void
-initarand(UINT16 seed);
+initarand(uint16_t seed);
 
 /** Returns a random number generated with the linear lagged additive method.
 
     @ref initarand() should be used to initialize the random number generator before using arand()
  */
-INT8
+int8_t
 arand(void);
 
 #endif

--- a/gbdk-lib/include/time.h
+++ b/gbdk-lib/include/time.h
@@ -5,10 +5,11 @@
 #define TIME_INCLUDE
 
 #include <types.h>
+#include <stdint.h>
 
 #define CLOCKS_PER_SEC		60
 
-typedef UINT16	time_t;
+typedef uint16_t	time_t;
 
 /** Returns an approximation of processor time used by the program in Clocks
 

--- a/gbdk-lib/libc/atoi.c
+++ b/gbdk-lib/libc/atoi.c
@@ -1,11 +1,12 @@
+#include <stdint.h>
 #include <stdlib.h>
 #include <types.h>
 #include <ctype.h>
 
 int atoi(const char *s) NONBANKED
 {
-  UINT8 i, sign = 0;
-  INT8 n;
+  uint8_t i, sign = 0;
+  int8_t n;
 
   for(i = 0; (s[i] == ' ') || (s[i] == '\n') || (s[i] == '\t'); ++i)
     ;

--- a/gbdk-lib/libc/atol.c
+++ b/gbdk-lib/libc/atol.c
@@ -1,9 +1,10 @@
+#include <stdint.h>
 #include <stdlib.h>
 #include <ctype.h>
 
 long atol(const char *s) NONBANKED
 {
-  UINT8 i, sign = 0;
+  uint8_t i, sign = 0;
   long n;
 
   for(i = 0; (s[i] == ' ') || (s[i] == '\n') || (s[i] == '\t'); ++i)

--- a/gbdk-lib/libc/bcd.c
+++ b/gbdk-lib/libc/bcd.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include "bcd.h"
 
-void uint2bcd(unsigned int i, BCD * value) __naked
+void uint2bcd(uint16_t i, BCD * value) __naked
 {
     i; value; // suppress warninig: unreferenced function argument
 __asm
@@ -141,7 +141,7 @@ __asm
 __endasm;
 }
 
-uint8_t bcd2text(BCD * bcd, uint8_t tile_offset, unsigned char * buffer) __naked
+uint8_t bcd2text(BCD * bcd, uint8_t tile_offset, uint8_t * buffer) __naked
 {
     bcd; tile_offset; buffer;
 __asm

--- a/gbdk-lib/libc/bcd.c
+++ b/gbdk-lib/libc/bcd.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include "bcd.h"
 
 void uint2bcd(unsigned int i, BCD * value) __naked
@@ -140,7 +141,7 @@ __asm
 __endasm;
 }
 
-UBYTE bcd2text(BCD * bcd, UBYTE tile_offset, unsigned char * buffer) __naked
+uint8_t bcd2text(BCD * bcd, uint8_t tile_offset, unsigned char * buffer) __naked
 {
     bcd; tile_offset; buffer;
 __asm

--- a/gbdk-lib/libc/gb/font.s
+++ b/gbdk-lib/libc/gb/font.s
@@ -73,7 +73,7 @@ _font_load_ibm::		; Banked
 	ret
 	
 	; Copy uncompressed 16 byte tiles from (BC) to (HL), length = DE*2
-	; Note: HL must be aligned on a UWORD boundry
+	; Note: HL must be aligned on a uint16_t boundry
 font_copy_uncompressed::
 	ld	a,d
 	or	e

--- a/gbdk-lib/libc/gb/get_t.s
+++ b/gbdk-lib/libc/gb/get_t.s
@@ -3,7 +3,7 @@
         ;; BANKED: checked
         .area   _BASE
 
-; void get_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, unsigned char *vram_addr, unsigned char *tiles);
+; void get_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t *vram_addr, uint8_t *tiles);
 
 _get_tiles::
         PUSH    BC

--- a/gbdk-lib/libc/gb/get_t.s
+++ b/gbdk-lib/libc/gb/get_t.s
@@ -3,7 +3,7 @@
         ;; BANKED: checked
         .area   _BASE
 
-; void get_tiles(UINT8 x, UINT8 y, UINT8 w, UINT8 h, unsigned char *vram_addr, unsigned char *tiles);
+; void get_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, unsigned char *vram_addr, unsigned char *tiles);
 
 _get_tiles::
         PUSH    BC

--- a/gbdk-lib/libc/gb/gprintf.c
+++ b/gbdk-lib/libc/gb/gprintf.c
@@ -1,10 +1,11 @@
+#include <stdint.h>
 #include <stdarg.h>
 #include <gb/drawing.h>
 
-INT8 gprintf(char *fmt, ...) NONBANKED
+int8_t gprintf(char *fmt, ...) NONBANKED
 {
   va_list ap;
-  INT8 nb = 0;
+  int8_t nb = 0;
 
   va_start(ap, fmt);
   for(; *fmt; fmt++)
@@ -18,25 +19,25 @@ INT8 gprintf(char *fmt, ...) NONBANKED
       }
       case 'd': {
 	/* decimal int */
-	  INT8 b = va_arg(ap, INT8);
+	  int8_t b = va_arg(ap, int8_t);
 	  gprintn(b, 10, SIGNED);
 	  break;
       }
       case 'u': {
 	  /* unsigned int */
-	  INT8 b = (INT8)va_arg(ap, int);
+	  int8_t b = (int8_t)va_arg(ap, int);
 	  gprintn(b, 10, UNSIGNED);
 	  break;
       }
       case 'o': {
 	  /* octal int */
-	  INT8 b = va_arg(ap, INT8);
+	  int8_t b = va_arg(ap, int8_t);
 	  gprintn(b, 8, UNSIGNED);
 	  break;
       }
       case 'x': {
 	  /* hexadecimal int */
-	  INT8 b = va_arg(ap, INT8);
+	  int8_t b = va_arg(ap, int8_t);
 	  gprintn(b, 16, UNSIGNED);
 	  break;
       }
@@ -52,19 +53,19 @@ INT8 gprintf(char *fmt, ...) NONBANKED
 	switch(*++fmt) {
 	case 'd':
 	  /* decimal long */
-	  gprintln(va_arg(ap, INT16), 10, SIGNED);
+	  gprintln(va_arg(ap, int16_t), 10, SIGNED);
 	  break;
 	case 'u':
 	  /* unsigned long */
-	  gprintln(va_arg(ap, INT16), 10, UNSIGNED);
+	  gprintln(va_arg(ap, int16_t), 10, UNSIGNED);
 	  break;
 	case 'o':
 	  /* octal long */
-	  gprintln(va_arg(ap, INT16), 8, UNSIGNED);
+	  gprintln(va_arg(ap, int16_t), 8, UNSIGNED);
 	  break;
 	case 'x':
 	  /* hexadecimal long */
-	  gprintln(va_arg(ap, INT16), 16, UNSIGNED);
+	  gprintln(va_arg(ap, int16_t), 16, UNSIGNED);
 	  break;
 	}
 	break;

--- a/gbdk-lib/libc/gb/gprintln.c
+++ b/gbdk-lib/libc/gb/gprintln.c
@@ -1,18 +1,19 @@
+#include <stdint.h>
 #include <gb/drawing.h>
 
 /* Print a long number in any radix */
 
 extern char *digits;
 
-void gprintln(INT16 number, INT8 radix, INT8 signed_value)
+void gprintln(int16_t number, int8_t radix, int8_t signed_value)
 {
-  UINT16 l;
+  uint16_t l;
 
   if(number < 0 && signed_value) {
     wrtchr('-');
     number = -number;
   }
-  if((l = (UINT16)number / (UINT16)radix) != 0)
+  if((l = (uint16_t)number / (uint16_t)radix) != 0)
     gprintln(l, radix, UNSIGNED);
-  wrtchr(digits[(UINT16)number % (UINT16)radix]);
+  wrtchr(digits[(uint16_t)number % (uint16_t)radix]);
 }

--- a/gbdk-lib/libc/gb/gprintn.c
+++ b/gbdk-lib/libc/gb/gprintn.c
@@ -1,18 +1,19 @@
+#include <stdint.h>
 #include <gb/drawing.h>
 
 /* Print a number in any radix */
 
 extern char *digits;
 
-void gprintn(BYTE number, BYTE radix, BYTE signed_value)
+void gprintn(int8_t number, int8_t radix, int8_t signed_value)
 {
-  UBYTE i;
+  uint8_t i;
 
   if(number < 0 && signed_value) {
     wrtchr('-');
     number = -number;
   }
-  if((i = (UBYTE)number / (UBYTE)radix) != 0)
+  if((i = (uint8_t)number / (uint8_t)radix) != 0)
     gprintn(i, radix, UNSIGNED);
-  wrtchr(digits[(UBYTE)number % (UBYTE)radix]);
+  wrtchr(digits[(uint8_t)number % (uint8_t)radix]);
 }

--- a/gbdk-lib/libc/gb/metasprites.s
+++ b/gbdk-lib/libc/gb/metasprites.s
@@ -19,7 +19,7 @@ ___render_shadow_OAM::
 
         .area   _CODE
 
-; UBYTE __move_metasprite(UINT8 id, UINT8 x, UINT8 y)
+; uint8_t __move_metasprite(uint8_t id, uint8_t x, uint8_t y)
 
 ___move_metasprite::
         ldhl    sp, #4
@@ -75,7 +75,7 @@ ___move_metasprite::
 
         ret
 
-; void __hide_metasprite(UINT8 id)
+; void __hide_metasprite(uint8_t id)
 
 ___hide_metasprite::
         ldhl    sp, #2

--- a/gbdk-lib/libc/gb/metasprites_flip.s
+++ b/gbdk-lib/libc/gb/metasprites_flip.s
@@ -9,7 +9,7 @@
 
         .area   _CODE
 
-; UBYTE __move_metasprite(UINT8 id, UINT8 x, UINT8 y)
+; uint8_t __move_metasprite(uint8_t id, uint8_t x, uint8_t y)
 
 ___move_metasprite_hflip::
         ldhl    sp, #4

--- a/gbdk-lib/libc/gb/rand.s
+++ b/gbdk-lib/libc/gb/rand.s
@@ -98,7 +98,7 @@ _randw::			; Banked
 
 	;; Note D is the low byte,E the high byte. This is intentional because
 	;; the high byte can be slightly 'more random' than the low byte, and I presume
-	;; most will cast the return value to a UBYTE. As if someone will use this, tha!
+	;; most will cast the return value to a uint8_t. As if someone will use this, tha!
 	RET
 
 	;; This sets the seed value. Call it whenever you like

--- a/gbdk-lib/libc/gb/set_t.s
+++ b/gbdk-lib/libc/gb/set_t.s
@@ -5,7 +5,7 @@
 	;; BANKED: checked, imperfect
         .area   _BASE
 
-; void set_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, unsigned char *vram_addr, const unsigned char *tiles);
+; void set_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t *vram_addr, const uint8_t *tiles);
 
 _set_tiles::
         PUSH    BC

--- a/gbdk-lib/libc/gb/set_t.s
+++ b/gbdk-lib/libc/gb/set_t.s
@@ -5,7 +5,7 @@
 	;; BANKED: checked, imperfect
         .area   _BASE
 
-; void set_tiles(UINT8 x, UINT8 y, UINT8 w, UINT8 h, unsigned char *vram_addr, const unsigned char *tiles);
+; void set_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, unsigned char *vram_addr, const unsigned char *tiles);
 
 _set_tiles::
         PUSH    BC

--- a/gbdk-lib/libc/scanf.c
+++ b/gbdk-lib/libc/scanf.c
@@ -1,8 +1,9 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <ctype.h>
 
-static UINT8 scan_skip(char *s, UINT8 i)
+static uint8_t scan_skip(char *s, uint8_t i)
 {
 oncemore:
   while(isspace(s[i]))
@@ -15,10 +16,10 @@ oncemore:
   return i;
 }
 
-static UINT8 scan_int(char *s, UINT8 i, UINT8 base, INT8 *nb)
+static uint8_t scan_int(char *s, uint8_t i, uint8_t base, int8_t *nb)
 {
-  INT8 n = 0;
-  UINT8 j, sign = 0;
+  int8_t n = 0;
+  uint8_t j, sign = 0;
 
   switch(s[i])
     {
@@ -45,10 +46,10 @@ static UINT8 scan_int(char *s, UINT8 i, UINT8 base, INT8 *nb)
   return i;
 }
 
-static UINT8 scan_long(char *s, UINT8 i, UINT8 base, INT16 *nb)
+static uint8_t scan_long(char *s, uint8_t i, uint8_t base, int16_t *nb)
 {
-  INT16 n = 0;
-  UINT8 j, sign = 0;
+  int16_t n = 0;
+  uint8_t j, sign = 0;
 
   switch(s[i])
     {
@@ -75,12 +76,12 @@ static UINT8 scan_long(char *s, UINT8 i, UINT8 base, INT16 *nb)
   return i;
 }
 
-INT8 scanf(char *fmt, ...)
+int8_t scanf(char *fmt, ...)
 {
   va_list ap;
   char s[64];
-  UINT8 i = 0;
-  INT8 nb = 0;
+  uint8_t i = 0;
+  int8_t nb = 0;
 
   gets(s);
   va_start(ap, fmt);
@@ -98,20 +99,20 @@ INT8 scanf(char *fmt, ...)
 	/* decimal int */
       case 'u':
 	/* unsigned int */
-	i = scan_int(s, i, 10, va_arg(ap, INT8 *));
+	i = scan_int(s, i, 10, va_arg(ap, int8_t *));
 	break;
       case 'o':
 	/* octal int */
-	i = scan_int(s, i, 8, va_arg(ap, INT8 *));
+	i = scan_int(s, i, 8, va_arg(ap, int8_t *));
 	break;
       case 'x':
 	/* hexadecimal int */
-	i = scan_int(s, i, 16, va_arg(ap, INT8 *));
+	i = scan_int(s, i, 16, va_arg(ap, int8_t *));
 	break;
       case 's':
 	/* string */
 	{
-	  INT8 j = 0;
+	  int8_t j = 0;
 	  char *d = va_arg(ap, char *);
 	  while((d[j++] = s[i++]) != 0)
 	    ;
@@ -124,15 +125,15 @@ INT8 scanf(char *fmt, ...)
 	  /* decimal long */
 	case 'u':
 	  /* unsigned long */
-	  i = scan_long(s, i, 10, va_arg(ap, INT16 *));
+	  i = scan_long(s, i, 10, va_arg(ap, int16_t *));
 	  break;
 	case 'o':
 	  /* octal long */
-	  i = scan_long(s, i, 8, va_arg(ap, INT16 *));
+	  i = scan_long(s, i, 8, va_arg(ap, int16_t *));
 	  break;
 	case 'x':
 	  /* hexadecimal long */
-	  i = scan_long(s, i, 16, va_arg(ap, INT16 *));
+	  i = scan_long(s, i, 16, va_arg(ap, int16_t *));
 	  break;
 	}
 	break;

--- a/gbdk-lib/libc/scanf.c
+++ b/gbdk-lib/libc/scanf.c
@@ -3,7 +3,7 @@
 #include <stdarg.h>
 #include <ctype.h>
 
-static uint8_t scan_skip(char *s, uint8_t i)
+static unsigned char scan_skip(char *s, unsigned char i)
 {
 oncemore:
   while(isspace(s[i]))
@@ -16,10 +16,10 @@ oncemore:
   return i;
 }
 
-static uint8_t scan_int(char *s, uint8_t i, uint8_t base, int8_t *nb)
+static unsigned char scan_int(char *s, unsigned char i, unsigned char base, char *nb)
 {
-  int8_t n = 0;
-  uint8_t j, sign = 0;
+  char n = 0;
+  unsigned char j, sign = 0;
 
   switch(s[i])
     {
@@ -46,10 +46,10 @@ static uint8_t scan_int(char *s, uint8_t i, uint8_t base, int8_t *nb)
   return i;
 }
 
-static uint8_t scan_long(char *s, uint8_t i, uint8_t base, int16_t *nb)
+static unsigned char scan_long(char *s, unsigned char i, unsigned char base, int *nb)
 {
-  int16_t n = 0;
-  uint8_t j, sign = 0;
+  int n = 0;
+  unsigned char j, sign = 0;
 
   switch(s[i])
     {
@@ -76,12 +76,12 @@ static uint8_t scan_long(char *s, uint8_t i, uint8_t base, int16_t *nb)
   return i;
 }
 
-int8_t scanf(char *fmt, ...)
+char scanf(char *fmt, ...)
 {
   va_list ap;
   char s[64];
-  uint8_t i = 0;
-  int8_t nb = 0;
+  unsigned char i = 0;
+  char nb = 0;
 
   gets(s);
   va_start(ap, fmt);
@@ -99,20 +99,20 @@ int8_t scanf(char *fmt, ...)
 	/* decimal int */
       case 'u':
 	/* unsigned int */
-	i = scan_int(s, i, 10, va_arg(ap, int8_t *));
+	i = scan_int(s, i, 10, va_arg(ap, char *));
 	break;
       case 'o':
 	/* octal int */
-	i = scan_int(s, i, 8, va_arg(ap, int8_t *));
+	i = scan_int(s, i, 8, va_arg(ap, char *));
 	break;
       case 'x':
 	/* hexadecimal int */
-	i = scan_int(s, i, 16, va_arg(ap, int8_t *));
+	i = scan_int(s, i, 16, va_arg(ap, char *));
 	break;
       case 's':
 	/* string */
 	{
-	  int8_t j = 0;
+	  char j = 0;
 	  char *d = va_arg(ap, char *);
 	  while((d[j++] = s[i++]) != 0)
 	    ;
@@ -125,15 +125,15 @@ int8_t scanf(char *fmt, ...)
 	  /* decimal long */
 	case 'u':
 	  /* unsigned long */
-	  i = scan_long(s, i, 10, va_arg(ap, int16_t *));
+	  i = scan_long(s, i, 10, va_arg(ap, int *));
 	  break;
 	case 'o':
 	  /* octal long */
-	  i = scan_long(s, i, 8, va_arg(ap, int16_t *));
+	  i = scan_long(s, i, 8, va_arg(ap, int *));
 	  break;
 	case 'x':
 	  /* hexadecimal long */
-	  i = scan_long(s, i, 16, va_arg(ap, int16_t *));
+	  i = scan_long(s, i, 16, va_arg(ap, int *));
 	  break;
 	}
 	break;

--- a/gbdk-lib/libc/time.c
+++ b/gbdk-lib/libc/time.c
@@ -3,12 +3,14 @@
   Simple, not completly conformant implementation of time routines
 */
 
+#include <stdint.h>
+
 /* clock() is in clock.s */
 #include <time.h>
 
 time_t time(time_t *t)
 {
-    UINT16 ret;
+    uint16_t ret;
 
     /* Should be relative to 0:00 1970 GMT but hey */
     ret = clock() / CLOCKS_PER_SEC;


### PR DESCRIPTION
In addition to #194 

Convert types for gbdk libs, but not for standard lib parts and string handling.

(UBYTE|UINT8|unsigned char) -> uint8_t
(BYTE|INT8|char) -> int8_t
(UWORD|UINT16|unsigned int) -> uint16_t
(WORD|INT16|int) -> int16_t
(ULONG|UDWORD|unsigned long) -> uint32_t
(LONG|DWORD|long) -> in32_t 

Samples all build and run.

Docs should be regenerated later to reflect new types in function declarations.
