### PR TITLE
Enable examples/cross-platform/pong for NES

### DIFF
--- a/gbdk-lib/examples/cross-platform/pong/Makefile
+++ b/gbdk-lib/examples/cross-platform/pong/Makefile
@@ -6,19 +6,20 @@ LCC = $(GBDK_HOME)bin/lcc
 # Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
 # They can also be built/cleaned individually: "make gg" and "make gg-clean"
 # Possible are: gb gbc pocket megaduck sms gg
-TARGETS=gb pocket megaduck sms gg
+TARGETS=gb pocket megaduck sms gg nes
 
 # Configure platform specific LCC flags here:
-LCCFLAGS_gb      = -Wm-ys -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
-LCCFLAGS_pocket  = -Wm-ys -Wl-yt0x1B # Usually the same as required for .gb
-LCCFLAGS_duck    = -Wm-ys -Wl-yt0x1B # Usually the same as required for .gb
-LCCFLAGS_gbc     = -Wm-ys -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
-LCCFLAGS_sms     =
-LCCFLAGS_gg      =
+LCCFLAGS_gb      = -Wm-ys -Wl-yt0x1B -autobank # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wm-ys -Wl-yt0x1B -autobank # Usually the same as required for .gb
+LCCFLAGS_duck    = -Wm-ys -Wl-yt0x1B -autobank # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wm-ys -Wl-yt0x1B -Wm-yc -autobank # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_sms     = -autobank
+LCCFLAGS_gg      = -autobank
+LCCFLAGS_nes     = 
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 
-LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
 # LCCFLAGS += -debug # Uncomment to enable debug output
 # LCCFLAGS += -v     # Uncomment for lcc verbose output
 

--- a/gbdk-lib/examples/cross-platform/pong/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/pong/Makefile.targets
@@ -48,3 +48,8 @@ gg-clean:
 gg:
 	${MAKE} build-target PORT=z80 PLAT=gg EXT=gg
 
+
+nes-clean:
+	${MAKE} clean-target EXT=nes
+nes:
+	${MAKE} build-target PORT=mos6502 PLAT=nes EXT=nes

--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -9,6 +9,7 @@ CSRC = crlf.c
 
 ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	font.s font_color.s set_data.s set_1bit_data.s color.s mode.s \
+	pad.s pad_ex.s \
 	crt0.s
 
 CRT0 =	crt0.s

--- a/gbdk-lib/libc/targets/mos6502/nes/pad.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/pad.s
@@ -1,0 +1,43 @@
+    .include    "global.s"
+
+    .area   _HOME
+
+_read_joypad::
+    ; Strobe to latch joypad data
+    lda #1
+    sta JOY1
+    lda #0
+    sta JOY1
+    ;
+    ldy #8
+_read_joypad_loop:
+    lda JOY1,x
+    lsr
+    ror *.tmp+1
+    dey
+    bne _read_joypad_loop
+    lda *.tmp+1
+    rts
+
+    ;; Wait until all buttons have been released
+.padup::
+_waitpadup::
+    jsr .jpad
+    beq _waitpadup
+    rts
+
+    ;; Get Keypad Button Status
+_joypad::
+.jpad::
+    ldx #0
+    jmp _read_joypad
+
+    ;; Wait for the key to be pressed
+_waitpad::
+.wait_pad::
+    sta *.tmp
+.wait_pad_loop:
+    jsr .jpad
+    and *.tmp
+    beq .wait_pad_loop
+    rts

--- a/gbdk-lib/libc/targets/mos6502/pad_ex.s
+++ b/gbdk-lib/libc/targets/mos6502/pad_ex.s
@@ -1,0 +1,45 @@
+    .include    "global.s"
+
+    MAX_JOYPADS = 2
+    .globl _read_joypad
+
+    .area   OSEG (PAG, OVR)
+    _joypad_init_PARM_2::       .ds 2
+
+    .area   _HOME
+
+_joypad_init::
+    ; Report at most MAX_JOYPADS number of joypads available
+    cmp #MAX_JOYPADS
+    bcc 1$
+    lda #MAX_JOYPADS
+1$:
+    pha
+    tax
+    ldy #0
+    sta [*_joypad_init_PARM_2],y
+    iny
+    lda #0
+_joypad_init_loop:
+    sta [*_joypad_init_PARM_2],y
+    iny
+    dex
+    bne _joypad_init_loop
+    pla
+    rts
+
+_joypad_ex::
+.joypad_ex::
+    sta *_joypad_init_PARM_2
+    stx *_joypad_init_PARM_2+1
+    ; Joypad #0
+    ldx #0
+    jsr _read_joypad
+    ldy #1
+    sta [*_joypad_init_PARM_2],y
+    ; Joypad #1
+    ldx #1
+    jsr _read_joypad
+    ldy #2
+    sta [*_joypad_init_PARM_2],y
+    rts


### PR DESCRIPTION
* Add "nes" to TARGETS in Makefile, and change platform specific flags to not use -autobank for NES
* Add nes/nes-clean to Makefile.targets

Note: Collision with pads is currently broken for NES - to-be-investigated