### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/pages/04_coding_guidelines.md
+++ b/docs/pages/04_coding_guidelines.md
@@ -78,7 +78,7 @@ If you wish to use the original tools, you must add the `const` keyword every ti
 
   - Instead of using a blocking @ref delay() for things such as sprite animations/etc (which can prevent the rest of the game from continuing) many times it's better to use a counter which performs an action once every N frames. @ref sys_time may be useful in these cases.
 
-  - When procesing for a given frame is done and it is time to wait before starting the next frame, @ref wait_vbl_done() can be used. It uses HALT to put the CPU into a low power state until processing resumes. The CPU will wake up and resume processing at the end of the current frame when the Vertical Blanking interrupt is triggered.
+  - When processing for a given frame is done and it is time to wait before starting the next frame, @ref wait_vbl_done() can be used. It uses HALT to put the CPU into a low power state until processing resumes. The CPU will wake up and resume processing at the end of the current frame when the Vertical Blanking interrupt is triggered.
 
   - Minimize use of multiplication, modulo with non-powers of 2, and division with non-powers of 2. These operations have no corresponding CPU instructions (software functions), and hence are time costly.
       - SDCC has some optimizations for:

--- a/docs/pages/docs_index.md
+++ b/docs/pages/docs_index.md
@@ -42,7 +42,7 @@ GBDK is freeware. Most of the tooling code is under the GPL. The runtime librari
 
 # Historical Info and Links
 
-The following is from the original GBDK documenation.
+The following is from the original GBDK documentation.
 
 Thanks to quang for many of the comments to the gb functions.  Some
 of the comments are ripped directly from the Linux Programmers

--- a/gbdk-lib/examples/ap/gb-dtmf/gb-dtmf.c
+++ b/gbdk-lib/examples/ap/gb-dtmf/gb-dtmf.c
@@ -69,7 +69,7 @@
 	Frequency setting
 */
 /*
-	We have to calculate the frequency as followin formula
+	We have to calculate the frequency as following formula
 
 	DTMF has two set frequency, we have to decide Row & Column
 	with each digit('0','1','2'...)

--- a/gbdk-lib/examples/ap/metasprites/metasprites.c
+++ b/gbdk-lib/examples/ap/metasprites/metasprites.c
@@ -111,7 +111,7 @@ void main(void) {
 	
 		// NOTE: In a real game it would be better to only call the move_metasprite..()
         //       functions if something changed (such as movement or rotation). That
-		//	     reduces CPU usage on frames that don't need udpates.
+		//	     reduces CPU usage on frames that don't need updates.
 		//
 		// In this example they are called every frame to simplify the example code
 

--- a/gbdk-lib/examples/gb/gb-dtmf/gb-dtmf.c
+++ b/gbdk-lib/examples/gb/gb-dtmf/gb-dtmf.c
@@ -69,7 +69,7 @@
 	Frequency setting
 */
 /*
-	We have to calculate the frequency as followin formula
+	We have to calculate the frequency as following formula
 
 	DTMF has two set frequency, we have to decide Row & Column
 	with each digit('0','1','2'...)

--- a/gbdk-lib/examples/gb/metasprites/metasprites.c
+++ b/gbdk-lib/examples/gb/metasprites/metasprites.c
@@ -111,7 +111,7 @@ void main(void) {
 	
 		// NOTE: In a real game it would be better to only call the move_metasprite..()
         //       functions if something changed (such as movement or rotation). That
-		//	     reduces CPU usage on frames that don't need udpates.
+		//	     reduces CPU usage on frames that don't need updates.
 		//
 		// In this example they are called every frame to simplify the example code
 

--- a/gbdk-lib/examples/gg/metasprites/metasprites.c
+++ b/gbdk-lib/examples/gg/metasprites/metasprites.c
@@ -108,7 +108,7 @@ void main(void) {
 	
 		// NOTE: In a real game it would be better to only call the move_metasprite..()
         //       functions if something changed (such as movement or rotation). That
-		//	     reduces CPU usage on frames that don't need udpates.
+		//	     reduces CPU usage on frames that don't need updates.
 		//
 		// In this example they are called every frame to simplify the example code
 

--- a/gbdk-lib/examples/sms/metasprites/metasprites.c
+++ b/gbdk-lib/examples/sms/metasprites/metasprites.c
@@ -108,7 +108,7 @@ void main(void) {
 	
 		// NOTE: In a real game it would be better to only call the move_metasprite..()
         //       functions if something changed (such as movement or rotation). That
-		//	     reduces CPU usage on frames that don't need udpates.
+		//	     reduces CPU usage on frames that don't need updates.
 		//
 		// In this example they are called every frame to simplify the example code
 

--- a/gbdk-lib/libc/time.c
+++ b/gbdk-lib/libc/time.c
@@ -1,6 +1,6 @@
 /*
   time.c
-  Simple, not completly conformant implementation of time routines
+  Simple, not completely conformant implementation of time routines
 */
 
 #include <stdint.h>

--- a/gbdk-support/gbcompress/gbcompress.c
+++ b/gbdk-support/gbcompress/gbcompress.c
@@ -35,7 +35,7 @@ static void check_write_size(uint8_t len) {
     if ((FoutIndex + len) >= Fsize_out) {
         uint8_t * p_tmp = *pp_FoutBuf;
 
-        // Reallocate to twice as larege
+        // Reallocate to twice as large
         Fsize_out = Fsize_out * 2;
         *pp_FoutBuf = (void *)realloc(*pp_FoutBuf, Fsize_out);
 


### PR DESCRIPTION
There are small typos in:
- docs/pages/04_coding_guidelines.md
- docs/pages/docs_index.md
- gbdk-lib/examples/ap/gb-dtmf/gb-dtmf.c
- gbdk-lib/examples/ap/metasprites/metasprites.c
- gbdk-lib/examples/gb/gb-dtmf/gb-dtmf.c
- gbdk-lib/examples/gb/metasprites/metasprites.c
- gbdk-lib/examples/gg/metasprites/metasprites.c
- gbdk-lib/examples/sms/metasprites/metasprites.c
- gbdk-lib/libc/time.c
- gbdk-support/gbcompress/gbcompress.c

Fixes:
- Should read `updates` rather than `udpates`.
- Should read `following` rather than `followin`.
- Should read `processing` rather than `procesing`.
- Should read `large` rather than `larege`.
- Should read `documentation` rather than `documenation`.
- Should read `completely` rather than `completly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md