### PR TITLE
Add ci/cd section with gbdk github action builder

### DIFF
--- a/docs/pages/02_links_and_tools.md
+++ b/docs/pages/02_links_and_tools.md
@@ -118,3 +118,11 @@ This is a brief list of useful tools and information. It is not meant to be comp
     Add line-by-line C source code to the main symbol file in a BGB compatible format. This allows for C source-like debugging in BGB in a limited way.
     https://gbdev.gg8.se/forums/viewtopic.php?id=710
 
+
+@anchor ci/cd
+# Continuous Integration/Deployment
+  - @anchor GBDK GitHub Action Builder
+    __GBDK GitHub Action Builder__  
+    Basic CI/CD capabilities for gbdk projects.  
+    https://github.com/wujood/gbdk-2020-github-builder
+    

--- a/docs/pages/02_links_and_tools.md
+++ b/docs/pages/02_links_and_tools.md
@@ -119,10 +119,10 @@ This is a brief list of useful tools and information. It is not meant to be comp
     https://gbdev.gg8.se/forums/viewtopic.php?id=710
 
 
-@anchor ci/cd
-# Continuous Integration/Deployment
-  - @anchor GBDK GitHub Action Builder
-    __GBDK GitHub Action Builder__  
-    Basic CI/CD capabilities for gbdk projects.  
+@anchor tools_build_ci_cd
+# Continuous Integration and Deployment
+  - @anchor GBDK_GitHub_Action_Builder
+    __GBDK GitHub Action Builder__
+    A Github Action which provides basic CI/CD for building projects based on GBDK (not for building GBDK itself).  
     https://github.com/wujood/gbdk-2020-github-builder
     


### PR DESCRIPTION
I created a github action for the gbdk-2020.
This could be a great addition to this documentation page.