### PR TITLE
Building: change make.bat generation to use name compile.bat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,8 +70,9 @@ far_fixer/Debug/
 far_fixer/.vs/
 [Dd]ebug/
 
-# Auto-generated make.bat (from Makefiles)
+# Auto-generated make.bat and compile.bat (from Makefiles)
 make.bat
+compile.bat
 
 # Doc generation files
 gbdk-lib/doc/

--- a/Makefile
+++ b/Makefile
@@ -221,8 +221,8 @@ gbdk-lib-install-examples:
 	@cp -r $(GBDKLIBDIR)/include $(GBDKLIBDIR)/examples $(BUILDDIR)
 	@for plat in $(PLATFORMS); do \
 		if [ -d "$(BUILDDIR)/examples/$$plat" ]; then \
-			echo Generating Examples make.bat for $$plat; \
-			$(MAKE) -C $(BUILDDIR)/examples/$$plat make.bat --no-print-directory; \
+			echo Generating Examples compile.bat for $$plat; \
+			$(MAKE) -C $(BUILDDIR)/examples/$$plat compile.bat --no-print-directory; \
 			echo; \
 		fi \
 	done
@@ -234,8 +234,8 @@ gbdk-lib-clean:
 	@echo
 
 gbdk-lib-examples-makefile:
