### PR TITLE
CI-CD: macOS binary compatibility fixes for older OSes

### DIFF
--- a/gbdk-support/bankpack/Makefile
+++ b/gbdk-support/bankpack/Makefile
@@ -12,7 +12,7 @@ endif
 
 # Target older macOS version than whatever build OS is for better compatibility
 ifeq ($(BUILD_OS),Darwin)
-	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+	export MACOSX_DEPLOYMENT_TARGET=10.10
 endif
 
 CC = $(TOOLSPREFIX)gcc

--- a/gbdk-support/bankpack/Makefile
+++ b/gbdk-support/bankpack/Makefile
@@ -4,8 +4,14 @@ ifndef TARGETDIR
 TARGETDIR = /opt/gbdk
 endif
 
+ifeq ($(OS),Windows_NT)
+	BUILD_OS := Windows_NT
+else
+	BUILD_OS := $(shell uname -s)
+endif
+
 # Target older macOS version than whatever build OS is for better compatibility
-ifeq ($(UNAME_S),Darwin)
+ifeq ($(BUILD_OS),Darwin)
 	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
 endif
 

--- a/gbdk-support/bankpack/Makefile
+++ b/gbdk-support/bankpack/Makefile
@@ -4,6 +4,11 @@ ifndef TARGETDIR
 TARGETDIR = /opt/gbdk
 endif
 
+# Target older macOS version than whatever build OS is for better compatibility
+ifeq ($(UNAME_S),Darwin)
+	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+endif
+
 CC = $(TOOLSPREFIX)gcc
 CFLAGS = -ggdb -O -Wno-incompatible-pointer-types -DGBDKLIBDIR=\"$(TARGETDIR)\"
 OBJ = bankpack.o files.o obj_data.o list.o path_ops.o

--- a/gbdk-support/gbcompress/Makefile
+++ b/gbdk-support/gbcompress/Makefile
@@ -12,7 +12,7 @@ endif
 
 # Target older macOS version than whatever build OS is for better compatibility
 ifeq ($(BUILD_OS),Darwin)
-	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+	export MACOSX_DEPLOYMENT_TARGET=10.10
 endif
 
 CC = $(TOOLSPREFIX)gcc

--- a/gbdk-support/gbcompress/Makefile
+++ b/gbdk-support/gbcompress/Makefile
@@ -4,8 +4,14 @@ ifndef TARGETDIR
 TARGETDIR = /opt/gbdk
 endif
 
+ifeq ($(OS),Windows_NT)
+	BUILD_OS := Windows_NT
+else
+	BUILD_OS := $(shell uname -s)
+endif
+
 # Target older macOS version than whatever build OS is for better compatibility
-ifeq ($(UNAME_S),Darwin)
+ifeq ($(BUILD_OS),Darwin)
 	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
 endif
 

--- a/gbdk-support/gbcompress/Makefile
+++ b/gbdk-support/gbcompress/Makefile
@@ -4,6 +4,11 @@ ifndef TARGETDIR
 TARGETDIR = /opt/gbdk
 endif
 
+# Target older macOS version than whatever build OS is for better compatibility
+ifeq ($(UNAME_S),Darwin)
+	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+endif
+
 CC = $(TOOLSPREFIX)gcc
 CFLAGS = -ggdb -O -Wno-incompatible-pointer-types -DGBDKLIBDIR=\"$(TARGETDIR)\"
 OBJ = main.o gbcompress.o rlecompress.o files.o files_c_source.o

--- a/gbdk-support/ihxcheck/Makefile
+++ b/gbdk-support/ihxcheck/Makefile
@@ -12,7 +12,7 @@ endif
 
 # Target older macOS version than whatever build OS is for better compatibility
 ifeq ($(BUILD_OS),Darwin)
-	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+	export MACOSX_DEPLOYMENT_TARGET=10.10
 endif
 
 CC = $(TOOLSPREFIX)gcc

--- a/gbdk-support/ihxcheck/Makefile
+++ b/gbdk-support/ihxcheck/Makefile
@@ -4,8 +4,14 @@ ifndef TARGETDIR
 TARGETDIR = /opt/gbdk
 endif
 
+ifeq ($(OS),Windows_NT)
+	BUILD_OS := Windows_NT
+else
+	BUILD_OS := $(shell uname -s)
+endif
+
 # Target older macOS version than whatever build OS is for better compatibility
-ifeq ($(UNAME_S),Darwin)
+ifeq ($(BUILD_OS),Darwin)
 	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
 endif
 

--- a/gbdk-support/ihxcheck/Makefile
+++ b/gbdk-support/ihxcheck/Makefile
@@ -4,10 +4,16 @@ ifndef TARGETDIR
 TARGETDIR = /opt/gbdk
 endif
 
+# Target older macOS version than whatever build OS is for better compatibility
+ifeq ($(UNAME_S),Darwin)
+	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+endif
+
 CC = $(TOOLSPREFIX)gcc
 CFLAGS = -ggdb -O -Wno-incompatible-pointer-types -DGBDKLIBDIR=\"$(TARGETDIR)\"
 OBJ = ihxcheck.o areas.o ihx_file.o
 BIN = ihxcheck
