### PR TITLE
[docs] Update gbdev.io URL from list.html to resources.html

### DIFF
--- a/docs/pages/02_links_and_tools.md
+++ b/docs/pages/02_links_and_tools.md
@@ -29,7 +29,7 @@ This is a brief list of useful tools and information. It is not meant to be comp
   - @anchor awesome_gb
     __Awesome Game Boy Development list__  
     A list of Game Boy/Color development resources, tools, docs, related projects and homebrew.  
-    https://gbdev.io/list.html
+    https://gbdev.io/resources.html
 
 
 @anchor links_sms_gg_docs

--- a/docs/pages/04_coding_guidelines.md
+++ b/docs/pages/04_coding_guidelines.md
@@ -16,7 +16,7 @@ Writing games and other programs with GBDK will be much easier with a basic unde
 
 ## Game Boy games in C
 
-  - https://gbdev.io/list.html#c
+  - https://gbdev.io/resources.html#c
 
 # Understanding the hardware
 In addition to understanding the C language it's important to learn how the Game Boy hardware works. What it is capable of doing, what it isn't able to do, and what resources are available to work with. A good way to do this is by reading the @ref Pandocs and checking out the @ref awesome_gb list.


### PR DESCRIPTION
`gbdev.io/list.html` goes to 404. The new URL is `gbdev.io/resources.html`.