### PR TITLE
Bankpack: Add -random for sparse random bank assignment

### DIFF
--- a/gbdk-support/bankpack/bankpack.c
+++ b/gbdk-support/bankpack/bankpack.c
@@ -8,6 +8,8 @@
 // #include <unistd.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <time.h>
+
 #include "obj_data.h"
 #include "files.h"
 
@@ -42,6 +44,7 @@ static void display_help(void) {
        "               Default entry is \"___bank_\" (see below)\n"
        "-cartsize    : Print min required cart size as \"autocartsize:<NNN>\"\n"
        "-plat=<plat> : Select platform specific behavior (default:gb) (gb,sms)\n"
+       "-random      : Distribute banks randomly for testing (honors -min/-max)\n"
        "-v           : Verbose output, show assignments\n"
        "\n"
        "Example: \"bankpack -ext=.rel -path=some/newpath/ file1.o file2.o\"\n"
@@ -100,6 +103,8 @@ static int handle_args(int argc, char * argv[]) {
                 g_option_cartsize = true;
             } else if (strstr(argv[i], "-plat=") == argv[i]) {
                 banks_set_platform(argv[i] + 6);
+            } else if (strstr(argv[i], "-random") == argv[i]) {
+                banks_set_random(true);
             } else
                 printf("BankPack: Warning: Ignoring unknown option %s\n", argv[i]);
         } else {
@@ -123,6 +128,7 @@ static int matches_extension(char * filename, char * extension) {
 
 
 static void init(void) {
+    srand( time(0) );
     files_init();
     obj_data_init();
 }

--- a/gbdk-support/bankpack/common.h
+++ b/gbdk-support/bankpack/common.h
@@ -25,6 +25,8 @@ enum {
 #define BANK_ROM_CALC_MAX     512 // Banks 0-512 (>256 not supported for auto-banking right now)
 #define BANK_SIZE_ROM         0x4000U
 
+#define BANK_ITEM_COUNT_MAX 0xFFFF
+
 #define BANK_NUM_ROM_MAX_MBC1  127
 #define BANK_NUM_ROM_MAX_MBC2  15
 #define BANK_NUM_ROM_MAX_MBC3  127

--- a/gbdk-support/bankpack/obj_data.h
+++ b/gbdk-support/bankpack/obj_data.h
@@ -30,6 +30,7 @@ typedef struct bank_item {
     uint32_t size;
     uint32_t free;
     uint32_t type;
+    uint16_t item_count;
 } bank_item;
 
 
@@ -64,6 +65,8 @@ uint32_t banks_calc_cart_size(void);
 
 bool banks_set_min(uint16_t bank_num);
 bool banks_set_max(uint16_t bank_num);
+
+void banks_set_random(bool is_random);
 
 void obj_data_init(void);
 void obj_data_cleanup(void);


### PR DESCRIPTION
- Distributes banks randomly and sparsely as possible to help reveal hidden bank problems and assumptions
- Also Fix scenario where MBC flag was overriding -max bank setting