### PR TITLE
Examples: Cross-platform: metasprites: platform specific png2asset conversion

### DIFF
--- a/gbdk-lib/examples/cross-platform/metasprites/Makefile
+++ b/gbdk-lib/examples/cross-platform/metasprites/Makefile
@@ -22,21 +22,30 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanki
 # LCCFLAGS += -debug # Uncomment to enable debug output
 # LCCFLAGS += -v     # Uncomment for lcc verbose output
 
+# Add directory where platform specific meta tile sprites get converted into (obj/<platform ext>/src)
+# So they can be included with "#include <res/somefile.h>"
+CFLAGS += -I$(OBJDIR)
+
 # You can set the name of the ROM file here
 PROJECTNAME = metasprites
 
-# EXT?=gb # Only sets extension to default (game boy .gb) if not populated
 SRCDIR      = src
 OBJDIR      = obj/$(EXT)
+RESOBJSRC   = obj/$(EXT)/res
 RESDIR      = res
 BINDIR      = build/$(EXT)
-MKDIRS      = $(OBJDIR) $(BINDIR) # See bottom of Makefile for directory auto-creation
+MKDIRS      = $(OBJDIR) $(BINDIR) $(RESOBJSRC) # See bottom of Makefile for directory auto-creation
 
 BINS	    = $(OBJDIR)/$(PROJECTNAME).$(EXT)
-PNGSOURCES  = $(foreach dir,$(RESDIR),$(notdir $(wildcard $(dir)/*.png)))
+# For png2asset: converting metasprite source pngs -> .c -> .o
+METAPNGS    = $(foreach dir,$(RESDIR),$(notdir $(wildcard $(dir)/*.png)))
+METASRCS    = $(METAPNGS:%.png=$(RESOBJSRC)/%.c)
+METAOBJS    = $(METASRCS:$(RESOBJSRC)/%.c=$(OBJDIR)/%.o)
+
 CSOURCES    = $(foreach dir,$(SRCDIR),$(notdir $(wildcard $(dir)/*.c))) $(foreach dir,$(RESDIR),$(notdir $(wildcard $(dir)/*.c)))
 ASMSOURCES  = $(foreach dir,$(SRCDIR),$(notdir $(wildcard $(dir)/*.s)))
-OBJS        = $(PNGSOURCES:%.png=$(OBJDIR)/%.o) $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
+OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
+
 
 # Builds all targets sequentially
 all: $(TARGETS)
@@ -45,8 +54,14 @@ all: $(TARGETS)
 # -sh 48   : Sets sprite height to 48 (width remains automatic)
 # -spr8x16 : Use 8x16 hardware sprites
 # -c ...   : Set C output file
-%.c:	%.png
-	$(PNG2ASSET) $< -sh 48 -spr8x16 -noflip -c $@ 
+# Convert metasprite .pngs in res/ -> .c files in obj/<platform ext>/src/
+$(RESOBJSRC)/%.c:	$(RESDIR)/%.png
+	$(PNG2ASSET) $< -sh 48 -spr8x16 -noflip -c $@
+
+# Compile the Metasprite pngs that were converted to .c files
+# .c files in obj/<platform ext>/src/ -> .o files in obj/
+$(OBJDIR)/%.o:	$(RESOBJSRC)/%.c
+	$(LCC) $(CFLAGS) -c -o $@ $<
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
@@ -65,9 +80,12 @@ $(OBJDIR)/%.o:	$(SRCDIR)/%.s
 $(OBJDIR)/%.s:	$(SRCDIR)/%.c
 	$(LCC) $(CFLAGS) -S -o $@ $<
 
+# Convert and build MetaSprites first so they're available when compiling the main sources
+$(OBJS):	$(METAOBJS)
+
 # Link the compiled object files into a .gb ROM file
 $(BINS):	$(OBJS)
-	$(LCC) $(LCCFLAGS) $(CFLAGS) -o $(BINDIR)/$(PROJECTNAME).$(EXT) $(OBJS)
+	$(LCC) $(LCCFLAGS) $(CFLAGS) -o $(BINDIR)/$(PROJECTNAME).$(EXT) $(METAOBJS) $(OBJS)
 
 clean:
 	@echo Cleaning

--- a/gbdk-lib/examples/cross-platform/metasprites/src/metasprites.c
+++ b/gbdk-lib/examples/cross-platform/metasprites/src/metasprites.c
@@ -3,7 +3,10 @@
 
 #include <stdint.h>
 
-#include "../res/sprite.h"
+// During build, png2asset metasprite conversion will write output to: obj/<platform ext>/res/
+//  Makefile adds part of that path as an include when compiling. Example: -Iobj/gb
+#include <res/sprite.h>
+
 
 const unsigned char pattern[] = {0x80,0x80,0x40,0x40,0x20,0x20,0x10,0x10,0x08,0x08,0x04,0x04,0x02,0x02,0x01,0x01};
 


### PR DESCRIPTION
- Converts metasprites into .c source that's written to: obj/<platform ext>/res
- Adds compile time include path : obj/<platform ext>
- Source file then uses #include <res/sprite.h>

The comments in the Makefile are a little verbose, but that's so it's easier for others (and my future self) to understand what's going on.