### PR TITLE
Docs: Updates for 4.0.6

### DIFF
--- a/docs/pages/01_getting_started.md
+++ b/docs/pages/01_getting_started.md
@@ -97,3 +97,50 @@ You might want to start off with a guided GBDK tutorial from the @ref links_gbdk
 # 10. Need help?
 Check out the links for @ref links_help_and_community "online community and support" and read the @ref docs_faq "FAQ".
 
+
+
+# Migrating From Pre-GBDK-2020 Tutorials
+Several popular GBDK Tutorials, Videos and How-to's were made before GBDK-2020 was available. As a result some information they include is outdated or incompatible. The following summarizes changes that should be made for best results.
+
+## Also see: 
+- @ref docs_migrating_versions
+- @ref docs_coding_guidelines
+- @ref docs_getting_started (the section above this)
+
+## Use auto-banking
+GBDK-2020 now supports auto-banking (@ref rom_autobanking). In most cases using auto-banking will be easier and less error prone than manually assigning source and assets to banks.
+- There is a source example `banks_autobank` project.
+
+## Non-standard types (UINT8, etc)
+The old GBDK types `UINT8`, `INT8`, `UINT16`, `INT16` are non-standard and less portable.
+
+The following should be used instead: `uint8_t`, `int16_t`, `uint16_t`, `int32_t`, `uint32_t` and `bool`.
+
+These are standard types defined in `stdint.h` (`#include <stdint.h>`) and `stdbool.h` (`#include <stdbool.h>`).
+
+## If using GBTD / GBMB, get the fixed version
+If you plan to use GBTD / GBMB for making graphics, make sure to get the version with the `const` fix and other improvements. See @ref const_gbtd_gbmb.
+
+## LCC and SDCC flags that are not needed
+The following flag is no longer needed with @ref lcc and @ref sdcc, it can be removed without any loss of performance.
+- `-DUSE_SFR`
+   - Behavior formerly enabled by USE_SFR_FOR_REG is on by default now (no need to specify it, it isn't a tested `#ifdef` anymore). check here why: https://gbdev.gg8.se/forums/viewtopic.php?id=697
+
+## ROM Header Settings (such as Color, SGB, etc)
+Setting ROM bytes directly with `-Wl-yp0x<address>=0x<value>` is no longer supported. Instead use @ref makebin flags. For example, use `-Wm-yC` instead of `-Wl-yp0x143=0xC0`. See @ref faq_gb_type_header_setting.
+
+## GBDK Header include changes
+The following header files which are now cross platform were moved from `gb/` to `gbdk/`: `bcd.h`, `console.h`, `far_ptr.h`, `font.h`, `gbdecompress.h`, `gbdk-lib.h`, `incbin.h`, `metasprites.h`, `platform.h`, `version.h`
+- When including them use `#include <gbdk/...>` instead of `#include <gb/>`
+
+## Include .h headers, not .c source files
+Do not `#include` `.c` source files into other `.c` source files. Instead create `.h` header files for them and include those.
+- https://www.tutorialspoint.com/cprogramming/c_header_files.htm
+
+## Use the Template Projects
+Modern project templates are included with GBDK-2020. Using them (and their Makefile or compile.bat) as a starting point for projects is recommended and can help ensure better default settings and project organization.
+
+## Use hUGEtracker instead of gbt_player
+hUGEtracker and it's driver @ref hUGEdriver are smaller, more efficient and more versatile than gbt_player.
+    
+

--- a/docs/pages/02_links_and_tools.md
+++ b/docs/pages/02_links_and_tools.md
@@ -42,6 +42,11 @@ This is a brief list of useful tools and information. It is not meant to be comp
 
 @anchor links_gbdk_tutorials
 # Tutorials
+  - @anchor tutorials_larolds
+    __Larold's Jubilant Junkyard  Tutorials__      
+    Several walk throughs about the fundamentals of developing for the Game Boy with GBDK-2020. There are simple examples with source code.
+    https://laroldsjubilantjunkyard.com/tutorials/
+
   - @anchor tutorials_gamingmonsters
     __Gaming Monsters Tutorials__  
     Several video tutorials and code for making games with GBDK/GBDK-2020.  
@@ -92,8 +97,8 @@ This is a brief list of useful tools and information. It is not meant to be comp
 
 
   - @anchor hUGEdriver
-    __hUGEdriver__  
-    A tracker and music driver that works with GBDK and RGBDS.
+    __hUGEtracker__ and __hUGEdriver__  
+    A tracker and music driver that work with GBDK and RGBDS.
     It is smaller, more efficient and more versatile than gbt_player.  
     https://github.com/untoxa/hUGEBuild  
     https://github.com/SuperDisk/hUGEDriver  

--- a/docs/pages/05_banking_mbcs.md
+++ b/docs/pages/05_banking_mbcs.md
@@ -181,8 +181,8 @@ The global variable @ref _current_bank is updated automatically when calling @re
 
 
 
-# Auto-Banking
 @anchor rom_autobanking
+# Auto-Banking
 A ROM bank auto-assignment feature was added in GBDK 2020 4.0.2.
 
 Instead of having to manually specify which bank a source file will reside it, the banks can be assigned automatically to make the best use of space. The bank assignment operates on object files, after compiling/assembling and before linking.

--- a/docs/pages/09_migrating_new_versions.md
+++ b/docs/pages/09_migrating_new_versions.md
@@ -7,6 +7,7 @@ This section contains information that may be useful to know or important when u
 ## Porting to GBDK 2020 4.0.6
   - No significant changes required
 
+
 ## Porting to GBDK 2020 4.0.5
   - GBDK now requires SDCC 12259 or higher with GBDK-2020 patches
   - @ref utility_png2asset "png2asset" is the new name for the `png2mtspr` utility
@@ -19,17 +20,21 @@ This section contains information that may be useful to know or important when u
   - The following header files which are now cross platform were moved from `gb/` to `gbdk/`: `bcd.h`, `console.h`, `far_ptr.h`, `font.h`, `gbdecompress.h`, `gbdk-lib.h`, `incbin.h`, `metasprites.h`, `platform.h`, `version.h`
     - When including them use `#include <gbdk/...>` instead of `#include <gb/>`
 
+
 ## Porting to GBDK 2020 4.0.4
   - GBDK now requires SDCC 12238 or higher
   - Made sample.h, cgb.h and sgb.h independent from gb.h
 
+
 ## Porting to GBDK 2020 4.0.3
   - No significant changes required
+
 
 ## Porting to GBDK 2020 4.0.2
  - The default font has been reduced from 256 to 96 characters.
    - Code using special characters may need to be updated.
    - The off-by-1 character index offset was removed for fonts. Old fonts with the offset need to be re-adjusted.
+
 
 ## Porting to GBDK 2020 4.0.1
  - __Important!__ : The `WRAM` memory region is no longer automatically initialized to zeros during startup.

--- a/docs/pages/10_release_notes.md
+++ b/docs/pages/10_release_notes.md
@@ -41,11 +41,14 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - Fixed incorrect `TILE_COUNT` value when not `-using_structs`
     - @ref lcc
       - Changed @ref makebin flags to turn off Nintendo logo copy for GB/CGB (use version in crt instead)
+      - Fixed lcc handling of makebin `-x*` arguments
   - Examples
     - Added logo example (cross-platform)
     - Added @ref ISR_VECTOR example of a raw ISR vector with no dispatcher for GB/CGB
     - Changed sgb_border example to use png2asset for graphics
     - Changed use of set_interrupts() in examples so it's outside critical sections (since it disables/enables interrupts)
+    - Changed cross-platform auto-banks example to use .h header files
+    - Changed SGB border example to also work with SGB on PAL SNES
 
 ## GBDK 2020 4.0.5
   2021/09

--- a/docs/pages/docs_index.md
+++ b/docs/pages/docs_index.md
@@ -35,8 +35,8 @@ GBDK features:
  - C and ASM toolchain based on SDCC with some support utilities
  - A set of libraries with source code
  - Example programs in ASM and in C
- - Support for multiple ROM bank images
- - Support for multiple consoles: Game Boy, Analogue Pocket, Master System and Game Gear
+ - Support for multiple ROM bank images and auto-banking
+ - Support for multiple consoles: Game Boy, Analogue Pocket, Mega Duck, Master System and Game Gear
 
 GBDK is freeware. Most of the tooling code is under the GPL. The runtime libraries should be under the LGPL. Please consider mentioning GBDK in the credits of projects made with it.
 


### PR DESCRIPTION
* Update 4.0.6 changelog a little more
* Docs intro page tweaks (auto-banking, megaduck)
* Initial version of Migrating-from-pre-gbdk-2020-tutorials guide
* Docs: Add link to Larolds tutorials