### PR TITLE
Include CGB in Supported Consoles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 GBDK is a cross-platform development kit for sm83 and z80 based gaming consoles. It includes libraries, toolchain utilities and the [SDCC](http://sdcc.sourceforge.net/) C compiler suite.
 
 __Supported Consoles:__ [(see docs)](https://gbdk-2020.github.io/gbdk-2020/docs/api/docs_supported_consoles.html)
-- Nintendo Gameboy
+- Nintendo Gameboy / Game Boy Color
 - Analogue Pocket
-- Sega Master System & Game Gear
 - Mega Duck / Cougar Boy
+- Sega Master System & Game Gear
 
 
 ## Current Release

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ GBDK is a cross-platform development kit for sm83 and z80 based gaming consoles.
 __Supported Consoles:__ [(see docs)](https://gbdk-2020.github.io/gbdk-2020/docs/api/docs_supported_consoles.html)
 - Nintendo Gameboy / Game Boy Color
 - Analogue Pocket
-- Mega Duck / Cougar Boy
 - Sega Master System & Game Gear
+- Mega Duck / Cougar Boy
 
 
 ## Current Release


### PR DESCRIPTION
Add Game Boy Color to line with Game Boy support. Also reorder the listing to reflect that of the [docs](docs/pages/06b_supported_consoles.md) page more accurately.