### PR TITLE
Docs: updates for 4.0.5 & fix doxygen warnings/dupes

### DIFF
--- a/docs/config/gbdk-2020-doxyfile
+++ b/docs/config/gbdk-2020-doxyfile
@@ -2169,7 +2169,10 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+# Defining __PORT_gbz80 fixes some functions that would get missed in
+# headers that are shared by multiple platforms. Use the Game Boy
+# versions by default
+PREDEFINED             = __PORT_gbz80
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/pages/04_coding_guidelines.md
+++ b/docs/pages/04_coding_guidelines.md
@@ -182,7 +182,7 @@ For example:
     printf("%hx %hx", (unsigned char)i, (unsigned char)i);
 
 Some functions that accept varargs:
- - @ref BGB_MESSAGE_FMT, @ref gprintf(), @ref printf(), @ref sprintf()
+ - @ref BGB_printf, @ref gprintf(), @ref printf(), @ref sprintf()
 
 Also See:
  - Other cases of char to int promotion: http://sdcc.sourceforge.net/doc/sdccman.pdf#chapter.6

--- a/docs/pages/05_banking_mbcs.md
+++ b/docs/pages/05_banking_mbcs.md
@@ -42,7 +42,7 @@ Note: You can use the `NONBANKED` keyword to define a function as non-banked if 
 
 
 ## Setting the RAM bank for a Source file
-  - Using the lcc switch for RAM bank `-Wf-ba<N>`. Example (RAM bank 3): `-Wf-bo3`
+  - Using the lcc switch for RAM bank `-Wf-ba<N>`. Example (ROM bank 3): `-Wf-bo3`
 
 
 @anchor setting_mbc_and_rom_ram_banks

--- a/docs/pages/06b_supported_consoles.md
+++ b/docs/pages/06b_supported_consoles.md
@@ -1,4 +1,4 @@
-@page docs_supported_consoles Supported Consoles & Cross Compile
+@page docs_supported_consoles Supported Consoles & Cross Compiling
   
 @anchor docs_consoles_supproted_list
 # Consoles Supported by GBDK

--- a/docs/pages/09_migrating_new_versions.md
+++ b/docs/pages/09_migrating_new_versions.md
@@ -9,7 +9,9 @@ This section contains information that may be useful to know or important when u
 - @ref utility_png2asset is the new name for the `png2mtspr` utility
 - @ref lcc : Changed default output format when not specified from `.ihx` to `.gb` (or other active rom extension)
 - The `_BSS` area is deprecated (use `_DATA` instead)
+- The `_BASE` area is renamed to `_HOME`
 - Variables in static storage are now initialized to zero per C standard (but remaining WRAM is not cleared)
+- @ref itoa(), @ref utoa(), @ref ltoa(), @ref ultoa() all now require a radix value (base) argument to be passed. On the Game Boy and Analogue Pocket the parameter is required but not utilized.
 
 ## Porting to GBDK 2020 4.0.4
 - GBDK now requires SDCC 12238 or higher

--- a/docs/pages/09_migrating_new_versions.md
+++ b/docs/pages/09_migrating_new_versions.md
@@ -11,7 +11,7 @@ This section contains information that may be useful to know or important when u
 - The `_BSS` area is deprecated (use `_DATA` instead)
 - The `_BASE` area is renamed to `_HOME`
 - Variables in static storage are now initialized to zero per C standard (but remaining WRAM is not cleared)
-- @ref itoa(), @ref utoa(), @ref ltoa(), @ref ultoa() all now require a radix value (base) argument to be passed. On the Game Boy and Analogue Pocket the parameter is required but not utilized.
+- @ref itoa(), @ref uitoa(), @ref ltoa(), @ref ultoa() all now require a radix value (base) argument to be passed. On the Game Boy and Analogue Pocket the parameter is required but not utilized.
 
 ## Porting to GBDK 2020 4.0.4
 - GBDK now requires SDCC 12238 or higher

--- a/docs/pages/10_release_notes.md
+++ b/docs/pages/10_release_notes.md
@@ -8,14 +8,9 @@ https://github.com/gbdk-2020/gbdk-2020/releases
 
 ## GBDK 2020 4.0.5
   2021/09