-	$(MAKE) -C $(BUILDDIR)/examples/gb make.bat
-	unix2dos $(BUILDDIR)/examples/gb/make.bat
+	$(MAKE) -C $(BUILDDIR)/examples/gb compile.bat
+	unix2dos $(BUILDDIR)/examples/gb/compile.bat
 
 gbdk-dist-examples-build:
 	$(MAKE) -C $(BUILDDIR)/examples/gb

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The last version in the OLD repo is [2.96](https://sourceforge.net/projects/gbdk
 # Usage
 Most users will only need to download and unzip the latest [release](https://github.com/gbdk-2020/gbdk-2020/releases)
 
-Then go to the examples folder and build them (with make.bat on windows or running make). They are a good starting point.
+Then go to the examples folder and build them (with compile.bat on windows or running make). They are a good starting point.
 
 ## Discord servers
 * [gbdk/zgb Discord](https://discord.gg/XCbjCvqnUY) - For help with using GBDK (and ZGB), discussion and development of gbdk-2020

--- a/docs/pages/01_getting_started.md
+++ b/docs/pages/01_getting_started.md
@@ -26,7 +26,7 @@ There are template projects included in the @ref docs_example_programs "GBDK exa
 
 1. Copy one of the template folders to a new folder name
 
-2. If you moved the folder out of the GBDK examples then you __must__ update the `GBDK` path variable and/or the path to `LCC` in the `Makefile` or `make.bat` so that it will still build correctly.
+2. If you moved the folder out of the GBDK examples then you __must__ update the `GBDK` path variable and/or the path to `LCC` in the `Makefile` or `compile.bat` so that it will still build correctly.
 
 3. Type `make` on the command line in that folder to verify it still builds.
 

--- a/gbdk-lib/examples/ap/Makefile
+++ b/gbdk-lib/examples/ap/Makefile
@@ -2,7 +2,7 @@
 SUBDIRS := $(wildcard */.)
 
 # Top-level phony targets.
-all clean make.bat: $(SUBDIRS) FORCE
+all clean compile.bat: $(SUBDIRS) FORCE
 # Similar to:
 # .PHONY: all clean
 # all clean: $(SUBDIRS)

--- a/gbdk-lib/examples/ap/Makefile.rgbds
+++ b/gbdk-lib/examples/ap/Makefile.rgbds
@@ -22,8 +22,8 @@ OTHER = sound.gb \
 
 all:	$(BINS)
 
-make.bat: Makefile
-	make -sn | sed y/\\//\\\\/ | grep -v make > make.bat
+compile.bat: Makefile
+	make -sn | sed y/\\//\\\\/ | grep -v make > compile.bat
 
 %.o:	%.s
 

--- a/gbdk-lib/examples/ap/banks/Makefile
+++ b/gbdk-lib/examples/ap/banks/Makefile
@@ -4,9 +4,9 @@ BINS	= banks.pocket \
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/ap/banks_autobank/Makefile
+++ b/gbdk-lib/examples/ap/banks_autobank/Makefile
@@ -13,9 +13,9 @@ OBJS       = $(CSOURCES:%.c=%.o) $(ASMSOURCES:%.c=%.o)
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(LCC) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/ap/banks_farptr/Makefile
+++ b/gbdk-lib/examples/ap/banks_farptr/Makefile
@@ -4,9 +4,9 @@ BINS	= banks_farptr.pocket \
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/ap/banks_nonintrinsic/Makefile
+++ b/gbdk-lib/examples/ap/banks_nonintrinsic/Makefile
@@ -5,9 +5,9 @@ BINS	= banks_nonintrinsic.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/ap/bcd/Makefile
+++ b/gbdk-lib/examples/ap/bcd/Makefile
@@ -4,9 +4,9 @@ BINS	= bcd.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/bgb_debug/Makefile
+++ b/gbdk-lib/examples/ap/bgb_debug/Makefile
@@ -4,9 +4,9 @@ BINS	= bgb_debug.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/colorbar/Makefile
+++ b/gbdk-lib/examples/ap/colorbar/Makefile
@@ -6,9 +6,9 @@ BINS	= colorbar.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/ap/comm/Makefile
+++ b/gbdk-lib/examples/ap/comm/Makefile
@@ -4,9 +4,9 @@ BINS	= comm.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/crash/Makefile
+++ b/gbdk-lib/examples/ap/crash/Makefile
@@ -4,9 +4,9 @@ BINS	= crash.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/dscan/Makefile
+++ b/gbdk-lib/examples/ap/dscan/Makefile
@@ -4,9 +4,9 @@ BINS	= dscan.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/ap/filltest/Makefile
+++ b/gbdk-lib/examples/ap/filltest/Makefile
@@ -4,9 +4,9 @@ BINS	= filltest.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/fonts/Makefile
+++ b/gbdk-lib/examples/ap/fonts/Makefile
@@ -4,9 +4,9 @@ BINS	= fonts.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/galaxy/Makefile
+++ b/gbdk-lib/examples/ap/galaxy/Makefile
@@ -4,9 +4,9 @@ BINS	= galaxy.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/gb-dtmf/Makefile
+++ b/gbdk-lib/examples/ap/gb-dtmf/Makefile
@@ -4,9 +4,9 @@ BINS	= gb-dtmf.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.s:	%.c
 	$(CC) -S -o $@ $<

--- a/gbdk-lib/examples/ap/gbdecompress/Makefile
+++ b/gbdk-lib/examples/ap/gbdecompress/Makefile
@@ -20,9 +20,9 @@ ASMSOURCES := $(wildcard *.s)
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link all source files in a single call to LCC
 $(BINS): $(CSOURCES) $(ASMSOURCES)

--- a/gbdk-lib/examples/ap/incbin/Makefile
+++ b/gbdk-lib/examples/ap/incbin/Makefile
@@ -26,9 +26,9 @@ OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 
 all:	prepare $(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/ap/irq/Makefile
+++ b/gbdk-lib/examples/ap/irq/Makefile
@@ -4,9 +4,9 @@ BINS	= irq.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/large_map/Makefile
+++ b/gbdk-lib/examples/ap/large_map/Makefile
@@ -3,9 +3,9 @@ CC	= ../../../bin/lcc -mgbz80:ap -Wl-j -Wm-yS
 all:
 	$(CC) -o large_map.pocket large_map.c bigmap_map.c bigmap_tiles.c
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 clean:
 	rm -f *.o *.lst *.map *.pocket *.ihx *.sym *.cdb *.adb *.asm

--- a/gbdk-lib/examples/ap/lcd_isr_wobble/Makefile
+++ b/gbdk-lib/examples/ap/lcd_isr_wobble/Makefile
@@ -4,9 +4,9 @@ BINS	= lcd_isr_wobble.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/linkerfile/Makefile
+++ b/gbdk-lib/examples/ap/linkerfile/Makefile
@@ -28,9 +28,9 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 
 all:	prepare $(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/ap/metasprites/Makefile
+++ b/gbdk-lib/examples/ap/metasprites/Makefile
@@ -16,9 +16,9 @@ CSOURCES    = $(filter-out $(PNGSOURCES:%.png=%.c), $(wildcard *.c))
 
 all: $(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Use png2mtspr to convert the png into C formatted metasprite data
 # -sh 48   : Sets sprite height to 48 (width remains automatic)

--- a/gbdk-lib/examples/ap/paint/Makefile
+++ b/gbdk-lib/examples/ap/paint/Makefile
@@ -4,9 +4,9 @@ BINS	= paint.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/ram_function/Makefile
+++ b/gbdk-lib/examples/ap/ram_function/Makefile
@@ -4,9 +4,9 @@ BINS	= ram_fn.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/ap/rand/Makefile
+++ b/gbdk-lib/examples/ap/rand/Makefile
@@ -4,9 +4,9 @@ BINS	= rand.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/rpn/Makefile
+++ b/gbdk-lib/examples/ap/rpn/Makefile
@@ -4,9 +4,9 @@ BINS	= rpn.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/samptest/Makefile
+++ b/gbdk-lib/examples/ap/samptest/Makefile
@@ -4,9 +4,9 @@ BINS	= samptest.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/scroller/Makefile
+++ b/gbdk-lib/examples/ap/scroller/Makefile
@@ -4,9 +4,9 @@ BINS	= text_scroller.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/sgb_border/Makefile
+++ b/gbdk-lib/examples/ap/sgb_border/Makefile
@@ -3,9 +3,9 @@ CC	= ../../../bin/lcc
 all:
 	$(CC) -mgbz80:ap -Wl-j -Wm-yS -Wm-ys -o border.pocket border.c sgb_border.c border_data.c
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 clean:
 	rm -f *.o *.lst *.map *.pocket *.ihx *.sym *.cdb *.adb *.asm

--- a/gbdk-lib/examples/ap/sgb_multiplayer/Makefile
+++ b/gbdk-lib/examples/ap/sgb_multiplayer/Makefile
@@ -4,9 +4,9 @@ BINS	= sgb_multiplayer.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/sgb_pong/Makefile
+++ b/gbdk-lib/examples/ap/sgb_pong/Makefile
@@ -4,9 +4,9 @@ BINS	= sgb_pong.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/sound/Makefile
+++ b/gbdk-lib/examples/ap/sound/Makefile
@@ -4,9 +4,9 @@ BINS	= sound.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/space/Makefile
+++ b/gbdk-lib/examples/ap/space/Makefile
@@ -5,9 +5,9 @@ BINS	= space.pocket
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.s

--- a/gbdk-lib/examples/ap/template_minimal/Makefile
+++ b/gbdk-lib/examples/ap/template_minimal/Makefile
@@ -20,9 +20,9 @@ ASMSOURCES := $(wildcard *.s)
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link all source files in a single call to LCC
 $(BINS):	$(CSOURCES) $(ASMSOURCES)

--- a/gbdk-lib/examples/ap/template_subfolders/Makefile
+++ b/gbdk-lib/examples/ap/template_subfolders/Makefile
@@ -27,9 +27,9 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 
 all:	prepare $(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/broken/fprpn/Makefile
+++ b/gbdk-lib/examples/broken/fprpn/Makefile
@@ -6,10 +6,10 @@ BINS =
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
 # Disabled building this for now since it's broken
-# @make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+# @make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/Makefile
+++ b/gbdk-lib/examples/gb/Makefile
@@ -2,7 +2,7 @@
 SUBDIRS := $(wildcard */.)
 
 # Top-level phony targets.
-all clean make.bat: $(SUBDIRS) FORCE
+all clean compile.bat: $(SUBDIRS) FORCE
 # Similar to:
 # .PHONY: all clean
 # all clean: $(SUBDIRS)

--- a/gbdk-lib/examples/gb/Makefile.rgbds
+++ b/gbdk-lib/examples/gb/Makefile.rgbds
@@ -22,8 +22,8 @@ OTHER = sound.gb \
 
 all:	$(BINS)
 
-make.bat: Makefile
-	make -sn | sed y/\\//\\\\/ | grep -v make > make.bat
+compile.bat: Makefile
+	make -sn | sed y/\\//\\\\/ | grep -v make > compile.bat
 
 %.o:	%.s
 

--- a/gbdk-lib/examples/gb/banks/Makefile
+++ b/gbdk-lib/examples/gb/banks/Makefile
@@ -4,9 +4,9 @@ BINS	= banks.gb \
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/gb/banks_autobank/Makefile
+++ b/gbdk-lib/examples/gb/banks_autobank/Makefile
@@ -13,9 +13,9 @@ OBJS       = $(CSOURCES:%.c=%.o) $(ASMSOURCES:%.c=%.o)
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(LCC) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/gb/banks_farptr/Makefile
+++ b/gbdk-lib/examples/gb/banks_farptr/Makefile
@@ -4,9 +4,9 @@ BINS	= banks_farptr.gb \
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/gb/banks_nonintrinsic/Makefile
+++ b/gbdk-lib/examples/gb/banks_nonintrinsic/Makefile
@@ -5,9 +5,9 @@ BINS	= banks_nonintrinsic.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/gb/bcd/Makefile
+++ b/gbdk-lib/examples/gb/bcd/Makefile
@@ -4,9 +4,9 @@ BINS	= bcd.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/bgb_debug/Makefile
+++ b/gbdk-lib/examples/gb/bgb_debug/Makefile
@@ -4,9 +4,9 @@ BINS	= bgb_debug.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/colorbar/Makefile
+++ b/gbdk-lib/examples/gb/colorbar/Makefile
@@ -6,9 +6,9 @@ BINS	= colorbar.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/gb/comm/Makefile
+++ b/gbdk-lib/examples/gb/comm/Makefile
@@ -4,9 +4,9 @@ BINS	= comm.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/crash/Makefile
+++ b/gbdk-lib/examples/gb/crash/Makefile
@@ -4,9 +4,9 @@ BINS	= crash.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/dscan/Makefile
+++ b/gbdk-lib/examples/gb/dscan/Makefile
@@ -4,9 +4,9 @@ BINS	= dscan.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/gb/filltest/Makefile
+++ b/gbdk-lib/examples/gb/filltest/Makefile
@@ -4,9 +4,9 @@ BINS	= filltest.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/fonts/Makefile
+++ b/gbdk-lib/examples/gb/fonts/Makefile
@@ -4,9 +4,9 @@ BINS	= fonts.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/galaxy/Makefile
+++ b/gbdk-lib/examples/gb/galaxy/Makefile
@@ -4,9 +4,9 @@ BINS	= galaxy.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/gb-dtmf/Makefile
+++ b/gbdk-lib/examples/gb/gb-dtmf/Makefile
@@ -4,9 +4,9 @@ BINS	= gb-dtmf.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.s:	%.c
 	$(CC) -S -o $@ $<

--- a/gbdk-lib/examples/gb/gbdecompress/Makefile
+++ b/gbdk-lib/examples/gb/gbdecompress/Makefile
@@ -20,9 +20,9 @@ ASMSOURCES := $(wildcard *.s)
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link all source files in a single call to LCC
 $(BINS): $(CSOURCES) $(ASMSOURCES)

--- a/gbdk-lib/examples/gb/incbin/Makefile
+++ b/gbdk-lib/examples/gb/incbin/Makefile
@@ -26,9 +26,9 @@ OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 
 all:	prepare $(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/gb/irq/Makefile
+++ b/gbdk-lib/examples/gb/irq/Makefile
@@ -4,9 +4,9 @@ BINS	= irq.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/large_map/Makefile
+++ b/gbdk-lib/examples/gb/large_map/Makefile
@@ -3,9 +3,9 @@ CC	= ../../../bin/lcc
 all:
 	$(CC) -o large_map.gb large_map.c bigmap_map.c bigmap_tiles.c
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 clean:
 	rm -f *.o *.lst *.map *.gb *.ihx *.sym *.cdb *.adb *.asm

--- a/gbdk-lib/examples/gb/lcd_isr_wobble/Makefile
+++ b/gbdk-lib/examples/gb/lcd_isr_wobble/Makefile
@@ -4,9 +4,9 @@ BINS	= lcd_isr_wobble.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/linkerfile/Makefile
+++ b/gbdk-lib/examples/gb/linkerfile/Makefile
@@ -27,9 +27,9 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 
 all:	prepare $(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/gb/metasprites/Makefile
+++ b/gbdk-lib/examples/gb/metasprites/Makefile
@@ -16,9 +16,9 @@ CSOURCES    = $(filter-out $(PNGSOURCES:%.png=%.c), $(wildcard *.c))
 
 all: $(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Use png2mtspr to convert the png into C formatted metasprite data
 # -sh 48   : Sets sprite height to 48 (width remains automatic)

--- a/gbdk-lib/examples/gb/paint/Makefile
+++ b/gbdk-lib/examples/gb/paint/Makefile
@@ -4,9 +4,9 @@ BINS	= paint.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/ram_function/Makefile
+++ b/gbdk-lib/examples/gb/ram_function/Makefile
@@ -4,9 +4,9 @@ BINS	= ram_fn.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/gb/rand/Makefile
+++ b/gbdk-lib/examples/gb/rand/Makefile
@@ -4,9 +4,9 @@ BINS	= rand.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/rpn/Makefile
+++ b/gbdk-lib/examples/gb/rpn/Makefile
@@ -4,9 +4,9 @@ BINS	= rpn.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/samptest/Makefile
+++ b/gbdk-lib/examples/gb/samptest/Makefile
@@ -4,9 +4,9 @@ BINS	= samptest.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/scroller/Makefile
+++ b/gbdk-lib/examples/gb/scroller/Makefile
@@ -4,9 +4,9 @@ BINS	= text_scroller.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/sgb_border/Makefile
+++ b/gbdk-lib/examples/gb/sgb_border/Makefile
@@ -3,9 +3,9 @@ CC	= ../../../bin/lcc
 all:
 	$(CC) -Wm-ys -o border.gb border.c sgb_border.c border_data.c
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 clean:
 	rm -f *.o *.lst *.map *.gb *.ihx *.sym *.cdb *.adb *.asm

--- a/gbdk-lib/examples/gb/sgb_multiplayer/Makefile
+++ b/gbdk-lib/examples/gb/sgb_multiplayer/Makefile
@@ -4,9 +4,9 @@ BINS	= sgb_multiplayer.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/sgb_pong/Makefile
+++ b/gbdk-lib/examples/gb/sgb_pong/Makefile
@@ -4,9 +4,9 @@ BINS	= sgb_pong.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/simple_physics/Makefile
+++ b/gbdk-lib/examples/gb/simple_physics/Makefile
@@ -4,9 +4,9 @@ BINS	= phys.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/sound/Makefile
+++ b/gbdk-lib/examples/gb/sound/Makefile
@@ -4,9 +4,9 @@ BINS	= sound.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/space/Makefile
+++ b/gbdk-lib/examples/gb/space/Makefile
@@ -6,9 +6,9 @@ BINS	= space.gb
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.s

--- a/gbdk-lib/examples/gb/template_minimal/Makefile
+++ b/gbdk-lib/examples/gb/template_minimal/Makefile
@@ -20,9 +20,9 @@ ASMSOURCES := $(wildcard *.s)
 
 all:	$(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link all source files in a single call to LCC
 $(BINS):	$(CSOURCES) $(ASMSOURCES)

--- a/gbdk-lib/examples/gb/template_subfolders/Makefile
+++ b/gbdk-lib/examples/gb/template_subfolders/Makefile
@@ -26,9 +26,9 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 
 all:	prepare $(BINS)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/gg/Makefile
+++ b/gbdk-lib/examples/gg/Makefile
@@ -2,7 +2,7 @@
 SUBDIRS := $(wildcard */.)
 
 # Top-level phony targets.
-all clean make.bat: $(SUBDIRS) FORCE
+all clean compile.bat: $(SUBDIRS) FORCE
 # Similar to:
 # .PHONY: all clean
 # all clean: $(SUBDIRS)

--- a/gbdk-lib/examples/gg/smoke/Makefile
+++ b/gbdk-lib/examples/gg/smoke/Makefile
@@ -5,13 +5,13 @@ BINS	= smoketest.gg
 all:	$(BINS)
 
 ASRC = $(wildcard *.s)
-CSRC = $(wildcard *.c) 
+CSRC = $(wildcard *.c)
 
 OBJS = $(CSRC:%.c=%.o) $(ASRC:%.s=%.o)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 

--- a/gbdk-lib/examples/sms/Makefile
+++ b/gbdk-lib/examples/sms/Makefile
@@ -2,7 +2,7 @@
 SUBDIRS := $(wildcard */.)
 
 # Top-level phony targets.
-all clean make.bat: $(SUBDIRS) FORCE
+all clean compile.bat: $(SUBDIRS) FORCE
 # Similar to:
 # .PHONY: all clean
 # all clean: $(SUBDIRS)

--- a/gbdk-lib/examples/sms/smoke/Makefile
+++ b/gbdk-lib/examples/sms/smoke/Makefile
@@ -9,9 +9,9 @@ CSRC = $(wildcard *.c)
 
 OBJS = $(CSRC:%.c=%.o) $(ASRC:%.s=%.o)
 
-make.bat: Makefile
-	@echo "REM Automatically generated from Makefile" > make.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> make.bat
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 

--- a/gbdk-support/README
+++ b/gbdk-support/README
@@ -27,10 +27,10 @@ Setup:
 * Recommended but not required: Add the gbdk 'bin' sub-directory to your
   system path using the Windows System control panel
 
-* Open a command line and compile the examples by running "make.bat" in 
+* Open a command line and compile the examples by running "compile.bat" in
   the "examples\gb" sub-directory:
     cd c:\gbdk\examples\gb
-    make.bat
+    compile.bat
 
 
 === Linux ===
@@ -42,7 +42,7 @@ Setup:
     Run from command line (only lasts for that session): export GBDKDIR=/opt/gbdk
     Or add that to your shell defaults (permanent)
 
-* Open a command line and compile the examples by running "make.bat" in 
+* Open a command line and compile the examples by running "make" in
   the "examples\gb" sub-directory:
     cd /opt/gbdk/examples/gb
     make


### PR DESCRIPTION
Avoids conflict between `make.bat` and `make` on windows

* Tested on Windows, seems ok