+
 
 all: $(BIN)
 

--- a/gbdk-support/lcc/Makefile
+++ b/gbdk-support/lcc/Makefile
@@ -8,6 +8,11 @@ endif
 BUILDDATE=$(shell date -u +%Y/%m/%d)
 BUILDTIME=$(shell date -u +%H:%M:%S)
 
+# Target older macOS version than whatever build OS is for better compatibility
+ifeq ($(UNAME_S),Darwin)
+	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+endif
+
 CC = $(TOOLSPREFIX)gcc
 CFLAGS = -ggdb -O -Wno-incompatible-pointer-types -DGBDKLIBDIR=\"$(TARGETDIR)\"
 CFLAGS += -DBUILDDATE=\"$(BUILDDATE)\" -DBUILDTIME=\"$(BUILDTIME)\"

--- a/gbdk-support/lcc/Makefile
+++ b/gbdk-support/lcc/Makefile
@@ -8,10 +8,17 @@ endif
 BUILDDATE=$(shell date -u +%Y/%m/%d)
 BUILDTIME=$(shell date -u +%H:%M:%S)
 
+ifeq ($(OS),Windows_NT)
+	BUILD_OS := Windows_NT
+else
+	BUILD_OS := $(shell uname -s)
+endif
+
 # Target older macOS version than whatever build OS is for better compatibility
-ifeq ($(UNAME_S),Darwin)
+ifeq ($(BUILD_OS),Darwin)
 	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
 endif
+
 
 CC = $(TOOLSPREFIX)gcc
 CFLAGS = -ggdb -O -Wno-incompatible-pointer-types -DGBDKLIBDIR=\"$(TARGETDIR)\"

--- a/gbdk-support/lcc/Makefile
+++ b/gbdk-support/lcc/Makefile
@@ -16,7 +16,7 @@ endif
 
 # Target older macOS version than whatever build OS is for better compatibility
 ifeq ($(BUILD_OS),Darwin)
-	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+	export MACOSX_DEPLOYMENT_TARGET=10.10
 endif
 
 

--- a/gbdk-support/png2asset/Makefile
+++ b/gbdk-support/png2asset/Makefile
@@ -19,26 +19,31 @@ ifeq ($(OS),Windows_NT)
 	EXT = .exe
 	LFLAGS += -static 
 endif
- 
+
+# Target older macOS version than whatever build OS is for better compatibility
+ifeq ($(UNAME_S),Darwin)
+	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+endif
+
 # ****************************************************
 # Targets needed to bring the executable up to date
- 
+
 TARGET = png2asset
 
 
 SRCS := lodepng.cpp png2asset.cpp
 OBJS := $(SRCS:%.cpp=%.o)
- 
+
 $(TARGET): $(OBJS)
 	$(CXX) $(LFLAGS) -o $(TARGET) $(OBJS)
 	strip $@$(EXT)
- 
+
 # The main.o target can be written more simply
- 
+
 %.cpp.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@
- 
- clean:
+
+clean:
 	rm -f *.o
 	rm -f *.exe
 	rm -f TARGET

--- a/gbdk-support/png2asset/Makefile
+++ b/gbdk-support/png2asset/Makefile
@@ -8,6 +8,18 @@ CXX = $(TOOLSPREFIX)g++
 CXXFLAGS = -Os -Wall -g
 LFLAGS = -g
 
+ifeq ($(OS),Windows_NT)
+	BUILD_OS := Windows_NT
+else
+	BUILD_OS := $(shell uname -s)
+endif
+
+# Target older macOS version than whatever build OS is for better compatibility
+ifeq ($(BUILD_OS),Darwin)
+	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+endif
+
+
 # Static flag for windows cross and native builds
 ifeq ($(TOOLSPREFIX),i686-w64-mingw32-)
 #   prefix will automatically be .exe for cross build
@@ -20,10 +32,8 @@ ifeq ($(OS),Windows_NT)
 	LFLAGS += -static 
 endif
 
-# Target older macOS version than whatever build OS is for better compatibility
-ifeq ($(UNAME_S),Darwin)
-	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
-endif
+
+
 
 # ****************************************************
 # Targets needed to bring the executable up to date

--- a/gbdk-support/png2asset/Makefile
+++ b/gbdk-support/png2asset/Makefile
@@ -16,7 +16,7 @@ endif
 
 # Target older macOS version than whatever build OS is for better compatibility
 ifeq ($(BUILD_OS),Darwin)
-	export MACOSX_DEPLOYMENT_TARGET=10.9 # 2013 vintage is plenty old
+	export MACOSX_DEPLOYMENT_TARGET=10.10
 endif
 
 


### PR DESCRIPTION
Set build target: MACOSX_DEPLOYMENT_TARGET=10.10

Was not able to target versions older than 10.10. In the future this minimum version may have to get increased if the CI runners for macOS is upgraded and drops support for 10.10.