-  - Known Issues
-    - The `bgb_debug` example has a compile error on macOS.
-      - The compiler has a bug on macOS where long strings used with macros cause a crash. @ref bgb_emu.h can still be used with shorter strings.
-  - Overall
-    - Added support for new consoles
-      - Analogue Pocket (`ap`)
-      - Sega Master System (`sms`) and Game Gear (`gg`)
-    - The windows make.bat files were renamed to compile.bat
+  - Added support for new consoles. See @ref docs_supported_consoles
+    - Analogue Pocket (`ap`)
+    - Sega Master System (`sms`) and Game Gear (`gg`)
   - Library
     - Variables in static storage are now initialized to zero per C standard (but remaining WRAM is not cleared)
     - Added new register flag constants and names. For example:
@@ -23,12 +18,15 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - @ref LCDCF_WINON, @ref LCDCF_WINOFF, @ref LCDCF_B_WINON
     - Added @ref BANK(), @ref BANKREF(), @ref BANKREF_EXTERN()
     - Added @ref INCBIN(), @ref BANK(), @ref INCBIN_SIZE(), @ref INCBIN_EXTERN()
-    - Updated bgb debug output. Added @ref BGB_printf()
+    - Added generic @ref SWITCH_ROM() and @ref SWITCH_RAM()
+    - Added @ref BGB_printf() and updated bgb debug output.
+    - Changed @ref itoa(), @ref utoa(), @ref ltoa(), @ref ultoa() to now require a radix value (base) argument to be passed. On the Game Boy and Analogue Pocket the parameter is required but not utilized.
   - Examples
-    - Added cross-platform examples (builds for multiple consoles: gb, ap, sms, gg)
-    - Added sms, gg, pocket examples
+    - Added cross-platform examples (build for multiple consoles: gb, ap, sms, gg)
+    - Added sms, gg, pocket(ap) examples
     - Added incbin example
     - Added simple physics sub-pixel / fixed point math example
+    - Changed windows make.bat files to compile.bat
     - Bug fixes and updates for existing examples
   - Toolchain / Utilities
     - @ref utility_png2asset "png2asset"
@@ -42,13 +40,18 @@ https://github.com/gbdk-2020/gbdk-2020/releases
     - @ref lcc
       - Use `-m` to select target port and platform: "-m[port]:[plat]" ports:`gbz80,z80` plats:`ap,gb,sms,gg`
       - Changed default output format when not specified from `.ihx` to `.gb` (or other active rom extension)
-      - 
+      - Changed lcc to always use the linkerfile `-lkout=` option when calling bankpack
+      - Fixed name generation crash when outfile lacks extension
     - @ref bankpack
       - Added linkerfile input and output: `-lkin=<file>`, `-lkout=<file>`
       - Added selector for platform specific behavior `plat=<plat>` (Default:gb, Avaialble:`gb,sms`). sms/gg targets prohibits packing `LIT_N` areas in the same banks as `CODE_N` areas
       - Added randomization for auto-banks (`-random`) for debugging and testing
-
+    - @ref utility_gbcompress
+      - Added C source array format output (--cout) (optional variable name argument --varname=)
+      - Added C source array format input (--cin) (experimental)
   - Docs
+    - Added @ref docs_supported_consoles section
+    - Various doc updates and improvements
   
 
 ## GBDK 2020 4.0.4

--- a/docs/pages/10_release_notes.md
+++ b/docs/pages/10_release_notes.md
@@ -20,7 +20,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
     - Added @ref INCBIN(), @ref BANK(), @ref INCBIN_SIZE(), @ref INCBIN_EXTERN()
     - Added generic @ref SWITCH_ROM() and @ref SWITCH_RAM()
     - Added @ref BGB_printf() and updated bgb debug output.
-    - Changed @ref itoa(), @ref utoa(), @ref ltoa(), @ref ultoa() to now require a radix value (base) argument to be passed. On the Game Boy and Analogue Pocket the parameter is required but not utilized.
+    - Changed @ref itoa(), @ref uitoa(), @ref ltoa(), @ref ultoa() to now require a radix value (base) argument to be passed. On the Game Boy and Analogue Pocket the parameter is required but not utilized.
   - Examples
     - Added cross-platform examples (build for multiple consoles: gb, ap, sms, gg)
     - Added sms, gg, pocket(ap) examples

