### PR TITLE
Examples: cross-platform: Some improvements

### DIFF
--- a/gbdk-lib/examples/cross-platform/banks_autobank/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_autobank/Makefile
@@ -1,21 +1,28 @@
-# Note: "override" ensures that appending to the variables still works if the variable was set from the command line
-#
-# If you move this project you can change the directory 
+# If you move this project you can change the directory
 # to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
 GBDK_HOME = ../../../
-LCC = $(GBDK_HOME)bin/lcc 
+LCC = $(GBDK_HOME)bin/lcc
 
-# Set platforms to build here (spaced separated). Possible are: gb gbc pocket sms gg
-# These are found in the separate Makefile.targets
+# Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
+# They can also be built/cleaned individually: "make gg" and "make gg-clean"
+# Possible are: gb gbc pocket sms gg
 TARGETS=gb pocket sms gg
 
-# MBC + Autobanking related flags
-override LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v
-# override LCCFLAGS += -debug # Uncomment to enable debug output
-# override LCCFLAGS += -v     # Uncomment for lcc verbose output
+# Configure platform specific LCC flags here:
+LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wl-yt0x1B # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_sms     =
+LCCFLAGS_gg      =
+
+LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
+
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+# LCCFLAGS += -debug # Uncomment to enable debug output
+# LCCFLAGS += -v     # Uncomment for lcc verbose output
 
 # You can set the name of the ROM file here
-PROJECTNAME = Example
+PROJECTNAME = banks_autobank
 
 # EXT?=gb # Only sets extension to default (game boy .gb) if not populated
 SRCDIR      = src
@@ -50,9 +57,7 @@ $(OBJDIR)/%.s:	$(SRCDIR)/%.c
 	$(LCC) $(CFLAGS) -S -o $@ $<
 
 # Link the compiled object files into a .gb ROM file
-# Then copy the ROM into a binary directory
 $(BINS):	$(OBJS)
-	@echo $(LCCFLAGS)
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -o $(BINDIR)/$(PROJECTNAME).$(EXT) $(OBJS)
 
 clean:
@@ -60,9 +65,6 @@ clean:
 	@for target in $(TARGETS); do \
 		$(MAKE) $$target-clean; \
 	done
