### PR TITLE
Examples: Auto-Banks: Fix missing MSXDOS platform target

### DIFF
--- a/gbdk-lib/examples/cross-platform/banks_autobank/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/banks_autobank/Makefile.targets
@@ -48,3 +48,8 @@ gg-clean:
 gg:
 	${MAKE} build-target PORT=z80 PLAT=gg EXT=gg
 
+msxdos-clean:
+    ${MAKE} clean-target EXT=com
+msxdos:
+    ${MAKE} build-target PORT=z80 PLAT=msxdos EXT=com
+

--- a/gbdk-lib/examples/cross-platform/banks_autobank/src/banks.c
+++ b/gbdk-lib/examples/cross-platform/banks_autobank/src/banks.c
@@ -23,7 +23,9 @@ void main(void)
 {
   uint8_t _saved_bank;
 
+  #ifndef MSXDOS // TODO
   set_default_palette();
+  #endif
   printf("Program Start...\n\n");
 
   // Call the functions, unbanked first then the banked ones


### PR DESCRIPTION
- Add a temporary shim for set_default_palette(); to allow sample to build