### PR TITLE
Docs: updates for 4.0.5

### DIFF
--- a/docs/pages/06_toolchain.md
+++ b/docs/pages/06_toolchain.md
@@ -204,7 +204,6 @@ Compresses (and decompresses) binary file data with the gbcompress algorithm (al
 Tool for converting PNGs into GBDK format MetaSprites and Tile Maps
 
 - Convert single or multiple frames of graphics into metasprite structured data for use with the ...metasprite...() functions.
-
 - When `-map` is used, converts images into Tile Maps and matching Tile Sets
 
 For detailed settings see @ref png2asset-settings  
@@ -212,7 +211,7 @@ For working with sprite properties (including cgb palettes), see @ref metasprite
 For API support see @ref move_metasprite() and related functions in @ref metasprites.h  
 
 ### Working with png2asset
-    - The origin (pivot) for the metasprite is not required to be in the upper left-hand corner as with regular hardware sprites. See `-px` and `-py`.
+  - The origin (pivot) for the metasprite is not required to be in the upper left-hand corner as with regular hardware sprites. See `-px` and `-py`.
 
   - The conversion process supports using both SPRITES_8x8 (`-spr8x8`) and SPRITES_8x16 mode (`-spr8x16`). If 8x16 mode is used then the height of the metasprite must be a multiple of 16.
 
@@ -240,6 +239,7 @@ Using this image a tileset will be created
   - Duplicated tiles will be removed
   - Tiles will be matched without mirror, using vertical mirror, horizontal mirror or both (use `-noflip` to turn off matching mirrored tiles)
   - The palette won't be taken into account for matching, only the pixel color order, meaning there will be a match between tiles using different palettes but looking identical on grayscale
+
 
 #### Maps
 Passing `-map` the png can be converted to a map that can be used in both the background and the window. In this case, png2asset will generate:

--- a/docs/pages/09_migrating_new_versions.md
+++ b/docs/pages/09_migrating_new_versions.md
@@ -5,18 +5,20 @@ This section contains information that may be useful to know or important when u
 # GBDK 2020 versions
 
 ## Porting to GBDK 2020 4.0.5
-- GBDK now requires SDCC 12259 or higher with GBDK-2020 patches
-- @ref utility_png2asset is the new name for the `png2mtspr` utility
-- @ref lcc : Changed default output format when not specified from `.ihx` to `.gb` (or other active rom extension)
-- The `_BSS` area is deprecated (use `_DATA` instead)
-- The `_BASE` area is renamed to `_HOME`
-- Variables in static storage are now initialized to zero per C standard (but remaining WRAM is not cleared)
-- @ref itoa(), @ref uitoa(), @ref ltoa(), @ref ultoa() all now require a radix value (base) argument to be passed. On the Game Boy and Analogue Pocket the parameter is required but not utilized.
-- set_bkg_1bit_data has been renamed to @ref set_bkg_1bpp_data
+  - GBDK now requires SDCC 12259 or higher with GBDK-2020 patches
+  - @ref utility_png2asset "png2asset" is the new name for the `png2mtspr` utility
+  - @ref lcc : Changed default output format when not specified from `.ihx` to `.gb` (or other active rom extension)
+  - The `_BSS` area is deprecated (use `_DATA` instead)
+  - The `_BASE` area is renamed to `_HOME`
+  - Variables in static storage are now initialized to zero per C standard (but remaining WRAM is not cleared)
+  - @ref itoa(), @ref uitoa(), @ref ltoa(), @ref ultoa() all now require a radix value (base) argument to be passed. On the Game Boy and Analogue Pocket the parameter is required but not utilized.
+  - set_bkg_1bit_data has been renamed to @ref set_bkg_1bpp_data
+  - The following header files which are now cross platform were moved from `gb/` to `gbdk/`: `bcd.h`, `console.h`, `far_ptr.h`, `font.h`, `gbdecompress.h`, `gbdk-lib.h`, `incbin.h`, `metasprites.h`, `platform.h`, `version.h`
+    - When including them use `#include <gbdk/...>` instead of `#include <gb/>`
 
 ## Porting to GBDK 2020 4.0.4
-- GBDK now requires SDCC 12238 or higher
-- Made sample.h, cgb.h and sgb.h independent from gb.h
+  - GBDK now requires SDCC 12238 or higher
+  - Made sample.h, cgb.h and sgb.h independent from gb.h
 
 ## Porting to GBDK 2020 4.0.3
   - No significant changes required


### PR DESCRIPTION
- Formatting fix for toolchain page
- Add note about header files that moved from gb to gbdk dir