### PR TITLE
Fix makebin build bug causing internal fork to get overwritten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ gbdk-dist-examples-clean:
 
 
 # Copy SDDC executable files
-SDCC_BINS = makebin packihx sdar sdasgb sdcc sdcdb sdcpp sdldgb sdnm sdobjcopy sdranlib sz80 sdasz80 sdldz80 sdas6500 sdld
+SDCC_BINS = packihx sdar sdasgb sdcc sdcdb sdcpp sdldgb sdnm sdobjcopy sdranlib sz80 sdasz80 sdldz80 sdas6500 sdld
 ifeq ($(OS),Windows_NT)
 MINGW64_RUNTIME = \
 	libgcc_s_seh-1.dll \


### PR DESCRIPTION
* Remove makebin from list of SDCC binaries to copy in sdcc-install build step
