### PR TITLE
LCC port:platform improvements

### DIFF
--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -25,6 +25,7 @@ typedef struct {
 	const char *port;
 	const char *plat;
 	const char *default_plat;
+	const char *rom_extension;
 	const char *cpp;
 	const char *include;
 	const char *com;
@@ -39,6 +40,7 @@ static struct {
 	const char *name;
 	const char *val;
 } _tokens[] = {
+		// expandable string tokens used in "CLASS" command strings
 		{ "port",		"gbz80" },
 		{ "plat",		"gb" },
 		{ "sdccdir", "%bindir%"},
@@ -113,9 +115,10 @@ $3 is the output file
 */
 static CLASS classes[] = {
 		// GB
-		{ "gbz80",	// port
-			"gb",	// plat
-			"gb",	// default_plat
+		{ "gbz80",		// port
+			"gb",		// plat
+			"gb",		// default_plat
+			EXT_GB,		// ROM file extension
 			"%cpp% %cppdefault% -DGB=1 -DGAMEBOY=1 -DINT_16_BITS $1 $2 $3",
 			"%includedefault%",
 			"%com% %comdefault% -Wa%asdefault% -DGB=1 -DGAMEBOY=1 -DINT_16_BITS $1 %comflag% $2 -o $3",
@@ -126,9 +129,10 @@ static CLASS classes[] = {
 			"%mkbin% -Z $1 $2 $3"
 		},
 		// AP
-		{ "gbz80",	// port
-			"ap",	// plat
-			"ap",	// default_plat
+		{ "gbz80",		// port
+			"ap",		// plat
+			"ap",		// default_plat
+			EXT_AP,		// ROM file extension
 			"%cpp% %cppdefault% -DGB=1 -DGAMEBOY=1 -DINT_16_BITS $1 $2 $3",
 			"%includedefault%",
 			"%com% %comdefault% -Wa%asdefault% -DGB=1 -DGAMEBOY=1 -DINT_16_BITS $1 %comflag% $2 -o $3",
@@ -139,30 +143,32 @@ static CLASS classes[] = {
 			"%mkbin% -Z $1 $2 $3"
 		},
 		// SMS
-		{ "z80",	// port
-			"sms",	// plat
-			"sms",	// default_plat
+		{ "z80",		// port
+			"sms",		// plat
+			"sms",		// default_plat
+			EXT_SMS,	// ROM file extension
 			"%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
 			"%includedefault%",
 			"%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
 			"%as_z80% %asdefault% $1 $3 $2",
-			"%bankpack% $1 $2",
+			"",			// bankpack command: turned off for this port:platform
 			"%ld_z80% -n -i $1 %libs_include% $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
-			"%mkbin% -Z $1 $2 $3"
+			"%mkbin% -S $1 $2 $3"
 		},
 		// GG
-		{ "z80",	// port
-			"gg",	// plat
-			"gg",	// default_plat
+		{ "z80",		// port
+			"gg",		// plat
+			"gg",		// default_plat
+			EXT_GG,		// ROM file extension
 			"%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
 			"%includedefault%",
 			"%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
 			"%as_z80% %asdefault% $1 $3 $2",
-			"%bankpack% $1 $2",
+			"",			// bankpack command: turned off for this port:platform
 			"%ld_z80% -n -i $1 %libs_include% $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
-			"%mkbin% -Z $1 $2 $3"
+			"%mkbin% -S $1 $2 $3"
 		}
 };
 
@@ -285,6 +291,7 @@ char *ihxcheck[256];
 char *ld[256];
 char *bankpack[256];
 char *mkbin[256];
+char *rom_extension;
 
 const char *starts_with(const char *s1, const char *s2)
 {
@@ -384,6 +391,7 @@ void finalise(void)
 	buildArgs(ld, _class->ld);
 	buildArgs(ihxcheck, _class->ihxcheck);
 	buildArgs(mkbin, _class->mkbin);
+	rom_extension = strdup(_class->rom_extension);
 }
 
 void set_gbdk_dir(char* argv_0)

--- a/gbdk-support/lcc/gb.h
+++ b/gbdk-support/lcc/gb.h
@@ -13,6 +13,9 @@
 #define EXT_OBJ  ".obj"
 #define EXT_IHX  ".ihx"
 #define EXT_GB   ".gb"
+#define EXT_AP   ".ap"
+#define EXT_SMS  ".sms"
+#define EXT_GG   ".gg"
 
 #endif // _LCC_GB_H
 


### PR DESCRIPTION
- Add default rom binary extensions for all ports:platforms
- Default to rom extension format instead of .ihx when no output target is specified
- Autobanking is only called for ports:platforms which have the bankpack compose string populated
- Change makebin default flag for current z80 ports to -S