### PR TITLE
Makefiles: minor png2mtspr and cross-build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ VER = 3.00
 
 # Prefix to add to the standard tools.  Usefull for a standard gcc
 # cross-compile.
-# TOOLSPREFIX = i686-w64-mingw32-
 TOOLSPREFIX =
+# TOOLSPREFIX = i686-w64-mingw32-
 
 TARGETCC = $(TOOLSPREFIX)gcc
 TARGETRANLIB = $(TOOLSPREFIX)ranlib
@@ -36,7 +36,8 @@ DOXYGEN_VER_HAS = $(shell doxygen -v)
 
 # Base setup
 # Extension to add to executables
-EXEEXTENSION =
+EXEEXTENSION = 
+# EXEEXTENSION=.exe
 # Host operating system identifier.
 HOSTOS = $(shell uname -s)
 # Target operating system identifier.  Used in the output zip name.
@@ -125,7 +126,7 @@ endif
 	@echo Building bankpack
 	@$(MAKE) -C $(GBDKSUPPORTDIR)/bankpack TOOLSPREFIX=$(TOOLSPREFIX) TARGETDIR=$(TARGETDIR)/ --no-print-directory
 	@echo Building png2mtspr
-	@$(MAKE) -C $(GBDKSUPPORTDIR)/png2mtspr
+	@$(MAKE) -C $(GBDKSUPPORTDIR)/png2mtspr TOOLSPREFIX=$(TOOLSPREFIX)
 	@echo Building gbcompress
 	@$(MAKE) -C $(GBDKSUPPORTDIR)/gbcompress TOOLSPREFIX=$(TOOLSPREFIX) TARGETDIR=$(TARGETDIR)/ --no-print-directory
 	@echo
@@ -146,7 +147,7 @@ gbdk-support-install: gbdk-support-build $(BUILDDIR)/bin
 	@$(TARGETSTRIP) $(BUILDDIR)/bin/bankpack*
 	@echo Installing png2mtspr
 	@cp $(GBDKSUPPORTDIR)/png2mtspr/png2mtspr$(EXEEXTENSION) $(BUILDDIR)/bin/png2mtspr$(EXEEXTENSION)
-	@$(TARGETSTRIP) $(BUILDDIR)/bin/bankpack*
+	@$(TARGETSTRIP) $(BUILDDIR)/bin/png2mtspr*
 	@echo Installing gbcompress
 	@cp $(GBDKSUPPORTDIR)/gbcompress/gbcompress $(BUILDDIR)/bin/gbcompress$(EXEEXTENSION)
 	@$(TARGETSTRIP) $(BUILDDIR)/bin/gbcompress*

--- a/gbdk-support/bankpack/Makefile
+++ b/gbdk-support/bankpack/Makefile
@@ -15,3 +15,5 @@ $(BIN): $(OBJ)
 
 clean:
 	rm -f *.o $(BIN) *~
+	rm -f *.exe
+

--- a/gbdk-support/gbcompress/Makefile
+++ b/gbdk-support/gbcompress/Makefile
@@ -16,6 +16,7 @@ $(BIN): $(OBJ)
 clean:
 	rm -f *.o $(BIN) *~
 	rm -f tmp.*
+	rm -f *.exe
 
 # round trip the executable through compression and de-compression as a brief test
 test:

--- a/gbdk-support/ihxcheck/Makefile
+++ b/gbdk-support/ihxcheck/Makefile
@@ -15,3 +15,5 @@ $(BIN): $(OBJ)
 
 clean:
 	rm -f *.o $(BIN) *~
+	rm -f *.exe
+

--- a/gbdk-support/lcc/Makefile
+++ b/gbdk-support/lcc/Makefile
@@ -23,3 +23,5 @@ $(BIN): $(OBJ)
 
 clean:
 	rm -f *.o $(BIN) *~
+	rm -f *.exe
+

--- a/gbdk-support/png2mtspr/Makefile
+++ b/gbdk-support/png2mtspr/Makefile
@@ -8,6 +8,12 @@ CXX = $(TOOLSPREFIX)g++
 CXXFLAGS = -Os -Wall -g
 LFLAGS = -g
 
+# Static flag for windows cross and native builds
+ifeq ($(TOOLSPREFIX),i686-w64-mingw32-)
+#   prefix will automatically be .exe for cross build
+	LFLAGS += -static 
+endif
+
 ifeq ($(OS),Windows_NT)
 	EXT = .exe
 	LFLAGS += -static 
@@ -24,7 +30,7 @@ OBJS := $(SRCS:%.cpp=%.o)
  
 $(TARGET): $(OBJS)
 	$(CXX) $(LFLAGS) -o $(TARGET) $(OBJS)
-	strip $@$(EXT)
+#	strip $@$(EXT)
  
 # The main.o target can be written more simply
  
@@ -35,3 +41,4 @@ $(TARGET): $(OBJS)
 	rm -f *.o
 	rm -f *.exe
 	rm -f TARGET
+


### PR DESCRIPTION
- fix a couple incorrect lines for png2mtspr
- fix png2mtspr cross building
- remove .exe in gbdk-support on make clean for all binaries (may have been ok in Windows, was not working on linux cross builds)

Copy gbdk-support stage of cross build still isn't working, but I won't tamper with that for now.