-
-cleanbin:
-	rm -f  $(BINDIR)/*.*
 
 # Include available build targets
 include Makefile.targets

--- a/gbdk-lib/examples/cross-platform/banks_autobank/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/banks_autobank/Makefile.targets
@@ -2,7 +2,7 @@
 # Platform specific flags for compiling (only populate if they're both present)
 ifneq ($(strip $(PORT)),)
 ifneq ($(strip $(PLAT)),)
-override CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
+CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
 endif
 endif
 
@@ -16,20 +16,19 @@ clean-target:
 gb-clean:
 	${MAKE} clean-target EXT=gb
 gb:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=gb EXT=gb
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gb
 
-# GB & GBC:      -Wm-yc
-# GBC Exclusive: -Wm-yC
+
 gbc-clean:
 	${MAKE} clean-target EXT=gbc
 gbc:
-	${MAKE} build-target LCCFLAGS="-Wl-yt0x1B -Wm-yC" PORT=gbz80 PLAT=gb EXT=gbc
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gbc
 
 
 pocket-clean:
 	${MAKE} clean-target EXT=pocket
 pocket:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=ap EXT=pocket
+	${MAKE} build-target PORT=gbz80 PLAT=ap EXT=pocket
 
 
 sms-clean:

--- a/gbdk-lib/examples/cross-platform/banks_farptr/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_farptr/Makefile
@@ -1,21 +1,28 @@
-# Note: "override" ensures that appending to the variables still works if the variable was set from the command line
-#
-# If you move this project you can change the directory 
+# If you move this project you can change the directory
 # to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
 GBDK_HOME = ../../../
-LCC = $(GBDK_HOME)bin/lcc 
+LCC = $(GBDK_HOME)bin/lcc
 
-# Set platforms to build here (spaced separated). Possible are: gb gbc pocket sms gg
-# These are found in the separate Makefile.targets
+# Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
+# They can also be built/cleaned individually: "make gg" and "make gg-clean"
+# Possible are: gb gbc pocket sms gg
 TARGETS=gb pocket sms gg
 
-# MBC + Autobanking related flags
-override LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v
-# override LCCFLAGS += -debug # Uncomment to enable debug output
-# override LCCFLAGS += -v     # Uncomment for lcc verbose output
+# Configure platform specific LCC flags here:
+LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wl-yt0x1B # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_sms     =
+LCCFLAGS_gg      =
+
+LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
+
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+# LCCFLAGS += -debug # Uncomment to enable debug output
+# LCCFLAGS += -v     # Uncomment for lcc verbose output
 
 # You can set the name of the ROM file here
-PROJECTNAME = Example
+PROJECTNAME = banks_farptr
 
 # EXT?=gb # Only sets extension to default (game boy .gb) if not populated
 SRCDIR      = src
@@ -50,9 +57,7 @@ $(OBJDIR)/%.s:	$(SRCDIR)/%.c
 	$(LCC) $(CFLAGS) -S -o $@ $<
 
 # Link the compiled object files into a .gb ROM file
-# Then copy the ROM into a binary directory
 $(BINS):	$(OBJS)
-	@echo $(LCCFLAGS)
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -o $(BINDIR)/$(PROJECTNAME).$(EXT) $(OBJS)
 
 clean:
@@ -60,9 +65,6 @@ clean:
 	@for target in $(TARGETS); do \
 		$(MAKE) $$target-clean; \
 	done
-
-cleanbin:
-	rm -f  $(BINDIR)/*.*
 
 # Include available build targets
 include Makefile.targets

--- a/gbdk-lib/examples/cross-platform/banks_farptr/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/banks_farptr/Makefile.targets
@@ -2,7 +2,7 @@
 # Platform specific flags for compiling (only populate if they're both present)
 ifneq ($(strip $(PORT)),)
 ifneq ($(strip $(PLAT)),)
-override CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
+CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
 endif
 endif
 
@@ -16,20 +16,19 @@ clean-target:
 gb-clean:
 	${MAKE} clean-target EXT=gb
 gb:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=gb EXT=gb
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gb
 
-# GB & GBC:      -Wm-yc
-# GBC Exclusive: -Wm-yC
+
 gbc-clean:
 	${MAKE} clean-target EXT=gbc
 gbc:
-	${MAKE} build-target LCCFLAGS="-Wl-yt0x1B -Wm-yC" PORT=gbz80 PLAT=gb EXT=gbc
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gbc
 
 
 pocket-clean:
 	${MAKE} clean-target EXT=pocket
 pocket:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=ap EXT=pocket
+	${MAKE} build-target PORT=gbz80 PLAT=ap EXT=pocket
 
 
 sms-clean:

--- a/gbdk-lib/examples/cross-platform/banks_nonintrinsic/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_nonintrinsic/Makefile
@@ -1,21 +1,28 @@
-# Note: "override" ensures that appending to the variables still works if the variable was set from the command line
-#
-# If you move this project you can change the directory 
+# If you move this project you can change the directory
 # to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
 GBDK_HOME = ../../../
-LCC = $(GBDK_HOME)bin/lcc 
+LCC = $(GBDK_HOME)bin/lcc
 
-# Set platforms to build here (spaced separated). Possible are: gb gbc pocket sms gg
-# These are found in the separate Makefile.targets
+# Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
+# They can also be built/cleaned individually: "make gg" and "make gg-clean"
+# Possible are: gb gbc pocket sms gg
 TARGETS=gb pocket sms gg
 
-# MBC + Autobanking related flags
-override LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v
-# override LCCFLAGS += -debug # Uncomment to enable debug output
-# override LCCFLAGS += -v     # Uncomment for lcc verbose output
+# Configure platform specific LCC flags here:
+LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wl-yt0x1B # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_sms     =
+LCCFLAGS_gg      =
+
+LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
+
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+# LCCFLAGS += -debug # Uncomment to enable debug output
+# LCCFLAGS += -v     # Uncomment for lcc verbose output
 
 # You can set the name of the ROM file here
-PROJECTNAME = Example
+PROJECTNAME = banks_nonintrinsic
 
 # EXT?=gb # Only sets extension to default (game boy .gb) if not populated
 SRCDIR      = src
@@ -50,9 +57,7 @@ $(OBJDIR)/%.s:	$(SRCDIR)/%.c
 	$(LCC) $(CFLAGS) -S -o $@ $<
 
 # Link the compiled object files into a .gb ROM file
-# Then copy the ROM into a binary directory
 $(BINS):	$(OBJS)
-	@echo $(LCCFLAGS)
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -o $(BINDIR)/$(PROJECTNAME).$(EXT) $(OBJS)
 
 clean:
@@ -60,9 +65,6 @@ clean:
 	@for target in $(TARGETS); do \
 		$(MAKE) $$target-clean; \
 	done
-
-cleanbin:
-	rm -f  $(BINDIR)/*.*
 
 # Include available build targets
 include Makefile.targets

--- a/gbdk-lib/examples/cross-platform/banks_nonintrinsic/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/banks_nonintrinsic/Makefile.targets
@@ -2,7 +2,7 @@
 # Platform specific flags for compiling (only populate if they're both present)
 ifneq ($(strip $(PORT)),)
 ifneq ($(strip $(PLAT)),)
-override CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
+CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
 endif
 endif
 
@@ -16,20 +16,19 @@ clean-target:
 gb-clean:
 	${MAKE} clean-target EXT=gb
 gb:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=gb EXT=gb
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gb
 
-# GB & GBC:      -Wm-yc
-# GBC Exclusive: -Wm-yC
+
 gbc-clean:
 	${MAKE} clean-target EXT=gbc
 gbc:
-	${MAKE} build-target LCCFLAGS="-Wl-yt0x1B -Wm-yC" PORT=gbz80 PLAT=gb EXT=gbc
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gbc
 
 
 pocket-clean:
 	${MAKE} clean-target EXT=pocket
 pocket:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=ap EXT=pocket
+	${MAKE} build-target PORT=gbz80 PLAT=ap EXT=pocket
 
 
 sms-clean:

--- a/gbdk-lib/examples/cross-platform/fonts/Makefile
+++ b/gbdk-lib/examples/cross-platform/fonts/Makefile
@@ -1,21 +1,28 @@
-# Note: "override" ensures that appending to the variables still works if the variable was set from the command line
-#
-# If you move this project you can change the directory 
+# If you move this project you can change the directory
 # to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
 GBDK_HOME = ../../../
-LCC = $(GBDK_HOME)bin/lcc 
+LCC = $(GBDK_HOME)bin/lcc
 
-# Set platforms to build here (spaced separated). Possible are: gb gbc pocket sms gg
-# These are found in the separate Makefile.targets
+# Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
+# They can also be built/cleaned individually: "make gg" and "make gg-clean"
+# Possible are: gb gbc pocket sms gg
 TARGETS=gb pocket sms gg
 
-# MBC + Autobanking related flags
-override LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v
-# override LCCFLAGS += -debug # Uncomment to enable debug output
-# override LCCFLAGS += -v     # Uncomment for lcc verbose output
+# Configure platform specific LCC flags here:
+LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wl-yt0x1B # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_sms     =
+LCCFLAGS_gg      =
+
+LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
+
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+# LCCFLAGS += -debug # Uncomment to enable debug output
+# LCCFLAGS += -v     # Uncomment for lcc verbose output
 
 # You can set the name of the ROM file here
-PROJECTNAME = Example
+PROJECTNAME = fonts
 
 # EXT?=gb # Only sets extension to default (game boy .gb) if not populated
 SRCDIR      = src
@@ -50,9 +57,7 @@ $(OBJDIR)/%.s:	$(SRCDIR)/%.c
 	$(LCC) $(CFLAGS) -S -o $@ $<
 
 # Link the compiled object files into a .gb ROM file
-# Then copy the ROM into a binary directory
 $(BINS):	$(OBJS)
-	@echo $(LCCFLAGS)
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -o $(BINDIR)/$(PROJECTNAME).$(EXT) $(OBJS)
 
 clean:
@@ -60,9 +65,6 @@ clean:
 	@for target in $(TARGETS); do \
 		$(MAKE) $$target-clean; \
 	done
-
-cleanbin:
-	rm -f  $(BINDIR)/*.*
 
 # Include available build targets
 include Makefile.targets

--- a/gbdk-lib/examples/cross-platform/fonts/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/fonts/Makefile.targets
@@ -2,7 +2,7 @@
 # Platform specific flags for compiling (only populate if they're both present)
 ifneq ($(strip $(PORT)),)
 ifneq ($(strip $(PLAT)),)
-override CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
+CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
 endif
 endif
 
@@ -16,20 +16,19 @@ clean-target:
 gb-clean:
 	${MAKE} clean-target EXT=gb
 gb:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=gb EXT=gb
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gb
 
-# GB & GBC:      -Wm-yc
-# GBC Exclusive: -Wm-yC
+
 gbc-clean:
 	${MAKE} clean-target EXT=gbc
 gbc:
-	${MAKE} build-target LCCFLAGS="-Wl-yt0x1B -Wm-yC" PORT=gbz80 PLAT=gb EXT=gbc
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gbc
 
 
 pocket-clean:
 	${MAKE} clean-target EXT=pocket
 pocket:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=ap EXT=pocket
+	${MAKE} build-target PORT=gbz80 PLAT=ap EXT=pocket
 
 
 sms-clean:

--- a/gbdk-lib/examples/cross-platform/large_map/Makefile
+++ b/gbdk-lib/examples/cross-platform/large_map/Makefile
@@ -1,21 +1,28 @@
-# Note: "override" ensures that appending to the variables still works if the variable was set from the command line
-#
-# If you move this project you can change the directory 
+# If you move this project you can change the directory
 # to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
 GBDK_HOME = ../../../
-LCC = $(GBDK_HOME)bin/lcc 
+LCC = $(GBDK_HOME)bin/lcc
 
-# Set platforms to build here (spaced separated). Possible are: gb gbc pocket sms gg
-# These are found in the separate Makefile.targets
+# Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
+# They can also be built/cleaned individually: "make gg" and "make gg-clean"
+# Possible are: gb gbc pocket sms gg
 TARGETS=gb gg
 
-# MBC + Autobanking related flags
-override LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v
-# override LCCFLAGS += -debug # Uncomment to enable debug output
-# override LCCFLAGS += -v     # Uncomment for lcc verbose output
+# Configure platform specific LCC flags here:
+LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wl-yt0x1B # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_sms     =
+LCCFLAGS_gg      =
+
+LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
+
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+# LCCFLAGS += -debug # Uncomment to enable debug output
+# LCCFLAGS += -v     # Uncomment for lcc verbose output
 
 # You can set the name of the ROM file here
-PROJECTNAME = Example
+PROJECTNAME = large-map
 
 # EXT?=gb # Only sets extension to default (game boy .gb) if not populated
 SRCDIR      = src
@@ -50,9 +57,7 @@ $(OBJDIR)/%.s:	$(SRCDIR)/%.c
 	$(LCC) $(CFLAGS) -S -o $@ $<
 
 # Link the compiled object files into a .gb ROM file
-# Then copy the ROM into a binary directory
 $(BINS):	$(OBJS)
-	@echo $(LCCFLAGS)
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -o $(BINDIR)/$(PROJECTNAME).$(EXT) $(OBJS)
 
 clean:
@@ -60,9 +65,6 @@ clean:
 	@for target in $(TARGETS); do \
 		$(MAKE) $$target-clean; \
 	done
-
-cleanbin:
-	rm -f  $(BINDIR)/*.*
 
 # Include available build targets
 include Makefile.targets

--- a/gbdk-lib/examples/cross-platform/large_map/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/large_map/Makefile.targets
@@ -2,7 +2,7 @@
 # Platform specific flags for compiling (only populate if they're both present)
 ifneq ($(strip $(PORT)),)
 ifneq ($(strip $(PLAT)),)
-override CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
+CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
 endif
 endif
 
@@ -16,20 +16,19 @@ clean-target:
 gb-clean:
 	${MAKE} clean-target EXT=gb
 gb:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=gb EXT=gb
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gb
 
-# GB & GBC:      -Wm-yc
-# GBC Exclusive: -Wm-yC
+
 gbc-clean:
 	${MAKE} clean-target EXT=gbc
 gbc:
-	${MAKE} build-target LCCFLAGS="-Wl-yt0x1B -Wm-yC" PORT=gbz80 PLAT=gb EXT=gbc
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gbc
 
 
 pocket-clean:
 	${MAKE} clean-target EXT=pocket
 pocket:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=ap EXT=pocket
+	${MAKE} build-target PORT=gbz80 PLAT=ap EXT=pocket
 
 
 sms-clean:

--- a/gbdk-lib/examples/cross-platform/metasprites/Makefile
+++ b/gbdk-lib/examples/cross-platform/metasprites/Makefile
@@ -1,22 +1,29 @@
-# Note: "override" ensures that appending to the variables still works if the variable was set from the command line
-#
-# If you move this project you can change the directory 
+# If you move this project you can change the directory
 # to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
 GBDK_HOME = ../../../
-LCC = $(GBDK_HOME)bin/lcc 
+LCC = $(GBDK_HOME)bin/lcc
 PNG2ASSET = $(GBDK_HOME)/bin/png2asset
 
-# Set platforms to build here (spaced separated). Possible are: gb gbc pocket sms gg
-# These are found in the separate Makefile.targets
+# Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
+# They can also be built/cleaned individually: "make gg" and "make gg-clean"
+# Possible are: gb gbc pocket sms gg
 TARGETS=gb pocket sms gg
 
-# MBC + Autobanking related flags
-override LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v
-# override LCCFLAGS += -debug # Uncomment to enable debug output
-# override LCCFLAGS += -v     # Uncomment for lcc verbose output
+# Configure platform specific LCC flags here:
+LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wl-yt0x1B # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_sms     =
+LCCFLAGS_gg      =
+
+LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
+
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+# LCCFLAGS += -debug # Uncomment to enable debug output
+# LCCFLAGS += -v     # Uncomment for lcc verbose output
 
 # You can set the name of the ROM file here
-PROJECTNAME = Example
+PROJECTNAME = metasprites
 
 # EXT?=gb # Only sets extension to default (game boy .gb) if not populated
 SRCDIR      = src
@@ -59,9 +66,7 @@ $(OBJDIR)/%.s:	$(SRCDIR)/%.c
 	$(LCC) $(CFLAGS) -S -o $@ $<
 
 # Link the compiled object files into a .gb ROM file
-# Then copy the ROM into a binary directory
 $(BINS):	$(OBJS)
-	@echo $(LCCFLAGS)
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -o $(BINDIR)/$(PROJECTNAME).$(EXT) $(OBJS)
 
 clean:
@@ -69,9 +74,6 @@ clean:
 	@for target in $(TARGETS); do \
 		$(MAKE) $$target-clean; \
 	done
-
-cleanbin:
-	rm -f  $(BINDIR)/*.*
 
 # Include available build targets
 include Makefile.targets

--- a/gbdk-lib/examples/cross-platform/metasprites/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/metasprites/Makefile.targets
@@ -2,7 +2,7 @@
 # Platform specific flags for compiling (only populate if they're both present)
 ifneq ($(strip $(PORT)),)
 ifneq ($(strip $(PLAT)),)
-override CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
+CFLAGS += -m$(PORT):$(PLAT) -D_PLAT_$(PLAT)
 endif
 endif
 
@@ -16,20 +16,19 @@ clean-target:
 gb-clean:
 	${MAKE} clean-target EXT=gb
 gb:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=gb EXT=gb
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gb
 
-# GB & GBC:      -Wm-yc
-# GBC Exclusive: -Wm-yC
+
 gbc-clean:
 	${MAKE} clean-target EXT=gbc
 gbc:
-	${MAKE} build-target LCCFLAGS="-Wl-yt0x1B -Wm-yC" PORT=gbz80 PLAT=gb EXT=gbc
+	${MAKE} build-target PORT=gbz80 PLAT=gb EXT=gbc
 
 
 pocket-clean:
 	${MAKE} clean-target EXT=pocket
 pocket:
-	${MAKE} build-target LCCFLAGS=-Wl-yt0x1B PORT=gbz80 PLAT=ap EXT=pocket
+	${MAKE} build-target PORT=gbz80 PLAT=ap EXT=pocket
 
 
 sms-clean:


### PR DESCRIPTION
- Move target specific flags into section in main Makefile
  - Easier to see and edit the target specific flags in one block near the top of the makefile
  - Removes the need for Makefile "override" keyword for LCCFLAGS variable
- Remove "cleanbin" target since "clean" cleans both obj/ and build/ dirs via "clean-target"
- Set ROM output names to match example purpose (instead of Example)
- Add note about how to build targets individually
- Remove some Makefile debug "echo" printing