### PR TITLE
fixing problem with png2asset's source tileset populating the map and…

### DIFF
--- a/gbdk-support/png2asset/png2asset.cpp
+++ b/gbdk-support/png2asset/png2asset.cpp
@@ -499,6 +499,11 @@ bool GetSourceTileset(bool keep_palette_order, unsigned int max_palettes, vector
 	image = source_tileset_image;
 	use_source_tileset = false;
 	GetMap();
+	
+	// Our source tileset shouldn't build the map arrays up
+	// Clear anything from the previous 'GetMap' call
+	map.clear();
+	map_attributes.clear();
 	use_source_tileset = true;
 
 	// Change the image variable back


### PR DESCRIPTION
tiles were appearing in VRAM twice. Which is ultimately because the first run of the GetMap function also put tiles in the map/map_attributes arrays. Those arrays are cleared after getting the source tilesets.