--- a/gbdk-lib/include/asm/z80/types.h
+++ b/gbdk-lib/include/asm/z80/types.h
@@ -1,5 +1,5 @@
 /** @file asm/gbz80/types.h
-    @anchor file_asm_gbz80_types_h
+    @anchor file_asm_z80_types_h
     Types definitions for the gb.
 */
 #ifndef ASM_Z80_TYPES_INCLUDE

--- a/gbdk-lib/include/gbdk/console.h
+++ b/gbdk-lib/include/gbdk/console.h
@@ -1,4 +1,4 @@
-/** @file gb/console.h
+/** @file gbdk/console.h
     Console functions that work like Turbo C's.
 
     The font is 8x8, making the screen 20x18 characters.

--- a/gbdk-lib/include/gbdk/far_ptr.h
+++ b/gbdk-lib/include/gbdk/far_ptr.h
@@ -1,4 +1,4 @@
-/** @file gb/far_ptr.h
+/** @file gbdk/far_ptr.h
 
     Far pointers include a segment (bank) selector so they are
     able to point to addresses (functions or data) outside

--- a/gbdk-lib/include/gbdk/font.h
+++ b/gbdk-lib/include/gbdk/font.h
@@ -1,4 +1,4 @@
-/** @file gb/font.h
+/** @file gbdk/font.h
     Multiple font support for the GameBoy
     Michael Hope, 1999
     michaelh@earthling.net

--- a/gbdk-lib/include/gbdk/gbdk-lib.h
+++ b/gbdk-lib/include/gbdk/gbdk-lib.h
@@ -1,4 +1,4 @@
-/** @file gbdk-lib.h
+/** @file gbdk/gbdk-lib.h
     Settings for the greater library system.
 */
 #ifndef GBDK_LIB_INCLUDE

--- a/gbdk-lib/include/gbdk/incbin.h
+++ b/gbdk-lib/include/gbdk/incbin.h
@@ -1,7 +1,7 @@
-/** @file gb/incbin.h
-    
+/** @file gbdk/incbin.h
+
     Allows binary data from other files to be included
-    into a C source file. 
+    into a C source file.
 
     It is implemented using asm .incbin and macros.
 
@@ -27,34 +27,34 @@ extern const void __size_ ## VARNAME; \
 extern const void __bank_ ## VARNAME;
 
 /** Obtains the __size in bytes__ of the INCBIN() generated data
-    
+
     @param VARNAME Name of the variable used with INCBIN
 
     Requires @ref INCBIN_EXTERN() to have been called earlier in the source file
 
-    @ref INCBIN(), INCBIN_EXTERN()    
+    @ref INCBIN(), INCBIN_EXTERN()
 */
 #define INCBIN_SIZE(VARNAME) ( (uint16_t) & __size_ ## VARNAME )
 
 /** Obtains the __bank number__ of the INCBIN() generated data
-    
+
     @param VARNAME Name of the variable used with INCBIN
 
     Requires @ref INCBIN_EXTERN() to have been called earlier in the source file
 
-    @ref INCBIN(), INCBIN_EXTERN()    
+    @ref INCBIN(), INCBIN_EXTERN()
 */
 #ifndef BANK
 #define BANK(VARNAME) ( (uint8_t) & __bank_ ## VARNAME )
 #endif
 
 /** Includes binary data into a C source file
-    
+
     @param VARNAME Variable name to use
     @param FILEPATH Path to the file which will be binary included into the C source file
 
-    __filepath__ is relative to the working directory of the tool 
-    that is calling it (often a makefile's working directory), __NOT__ 
+    __filepath__ is relative to the working directory of the tool
+    that is calling it (often a makefile's working directory), __NOT__
     to the file it's being included into.
 
     The variable name is not modified and can be used as-is.
@@ -77,7 +77,7 @@ _ ## VARNAME:: \
     ___bank_ ## VARNAME = b___func_ ## VARNAME \
     .globl ___bank_ ## VARNAME \
 __endasm; \
-} 
+}
 
 #endif // _INCBIN_H
 


### PR DESCRIPTION
Docs: Fix misc doxygen warnings and duplicate entries
Docs: Doxygen config: Define __PORT_gbz80
- Fixes issue where function definitions would be ignored if no valid PORT was defined
- Defaults to GB Port for documentation when required
- See: PREDEFINED = __PORT_gbz80

