### PR TITLE
Docs updates for 4.0.6

### DIFF
--- a/docs/pages/06_toolchain.md
+++ b/docs/pages/06_toolchain.md
@@ -208,6 +208,7 @@ Tool for converting PNGs into GBDK format MetaSprites and Tile Maps
 
 - Convert single or multiple frames of graphics into metasprite structured data for use with the ...metasprite...() functions.
 - When `-map` is used, converts images into Tile Maps and matching Tile Sets
+- Supports Game Boy 2bpp, GBC 4bpp, SGB 4bpp, and SMS/GG 4bpp
 
 For detailed settings see @ref png2asset-settings  
 For working with sprite properties (including cgb palettes), see @ref metasprite_and_sprite_properties  
@@ -262,3 +263,14 @@ By default the png will be converted to metasprites. The image will be subdivide
     - x offset
     - flags, containing the mirror info, the palettes for both DMG and GBC and the sprite priority
   - The metasprites array
+
+
+#### Super Game Boy Borders (SGB)
+Screen border assets for the Super Game Boy can be generated using png2asset.
+
+The following flags should be used to perform the conversion:
+  - `<input_border_file.png> -map -bpp 4 -max_palettes 4 -pack_mode sgb -use_map_attributes -c <output_border_data.c>`
+  - Where `<input_border_file.png>` is the image of the SGB border (256x224) and `<output_border_data.c>` is the name of the source file to write the assets out to.
+
+
+See the `sgb_border` example project for more details.

--- a/docs/pages/06b_supported_consoles.md
+++ b/docs/pages/06b_supported_consoles.md
@@ -118,6 +118,11 @@ GBDK includes an number of cross platform example projects. These projects show 
 
 They also show how to build for multiple target consoles with a single build command and `Makefile`. The `Makefile.targets` allows selecting different `port` and `plat` settings when calling the build stages.
 
+## Cross Platform Asset Example
+The cross-platform `Logo` example project shows how assets can be managed for multiple different console targets together.
+
+In the example @ref utility_png2asset is used to generate assets in the native format for each console at compile-time from separate source PNG images. The Makefile is set to use the source PNG folder which matches the current console being compiled, and the source code uses @ref set_native_tile_data() to load the assets tiles in native format.
+
 
 # Porting From Game Boy to Analogue Pocket
 The Analogue Pocket is (for practical purposes) functionally identical to the Game Boy / Color, but has a couple altered register flag and address definitions and a different boot logo. In order for software to be easily ported to the Analogue Pocket, or to run on both, use the following practices.

--- a/docs/pages/20_toolchain_settings.md
+++ b/docs/pages/20_toolchain_settings.md
@@ -457,8 +457,8 @@ usage: png2asset    <file>.png [options]
 -noflip             disable tile flip
 -map                Export as map (tileset + bg)
 -use_map_attributes Use CGB BG Map attributes (default: palettes are stored for each tile in a separate array)
--use_structs        Group the exported info into structs (default: false)
--bpp                bits per pixel (default: 2)
+-use_structs        Group the exported info into structs (default: false) (used by ZGB Game Engine)
+-bpp                bits per pixel: 2, 4 (default: 2)
 -max_palettes       maximum number of palettes allowed (default: 2)
 -pack_mode          gb, sgb or sms (default:GB)
 -tile_origin        tile index offset for maps (instead of zero)

--- a/gbdk-lib/examples/cross-platform/logo/Readme.md
+++ b/gbdk-lib/examples/cross-platform/logo/Readme.md
@@ -1,0 +1,4 @@
+This project shows how assets can be managed for multiple different console targets together.
+
+`png2asset` is used to generate assets in the native format for each console at compile-time from separate source PNG images. The Makefile is set to use the source PNG folder which matches the current console being compiled, and the source code uses @ref set_native_tile_data() to load the assets tiles in native format.
+

--- a/gbdk-support/png2asset/png2asset.cpp
+++ b/gbdk-support/png2asset/png2asset.cpp
@@ -389,7 +389,7 @@ int main(int argc, char *argv[])
 		printf("-map                Export as map (tileset + bg)\n");
 		printf("-use_map_attributes Use CGB BG Map attributes (default: palettes are stored for each tile in a separate array)\n");
 		printf("-use_structs        Group the exported info into structs (default: false) (used by ZGB Game Engine)\n");
-		printf("-bpp                bits per pixel (default: 2)\n");
+		printf("-bpp                bits per pixel: 2, 4 (default: 2)\n");
 		printf("-max_palettes       maximum number of palettes allowed (default: 2)\n");
 		printf("-pack_mode          gb, sgb or sms (default:GB)\n");
 		printf("-tile_origin        tile index offset for maps (instead of zero)\n");


### PR DESCRIPTION
- Notes about cross-platform Logo example
- png2asset: notes about SGB border conversion and example, update it's bpp help output