### PR TITLE
NES joypad support

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -9,6 +9,7 @@ CSRC = crlf.c
 
 ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	font.s font_color.s set_data.s set_1bit_data.s color.s mode.s \
+	pad.s pad_ex.s \
 	crt0.s
 
 CRT0 =	crt0.s

--- a/gbdk-lib/libc/targets/mos6502/nes/pad.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/pad.s
@@ -1,0 +1,43 @@
+    .include    "global.s"
+
+    .area   _HOME
+
+_read_joypad::
+    ; Strobe to latch joypad data
+    lda #1
+    sta JOY1
+    lda #0
+    sta JOY1
+    ;
+    ldy #8
+_read_joypad_loop:
+    lda JOY1,x
+    lsr
+    ror *.tmp+1
+    dey
+    bne _read_joypad_loop
+    lda *.tmp+1
+    rts
+
+    ;; Wait until all buttons have been released
+.padup::
+_waitpadup::
+    jsr .jpad
+    beq _waitpadup
+    rts
+
+    ;; Get Keypad Button Status
+_joypad::
+.jpad::
+    ldx #0
+    jmp _read_joypad
+
+    ;; Wait for the key to be pressed
+_waitpad::
+.wait_pad::
+    sta *.tmp
+.wait_pad_loop:
+    jsr .jpad
+    and *.tmp
+    beq .wait_pad_loop
+    rts

--- a/gbdk-lib/libc/targets/mos6502/pad_ex.s
+++ b/gbdk-lib/libc/targets/mos6502/pad_ex.s
@@ -1,0 +1,45 @@
+    .include    "global.s"
+
+    MAX_JOYPADS = 2
+    .globl _read_joypad
+
+    .area   OSEG (PAG, OVR)
+    _joypad_init_PARM_2::       .ds 2
+
+    .area   _HOME
+
+_joypad_init::
+    ; Report at most MAX_JOYPADS number of joypads available
+    cmp #MAX_JOYPADS
+    bcc 1$
+    lda #MAX_JOYPADS
+1$:
+    pha
+    tax
+    ldy #0
+    sta [*_joypad_init_PARM_2],y
+    iny
+    lda #0
+_joypad_init_loop:
+    sta [*_joypad_init_PARM_2],y
+    iny
+    dex
+    bne _joypad_init_loop
+    pla
+    rts
+
+_joypad_ex::
+.joypad_ex::
+    sta *_joypad_init_PARM_2
+    stx *_joypad_init_PARM_2+1
+    ; Joypad #0
+    ldx #0
+    jsr _read_joypad
+    ldy #1
+    sta [*_joypad_init_PARM_2],y
+    ; Joypad #1
+    ldx #1
+    jsr _read_joypad
+    ldy #2
+    sta [*_joypad_init_PARM_2],y
+    rts


### PR DESCRIPTION
* Add NES-specific code pad.s for reading NES joypads
* Add 6502 code pad_ex.s for reading up to 2 joypads into the joypads_t struct