### PR TITLE
Fix build system bug accidentally introduced by PR#356

### DIFF
--- a/gbdk-lib/libc/rules-asxxxx.mk
+++ b/gbdk-lib/libc/rules-asxxxx.mk
@@ -11,6 +11,9 @@ $(BUILD)/%.o: ../%.c
 $(BUILD)/%.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
+$(BUILD)/%.o: ../../%.s
+	$(AS) -plosgff $@ $<
+
 $(BUILD)/%.o: ../%.s
 	$(AS) -plosgff $@ $<
 

--- a/gbdk-lib/libc/targets/sm83/ap/Makefile
+++ b/gbdk-lib/libc/targets/sm83/ap/Makefile
@@ -10,7 +10,7 @@ CSRC = crlf.c digits.c gprint.c gprintf.c gprintln.c gprintn.c
 ASSRC =	cgb.s cgb_palettes.s cgb_compat.s \
 	cpy_data.s \
 	drawing.s drawing_isr.s color.s \
-	../../f_ibm_full.s ../../f_ibm_sh.s ../../f_italic.s ../../f_min.s ../../f_spect.s \
+	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	get_bk_t.s get_data.s get_tile.s \
 	get_wi_t.s get_xy_t.s \
 	get_addr.s \

--- a/gbdk-lib/libc/targets/sm83/duck/Makefile
+++ b/gbdk-lib/libc/targets/sm83/duck/Makefile
@@ -10,7 +10,7 @@ CSRC = crlf.c digits.c gprint.c gprintf.c gprintln.c gprintn.c
 ASSRC =	cgb.s cgb_palettes.s cgb_compat.s \
 	cpy_data.s \
 	drawing.s drawing_isr.s color.s \
-	../../f_ibm_full.s ../../f_ibm_sh.s ../../f_italic.s ../../f_min.s ../../f_spect.s \
+	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	get_bk_t.s get_data.s get_tile.s \
 	get_wi_t.s get_xy_t.s \
 	get_addr.s \

--- a/gbdk-lib/libc/targets/sm83/gb/Makefile
+++ b/gbdk-lib/libc/targets/sm83/gb/Makefile
@@ -10,7 +10,7 @@ CSRC = crlf.c digits.c gprint.c gprintf.c gprintln.c gprintn.c
 ASSRC =	cgb.s cgb_palettes.s cgb_compat.s \
 	cpy_data.s \
 	drawing.s drawing_isr.s color.s \
-	../../f_ibm_full.s ../../f_ibm_sh.s ../../f_italic.s ../../f_min.s ../../f_spect.s \
+	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	get_bk_t.s get_data.s get_tile.s \
 	get_wi_t.s get_xy_t.s \
 	get_addr.s \

--- a/gbdk-lib/libc/targets/z80/gg/Makefile
+++ b/gbdk-lib/libc/targets/z80/gg/Makefile
@@ -17,7 +17,7 @@ ASSRC =	set_interrupts.s \
 	set_tile.s \
 	sms_fill_rect.s sms_fill_rect_xy.s sms_fill_rect_compat.s sms_fill_rect_xy_compat.s \
 	sms_metasprites.s sms_metasprites_hide.s sms_metasprites_hide_spr.s \
-	../../f_ibm_full.s ../../f_ibm_sh.s ../../f_italic.s ../../f_min.s ../../f_spect.s \
+	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	font.s color.s \
 	putchar.s \
 	scroll.s cls.s gotoxy.s \

--- a/gbdk-lib/libc/targets/z80/sms/Makefile
+++ b/gbdk-lib/libc/targets/z80/sms/Makefile
@@ -17,7 +17,7 @@ ASSRC =	set_interrupts.s \
 	set_tile.s \
 	sms_fill_rect.s sms_fill_rect_xy.s sms_fill_rect_compat.s sms_fill_rect_xy_compat.s \
 	sms_metasprites.s sms_metasprites_hide.s sms_metasprites_hide_spr.s \
-	../../f_ibm_full.s ../../f_ibm_sh.s ../../f_italic.s ../../f_min.s ../../f_spect.s \
+	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	font.s color.s \
 	putchar.s \
 	scroll.s cls.s gotoxy.s \


### PR DESCRIPTION
* Strip all relative paths from font filenames in each targets/CPU/Makefile
* Add additional rule for stripping ../../ from .o filename in rules-asxxxx.mk