### PR TITLE
Feature/ap sms autobank

### DIFF
--- a/gbdk-support/bankpack/bankpack.c
+++ b/gbdk-support/bankpack/bankpack.c
@@ -41,6 +41,7 @@ static void display_help(void) {
        "-sym=<prefix>: Add symbols starting with <prefix> to match + update list.\n"
        "               Default entry is \"___bank_\" (see below)\n"
        "-cartsize    : Print min required cart size as \"autocartsize:<NNN>\"\n"
+       "-plat=<plat> : Select platform specific behavior (default:gb) (gb,sms)\n"
        "-v           : Verbose output, show assignments\n"
        "\n"
        "Example: \"bankpack -ext=.rel -path=some/newpath/ file1.o file2.o\"\n"
@@ -97,6 +98,8 @@ static int handle_args(int argc, char * argv[]) {
                 symbol_match_add(argv[i] + 5);
             } else if (strstr(argv[i], "-cartsize") == argv[i]) {
                 g_option_cartsize = true;
+            } else if (strstr(argv[i], "-plat=") == argv[i]) {
+                banks_set_platform(argv[i] + 6);
             } else
                 printf("BankPack: Warning: Ignoring unknown option %s\n", argv[i]);
         } else {
@@ -143,7 +146,11 @@ int main( int argc, char *argv[] )  {
 
     if (handle_args(argc, argv)) {
 
-        if (banks_get_mbc_type() != MBC_TYPE_NONE) {
+        // Require MBC for Game Boy
+        // SMS doesn't require an MBC setting
+        if ((banks_get_platform() == PLATFORM_GB) && (banks_get_mbc_type() == MBC_TYPE_NONE))
+            printf("BankPack: ERROR: auto-banking does not work with unbanked ROMS (no MBC for Game Boy)\n");
+        else {
             // Extract areas, sort and assign them to banks
             // then rewrite object files as needed
             files_extract();
@@ -156,8 +163,7 @@ int main( int argc, char *argv[] )  {
 
             cleanup();
             ret = EXIT_SUCCESS;
-        } else
-            printf("BankPack: ERROR: auto-banking does not work with unbanked ROMS (no MBC)\n");
+        }
     }
 
     return ret; // Exit with failure by default

--- a/gbdk-support/bankpack/files.c
+++ b/gbdk-support/bankpack/files.c
@@ -52,6 +52,7 @@ void files_add(char * filename) {
     if (snprintf(newfile.name_in, sizeof(newfile.name_in), "%s", filename) > sizeof(newfile.name_in))
         printf("Warning: truncated input filename to:%s\n",newfile.name_in);
 
+    newfile.name_out[0] = '\0';
     newfile.rewrite_needed = false;
     newfile.bank_num = BANK_NUM_UNASSIGNED;
 
@@ -66,7 +67,7 @@ char * file_get_name_in_by_id(uint32_t file_id) {
     if ((file_id >= 0) && (file_id < filelist.count))
         return files[file_id].name_in;
     else
-        return NULL;
+        return (char *)"\0";
 }
 
 
@@ -77,7 +78,7 @@ char * file_get_name_out_by_id(uint32_t file_id) {
     if ((file_id >= 0) && (file_id < filelist.count))
         return files[file_id].name_out;
     else
-        return NULL;
+        return (char *)"\0";
 }
 
 

--- a/gbdk-support/bankpack/obj_data.h
+++ b/gbdk-support/bankpack/obj_data.h
@@ -12,10 +12,24 @@
 #define SYMBOL_LINE_RECORDS    2 // Name, DefVal
 #define SYMBOL_REWRITE_RECORDS 2 // Name, DefVal
 
+#define PLATFORM_GB                 0
+#define PLATFORM_SMS                1
+#define PLATFORM_DEFAULT            PLATFORM_GB
+
+#define PLATFORM_STR_GB             "gb"
+#define PLATFORM_STR_AP             "ap"    // Uses PLATFORM_GB
+#define PLATFORM_STR_SMS            "sms"
+#define PLATFORM_STR_GG             "gg"    // Uses PLATFORM_SMS
+
+#define BANK_TYPE_UNSET             0
+#define BANK_TYPE_DEFAULT           1
+#define BANK_TYPE_LIT_EXCLUSIVE     2
+
 
 typedef struct bank_item {
     uint32_t size;
     uint32_t free;
+    uint32_t type;
 } bank_item;
 
 
@@ -25,6 +39,7 @@ typedef struct area_item {
     uint32_t size;         // uint32_t to avoid mingw sscanf() buffer overflow
     uint32_t bank_num_in;  // uint32_t to avoid mingw sscanf() buffer overflow
     uint32_t bank_num_out; // uint32_t to avoid mingw sscanf() buffer overflow
+    uint32_t type;
 } area_item;
 
 typedef struct symbol_item {
@@ -39,6 +54,8 @@ typedef struct symbol_match_item {
     char     name[OBJ_NAME_MAX_STR_LEN];
 } symbol_match_item;
 
+void banks_set_platform(char * platform_str);
+int banks_get_platform(void);
 int banks_get_mbc_type(void);
 void banks_set_mbc(int);
 void banks_set_mbc_by_rom_byte_149(int);

--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -151,8 +151,8 @@ static CLASS classes[] = {
 			"%includedefault%",
 			"%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
 			"%as_z80% %asdefault% $1 $3 $2",
-			"%bankpack% $1 $2",
-			"%ld_z80% -n -i $1 %libs_include% $3 %crt0dir% $2",
+			"%bankpack% -plat=sms $1 $2",
+			"%ld_z80% -a sms -n -i $1 %libs_include% $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
 			"%mkbin% -S $1 $2 $3"
 		},
@@ -165,8 +165,8 @@ static CLASS classes[] = {
 			"%includedefault%",
 			"%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
 			"%as_z80% %asdefault% $1 $3 $2",
-			"%bankpack% $1 $2",
-			"%ld_z80% -n -i $1 %libs_include% $3 %crt0dir% $2",
+			"%bankpack% -plat=sms $1 $2",
+			"%ld_z80% -a sms -n -i $1 %libs_include% $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
 			"%mkbin% -S $1 $2 $3"
 		}

--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -151,7 +151,7 @@ static CLASS classes[] = {
 			"%includedefault%",
 			"%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
 			"%as_z80% %asdefault% $1 $3 $2",
-			"",			// bankpack command: turned off for this port:platform
+			"%bankpack% $1 $2",
 			"%ld_z80% -n -i $1 %libs_include% $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
 			"%mkbin% -S $1 $2 $3"
@@ -165,7 +165,7 @@ static CLASS classes[] = {
 			"%includedefault%",
 			"%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
 			"%as_z80% %asdefault% $1 $3 $2",
-			"",			// bankpack command: turned off for this port:platform
+			"%bankpack% $1 $2",
 			"%ld_z80% -n -i $1 %libs_include% $3 %crt0dir% $2",
 			"%ihxcheck% $2 $1",
 			"%mkbin% -S $1 $2 $3"


### PR DESCRIPTION
- lcc: update classes to automatically set platform for `sdldz80` and `bankpack` when using `sms` and `gg` (use `sms` for both right now)

- bankpack: add sms platform support
  - don't allow `_CODE_N` and `_LIT_N` mixing in the same bank
  - select platform with `-plat=sms`
  - minor cleanup in `file_get_name...()` functions

