### PR TITLE
Minor docs edits

### DIFF
--- a/docs/pages/04_coding_guidelines.md
+++ b/docs/pages/04_coding_guidelines.md
@@ -76,6 +76,8 @@ If you wish to use the original tools, you must add the `const` keyword every ti
   - Do not `#include` `.c` source files into other `.c` source files. Instead create `.h` header files for them and include those.
     https://www.tutorialspoint.com/cprogramming/c_header_files.htm
 
+  - Instead of using a blocking @ref delay() for things such as sprite animations/etc (which can prevent the rest of the game from continuing) many times it's better to use a counter which performs an action once every N frames. @ref sys_time may be useful in these cases.
+
   - When procesing for a given frame is done and it is time to wait before starting the next frame, @ref wait_vbl_done() can be used. It uses HALT to put the CPU into a low power state until processing resumes. The CPU will wake up and resume processing at the end of the current frame when the Vertical Blanking interrupt is triggered.
 
   - Minimize use of multiplication, modulo with non-powers of 2, and division with non-powers of 2. These operations have no corresponding CPU instructions (software functions), and hence are time costly.
@@ -115,6 +117,8 @@ If you wish to use the original tools, you must add the `const` keyword every ti
   - drawing.h: The Game Boy graphics hardware is not well suited to frame-buffer style graphics such as the kind provided in @ref drawing.h. Due to that, most drawing functions (rectangles, circles, etc) will be slow . When possible it's much faster and more efficient to work with the tiles and tile maps that the Game Boy hardware is built around.
 
   - @ref waitpad() and @ref waitpadup check for input in a loop that doesn't HALT at all, so the CPU will be maxed out until it returns. One alternative is to write a function with a loop that checks input with @ref joypad() and then waits a frame using @ref wait_vbl_done() (which idles the CPU while waiting) before checking input again.
+
+  - @ref joypad(): When testing for multiple different buttons, it's best to read the joypad state *once* into a variable and then test using that variable (instead of making multiple calls).
 
 
 ## Toolchain

--- a/docs/pages/08_faq.md
+++ b/docs/pages/08_faq.md
@@ -48,6 +48,9 @@
     - Yes, turn on `.noi` output (LCC argument: `-Wl-j` or `-debug` and then use `-Wm-yS` with LCC (or `-yS` with makebin directly). <!-- -->   
 
 # API / Utilities
+  - Can I use the `float` type to do floating point math?
+    - There is no support for 'float' in GBDK-2020.
+
   - Why are 8 bit numbers not printing correctly with printf()?
     - To correctly pass chars/uint8s for printing, they must be explicitly re-cast as such when calling the function. See docs_chars_varargs for more details.  <!-- -->  
 

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -165,6 +165,11 @@ void remove_JOY(int_handler h) NONBANKED;
     called last.  If the @ref remove_VBL function is to be called,
     only three may be added.
 
+    Do not use '__critical' and '__interrupt' attributes for a
+    function added via add_VBL() (or LCD, etc). The attributes 
+    are only required when constructing a bare jump from the 
+    interrupt vector itself.
+
     Note: The default VBL is installed automatically.
 */
 void add_VBL(int_handler h) NONBANKED;
@@ -221,9 +226,7 @@ void add_SIO(int_handler h) NONBANKED;
     or more times for every button press and one or more
     times for every button release.
 
-
-
-    @see joypad()
+    @see joypad(), add_VBL()
 */
 void add_JOY(int_handler h) NONBANKED;
 
@@ -1336,12 +1339,15 @@ void set_tiles(uint8_t x,
           uint8_t *vram_addr,
           const uint8_t *tiles) NONBANKED __preserves_regs(b, c);
 
-/** Sets VRAM Tile Pattern data starting from given base address
+/** Sets VRAM Tile Pattern data starting from given base address 
+    without taking into account the state of LCDC bit 4.
 
     @param first_tile  Index of the first tile to write
     @param nb_tiles    Number of tiles to write
     @param data        Pointer to (2 bpp) source Tile Pattern data.
 	@param base        MSB of the destination address in VRAM (usually 0x80 or 0x90 which gives 0x8000 or 0x9000)
+
+set_tile_data() allows to load tile data not taking into account LCDC bit 4 state    
 */
 void set_tile_data(uint8_t first_tile,
           uint8_t nb_tiles,

--- a/gbdk-lib/include/gb/metasprites.h
+++ b/gbdk-lib/include/gb/metasprites.h
@@ -72,6 +72,8 @@
     and a pool of tiles they reference. If a metasprite has multiple frames then each
     frame will be built from some number of metasprite_t items (which may vary based
     on how many sprites are required for that particular frame).
+
+    A metasprite frame is terminated with a {metasprite_end} entry.
 */
 typedef struct metasprite_t {
     int8_t  dy, dx;


### PR DESCRIPTION
- Advise against blocking use of `delay()` vs every N frames
- Advise against repeated sequential calls to `joypad()`, cache result instead
- Add `float` to FAQ
- Add mention of when `metasprite_end` is used