### PR TITLE
lcc: fix handling of makebin sega -x* options

### DIFF
--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -885,7 +885,7 @@ static void opt(char *arg) {
 				char *tmp = malloc(256);
 				char *tmp2 = malloc(256);
 				tmp2[0] = '\0'; // Zero out second arg by default
-				if(arg[4] == 'y') {
+				if (arg[4] == 'y') {
 					sprintf(tmp, "%c%c%c", arg[3], arg[4], arg[5]); //-yo -ya -yt -yl -yk -yn -yp
 					if (!(arg[5] == 'c' || arg[5] == 'C' || arg[5] == 's'  || arg[5] == 'S' || arg[5] == 'j' || arg[5] == 'p')) // Don't add second arg for -yc -yC -ys -yS -yj
 						sprintf(tmp2, "%s", &arg[6]);
@@ -897,6 +897,13 @@ static void opt(char *arg) {
 					// If MBC option is present for makebin (-Wl-yt <n> or -Wm-yt <n>) then make a copy for bankpack to use
 					if (arg[5] == 't')
 						bankpack_flags = append(&arg[3], bankpack_flags);
+				} else if ((arg[4] == 'x') && arg[5] && arg[6]) {
+					// SMS options
+					// Print "-" plus first two option chars into first arg
+					// and any trailing option chars into a separate arg
+					sprintf(tmp, "%c%c%c", arg[3], arg[4], arg[5]);  //-xo -xj -xv
+					if(arg[6])
+						sprintf(tmp2, "%s", &arg[6]);
 				} else {
 					sprintf(tmp, "%c%c", arg[3], arg[4]); //-s
 					if(arg[5])


### PR DESCRIPTION
* Split -xjn to -xj n instead of -x jn (same for -xo and -xv)