### PR TITLE
Docs: Getting Started and Supported Consoles

### DIFF
--- a/docs/pages/01_getting_started.md
+++ b/docs/pages/01_getting_started.md
@@ -10,13 +10,26 @@ You can get the latest releases from here: https://github.com/gbdk-2020/gbdk-202
 # 2. Compile Example projects
 Make sure your GBDK-2020 installation is working correctly by compiling some of the included @ref docs_example_programs "example projects".
 
+If everything in works in the steps below and there are no errors reported then each project that was build should have it's on .gb ROM file (or suitable extension for the other supported targets).
+
+## Windows (without Make installed):
+Navigate to a project within the example projects folder (`"examples\gb\"` under your GBDK-2020 install folder) and open a command line. Then type:
+
+    compile
+
+or
+
+    compile.bat
+
+This should build the example project. You can also navigate into other example project folders and build them by typing `make`.
+
+
+## Linux / MacOS / Windows with Make installed:
 Navigate to the example projects folder (`"examples/gb/"` under your GBDK-2020 install folder) and open a command line. Then type:
 
     make
 
 This should build all of the examples sequentially. You can also navigate into an individual example project's folder and build it by typing `make`.
-
-If everything works and there are no errors reported each example sub-folder should have it's on .gb ROM file.
 
 
 # 3. Use a Template
@@ -51,7 +64,15 @@ What size will your game or program be?
   - Larger than 32K (MBC required)
   - See more details about @ref docs_rombanking_mbcs "ROM Banking and MBCs".
 
-What hardware will it run on?
+What console platform(s) will it run on?
+  - Game Boy (GB/GBC)
+  - Analogue Pocket (AP)
+  - Sega Master System (SMS)
+  - Game Gear (GG)
+  - Mega Duck (DUCK)
+  - See @ref docs_supported_consoles
+
+If targeting the Game Boy, what hardware will it run on?
   - Game Boy (& Game Boy Color)
   - Game Boy Color only
   - Game Boy & Super Game Boy

--- a/docs/pages/06b_supported_consoles.md
+++ b/docs/pages/06b_supported_consoles.md
@@ -8,6 +8,7 @@ As of version `4.0.5` GBDK includes support for other consoles in addition to th
   - Analogue Pocket (AP)
   - Sega Master System (SMS)
   - Sega Game Gear (GG)
+  - Mega Duck / Cougar Boy (DUCK)
 
 While the GBDK API has many convenience functions that work the same or similar across different consoles, it's important to keep their different capabilities in mind when writing code intended to run on more than one. Some (but not all) of the differences are screen sizes, color abilities, memory layouts, processor type (z80 vs gbz80/sm83) and speed.
 
@@ -42,6 +43,9 @@ When linking with @ref sdldgb-settings "sdldgb" (for GB/AP) and @ref sdldz80-set
   - Analogue Pocket
     - @ref lcc : `-mgbz80:ap`
     - port:`gbz80`, plat:`ap`
+  - Mega Duck / Cougar Boy
+    - @ref lcc : `-mgbz80:duck`
+    - port:`gbz80`, plat:`duck`
 
   - Sega Master System
     - @ref lcc : `-mz80:sms`
@@ -62,6 +66,10 @@ There are several constant \#defines that can be used to help select console spe
     - When building for Analogue Pocket
       - `NINTENDO` will be \#defined
       - `ANALOGUEPOCKET` will be \#defined
+    - When building for Mega Duck / Cougar Boy
+      - `NINTENDO` will be \#defined
+      - `MEGADUCK` will be \#defined
+
 
   - When `<sms/sms.h >` is included (either directly or through `<gbdk/platform.h>`)
     - When building for Master System
@@ -107,6 +115,7 @@ GBDK includes an number of cross platform example projects. These projects show 
 
 They also show how to build for multiple target consoles with a single build command and `Makefile`. The `Makefile.targets` allows selecting different `port` and `plat` settings when calling the build stages.
 
+
 # Porting From Game Boy to Analogue Pocket
 The Analogue Pocket is (for practical purposes) functionally identical to the Game Boy / Color, but has a couple altered register flag and address definitions and a different boot logo. In order for software to be easily ported to the Analogue Pocket, or to run on both, use the following practices.
 
@@ -119,6 +128,17 @@ Use API defined registers and register flags instead of hardwired ones
 
 ## Boot logo
 As long as the target console is @ref docs_consoles_compiling "set during build time" then the correct boot logo will be automatically selected.
+
+
+# Porting From Game Boy to Mega Duck / Cougar Boy
+The Mega Duck is fairly similar to the classic Game Boy. It has a couple altered register flag and address definitions, no boot logo and a different startup/entry-point address. In order for software to be easily ported to the Mega Duck, or to run on both, use the following practices.
+
+## Registers and Flags
+Use API defined registers and register flags instead of hardwired ones
+   - LCDC register: @ref LCDC_REG or @ref rLCDC
+   - STAT register: @ref STAT_REG or @ref rSTAT
+   - LCDC flags: -> LCDCF_... (example: @ref LCDCF_ON)
+   - STAT flags: -> STATF_... (example: @ref STATF_LYC)
 
 
 # Porting From Game Boy to SMS/GG


### PR DESCRIPTION
* Getting Started: Fix naming and steps for Windows without make (compile.bat)
* Supported Consoles: Add Megaduck