### PR TITLE
Add (non-flipped) metasprite support for NES

### DIFF
--- a/gbdk-lib/examples/cross-platform/metasprites/Makefile
+++ b/gbdk-lib/examples/cross-platform/metasprites/Makefile
@@ -7,19 +7,20 @@ PNG2ASSET = $(GBDK_HOME)/bin/png2asset
 # Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
 # They can also be built/cleaned individually: "make gg" and "make gg-clean"
 # Possible are: gb gbc pocket megaduck sms gg
-TARGETS=gb pocket megaduck sms gg
+TARGETS=gb pocket megaduck sms gg nes
 
 # Configure platform specific LCC flags here:
-LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
-LCCFLAGS_pocket  = -Wl-yt0x1B # Usually the same as required for .gb
-LCCFLAGS_duck    = -Wl-yt0x1B # Usually the same as required for .gb
-LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
-LCCFLAGS_sms     =
-LCCFLAGS_gg      =
+LCCFLAGS_gb      = -Wl-yt0x1B -autobank # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wl-yt0x1B -autobank # Usually the same as required for .gb
+LCCFLAGS_duck    = -Wl-yt0x1B -autobank # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc -autobank # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_sms     = -autobank
+LCCFLAGS_gg      = -autobank
+LCCFLAGS_nes     = 
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 
-LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
 # LCCFLAGS += -debug # Uncomment to enable debug output
 # LCCFLAGS += -v     # Uncomment for lcc verbose output
 

--- a/gbdk-lib/examples/cross-platform/metasprites/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/metasprites/Makefile.targets
@@ -48,3 +48,7 @@ gg-clean:
 gg:
 	${MAKE} build-target PORT=z80 PLAT=gg EXT=gg
 
+nes-clean:
+	${MAKE} clean-target EXT=nes
+nes:
+	${MAKE} build-target PORT=mos6502 PLAT=nes EXT=nes

--- a/gbdk-lib/include/gbdk/metasprites.h
+++ b/gbdk-lib/include/gbdk/metasprites.h
@@ -7,6 +7,8 @@
   #include <sms/metasprites.h>
 #elif defined(__TARGET_msxdos)
   #include <msx/metasprites.h>
+#elif defined(__TARGET_nes)
+  #include <nes/metasprites.h>
 #else
   #error Unrecognized port
 #endif

--- a/gbdk-lib/include/nes/metasprites.h
+++ b/gbdk-lib/include/nes/metasprites.h
@@ -1,0 +1,231 @@
+/** @file nes/metasprites.h
+
+    # Metasprite support
+
+    A metasprite is a larger sprite made up from a
+    collection of smaller individual hardware sprites.
+    Different frames of the same metasprites can share
+    tile data.
+
+    The api supports metasprites in both
+    @ref SPRITES_8x8 and @ref SPRITES_8x16 mode. If
+    8x16 mode is used then the height of the metasprite
+    must be a multiple of 16.
+
+    The origin (pivot) for the metasprite is not required
+    to be in the upper left-hand corner as with regular
+    hardware sprites.
+
+    Use the @ref utility_png2asset tool to convert single
+    or multiple frames of graphics into metasprite
+    structured data for use with the ...metasprite...()
+    functions.
+
+    # Metasprites composed of variable numbers of sprites
+
+    When using png2asset, it's common for the output of
+    different frames to be composed of different numbers
+    of hardware sprites (since it's trying to create each
+    frame as efficiently as possible). Due to that, it's
+    good practice to clear out (hide) unused sprites in the
+    shadow_OAM that have been set by previous frames.
+
+    \code
+    // Example:
+    // Hide rest of the hardware sprites, because amount
+    // of sprites differ between animation frames.
+    // (where hiwater == last hardware sprite used + 1)
+    for (uint8_t i = hiwater; i < 64; i++) shadow_OAM[i].y = 0;
+    \endcode
+
+    @anchor metasprite_and_sprite_properties
+    # Metasprites and sprite properties (including cgb palette)
+
+    When the move_metasprite_*() functions are called they
+    update all properties for the affected sprites in the
+    Shadow OAM. This means any existing property flags set
+    for a sprite will get overwritten.
+
+    How to use sprite property flags with metasprites:
+    - Metsaprite structures can be copied into RAM so their
+      property flags can be modified at runtime.
+    - The metasprite structures can have the property flags
+      modified before compilation (such as with `-sp <props>`
+      in the @ref utility_png2asset "png2asset" tool).
+    - Update properties for the affected sprites after calling
+      a move_metasprite_*() function.
+*/
+
+#ifndef _METASPRITES_H_INCLUDE
+#define _METASPRITES_H_INCLUDE
+
+#include <nes/hardware.h>
+#include <types.h>
+#include <stdint.h>
+
+/** Metasprite sub-item structure
+    @param dy        (int8_t)  Y coordinate of the sprite relative to the metasprite origin (pivot)
+    @param dx        (int8_t)  X coordinate of the sprite relative to the metasprite origin (pivot)
+    @param dtile     (uint8_t) Start tile relative to the metasprites own set of tiles
+    @param props     (uint8_t) Property Flags
+
+    Metasprites are built from multiple metasprite_t items (one for each sub-sprite)
+    and a pool of tiles they reference. If a metasprite has multiple frames then each
+    frame will be built from some number of metasprite_t items (which may vary based
+    on how many sprites are required for that particular frame).
+
+    A metasprite frame is terminated with a {metasprite_end} entry.
+*/
+typedef struct metasprite_t {
+    int8_t  dy, dx;
+    uint8_t dtile;
+    uint8_t props;
+} metasprite_t;
+
+#define metasprite_end -128
+#define METASPR_ITEM(dy,dx,dt,a) {(dy),(dx),(dt),(a)}
+#define METASPR_TERM {metasprite_end}
+
+extern const void * __current_metasprite;
+extern uint8_t __current_base_tile;
+extern uint8_t __render_shadow_OAM;
+
+
+static uint8_t __move_metasprite(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
+static uint8_t __move_metasprite_vflip(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
+static uint8_t __move_metasprite_hflip(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
+static uint8_t __move_metasprite_hvflip(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
+static void __hide_metasprite(uint8_t id) OLDCALL;
+
+/**
+ * Hides all hardware sprites in range from <= X < to
+ * @param from start OAM index
+ * @param to finish OAM index
+ */
+void hide_sprites_range(UINT8 from, UINT8 to) OLDCALL;
+
+/** Moves metasprite to the absolute position x and y
+
+    @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
+    @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_sprite  Number of the first hardware sprite to be used by the metasprite
+    @param x            Absolute x coordinate of the sprite
+    @param y            Absolute y coordinate of the sprite
+
+    Moves __metasprite__ to the absolute position __x__ and __y__
+    (with __no flip__ on the X or Y axis). Hardware sprites are
+    allocated starting from __base_sprite__, using tiles
+    starting from __base_tile__.
+
+    Sets:
+    \li __current_metasprite = metasprite;
+    \li __current_base_tile = base_tile;
+
+    Note: Overwrites OAM sprite properties (such as palette), see
+          @ref metasprite_and_sprite_properties "Metasprites and sprite properties".
+
+    @return Number of hardware sprites used to draw this metasprite
+ */
+inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
+    __current_metasprite = metasprite;
+    __current_base_tile = base_tile;
+    return __move_metasprite(base_sprite, x, y);
+}
+
+/** Moves metasprite to the absolute position x and y, __flipped on the Y axis__
+
+    @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
+    @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_sprite  Number of the first hardware sprite to be used by the metasprite
+    @param x            Absolute x coordinate of the sprite
+    @param y            Absolute y coordinate of the sprite
+
+    Same as @ref move_metasprite(), but with the metasprite flipped on the Y axis only.
+
+    Sets:
+    \li __current_metasprite = metasprite;
+    \li __current_base_tile = base_tile;
+
+    Note: Overwrites OAM sprite properties (such as palette), see
+          @ref metasprite_and_sprite_properties "Metasprites and sprite properties".
+
+    @return Number of hardware sprites used to draw this metasprite
+
+    @see move_metasprite()
+*/
+inline uint8_t move_metasprite_vflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
+    __current_metasprite = metasprite;
+    __current_base_tile = base_tile;
+    return __move_metasprite_vflip(base_sprite, x - 8, y);
+}
+
+
+/** Moves metasprite to the absolute position x and y, __flipped on the X axis__
+
+    @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
+    @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_sprite  Number of the first hardware sprite to be used by the metasprite
+    @param x            Absolute x coordinate of the sprite
+    @param y            Absolute y coordinate of the sprite
+
+    Same as @ref move_metasprite(), but with the metasprite flipped on the X axis only.
+
+    Sets:
+    \li __current_metasprite = metasprite;
+    \li __current_base_tile = base_tile;
+
+    Note: Overwrites OAM sprite properties (such as palette), see
+          @ref metasprite_and_sprite_properties "Metasprites and sprite properties".
+
+    @return Number of hardware sprites used to draw this metasprite
+
+    @see move_metasprite()
+*/
+inline uint8_t move_metasprite_hflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
+    __current_metasprite = metasprite;
+    __current_base_tile = base_tile;
+    return __move_metasprite_hflip(base_sprite, x, y - ((shadow_PPUCTRL & PPUCTRL_SPR_8X16) ? 16 : 8) );
+}
+
+/** Moves metasprite to the absolute position x and y, __flipped on the X and Y axis__
+
+    @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
+    @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_sprite  Number of the first hardware sprite to be used by the metasprite
+    @param x            Absolute x coordinate of the sprite
+    @param y            Absolute y coordinate of the sprite
+
+    Same as @ref move_metasprite(), but with the metasprite flipped on both the X and Y axis.
+
+    Sets:
+    \li __current_metasprite = metasprite;
+    \li __current_base_tile = base_tile;
+
+    Note: Overwrites OAM sprite properties (such as palette), see
+          @ref metasprite_and_sprite_properties "Metasprites and sprite properties".
+
+    @return Number of hardware sprites used to draw this metasprite
+
+    @see move_metasprite()
+*/
+inline uint8_t move_metasprite_hvflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
+    __current_metasprite = metasprite;
+    __current_base_tile = base_tile;
+    return __move_metasprite_hvflip(base_sprite, x - 8, y - ((shadow_PPUCTRL & PPUCTRL_SPR_8X16) ? 16 : 8));
+}
+
+/** Hides a metasprite from the screen
+
+    @param metasprite    Pointer to first struct of the desired metasprite frame
+    @param base_sprite   Number of hardware sprite to start with
+
+    Sets:
+    \li __current_metasprite = metasprite;
+
+ **/
+inline void hide_metasprite(const metasprite_t * metasprite, uint8_t base_sprite) {
+    __current_metasprite = metasprite;
+    __hide_metasprite(base_sprite);
+}
+
+#endif

--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -9,6 +9,8 @@ CSRC = crlf.c
 
 ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	font.s font_color.s set_data.s set_1bit_data.s color.s mode.s \
+	metasprites.s metasprites_hide.s metasprites_hide_spr.s \
+	fill_rect_bk.s \
 	pad.s pad_ex.s \
 	crt0.s
 

--- a/gbdk-lib/libc/targets/mos6502/nes/fill_rect_bk.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/fill_rect_bk.s
@@ -1,0 +1,49 @@
+    .include    "global.s"
+
+    .area   OSEG (PAG, OVR)
+    _fill_bkg_rect_PARM_3::     .ds 1
+    _fill_bkg_rect_PARM_4::     .ds 1
+    _fill_bkg_rect_PARM_5::     .ds 1
+    .xpos:                      .ds 1
+    .ypos:                      .ds 1
+
+    .area   _HOME
+
+_fill_bkg_rect::
+    ; TODO: Switch to use vram transfer buffer when screen not blanked
+    .define .width  "_fill_bkg_rect_PARM_3"
+    .define .height "_fill_bkg_rect_PARM_4"
+    .define .tile   "_fill_bkg_rect_PARM_5"
+    ldy *.height
+1$:
+    lda #0
+    sta *.tmp+1
+    lda *.ypos
+    asl
+    rol *.tmp+1
+    asl
+    rol *.tmp+1
+    asl
+    rol *.tmp+1
+    asl
+    rol *.tmp+1
+    asl
+    rol *.tmp+1
+    ora *.xpos
+    sta *.tmp
+    ;
+    lda *.tmp+1
+    ora #0x20
+    sta PPUADDR
+    lda *.tmp
+    sta PPUADDR
+    ldx *.width
+    lda *.tile
+2$:
+    sta PPUDATA
+    dex
+    bne 2$
+    inc *.ypos
+    dey
+    bne 1$
+    rts

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -56,6 +56,11 @@
 
         OAM_COUNT       = 64  ; number of OAM entries in OAM RAM
 
+        OAM_POS_Y       = 0
+        OAM_TILE_INDEX  = 1
+        OAM_ATTRIBUTES  = 2
+        OAM_POS_X       = 3
+
         OAMF_PRI        = 0b00100000 ; Priority
         OAMF_YFLIP      = 0b10000000 ; Y flip
         OAMF_XFLIP      = 0b01000000 ; X flip

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites.s
@@ -1,0 +1,76 @@
+    .include    "global.s"
+
+    .title  "Metasprites"
+    .module Metasprites
+
+    .area	OSEG (PAG, OVR)
+    ___current_metasprite::     .ds 2
+    ___current_base_tile::      .ds 1
+    ___move_metasprite_PARM_3:: .ds 2
+
+    .area   _INITIALIZED
+    ___render_shadow_OAM:: .ds     0x01
+
+    .area   _INITIALIZER
+    .db     #>_shadow_OAM
+
+    .area   _HOME
+
+; uint8_t __move_metasprite(uint8_t id, uint8_t x, uint8_t y)
+.define xPos  ".tmp"
+.define yPos  "___move_metasprite_PARM_3"
+.define id    ".tmp+1"
+___move_metasprite::
+    sta *id
+    stx xPos
+    asl
+    asl
+    tax
+    ; Make 8x16 mode bit fetch from second pattern table by setting bit0 of tile index
+    lda *_shadow_PPUCTRL
+    lsr
+    lsr
+    lsr
+    lsr
+    lsr
+    and #1
+    ora *___current_base_tile
+    sta *___current_base_tile
+    ldy #0
+___move_metasprite_loop:
+    lda [*___current_metasprite],y      ; dy
+    iny
+    cmp #0x80
+    beq ___move_metasprite_end
+    clc
+    adc *yPos
+    sta *yPos
+    sta _shadow_OAM+OAM_POS_Y,x
+    lda [*___current_metasprite],y      ; dx
+    iny
+    clc
+    adc *xPos
+    sta *xPos
+    sta _shadow_OAM+OAM_POS_X,x
+    lda [*___current_metasprite],y      ; tile index
+    iny
+    clc
+    adc *___current_base_tile
+    sta _shadow_OAM+OAM_TILE_INDEX,x
+    lda [*___current_metasprite],y      ; props
+    iny
+    ; TODO: Handle attributes in png2asset
+    sta _shadow_OAM+OAM_ATTRIBUTES,x
+    inx
+    inx
+    inx
+    inx
+    bne ___move_metasprite_loop
+___move_metasprite_end:
+    ; Return number of hardware sprites used
+    txa
+    lsr
+    lsr
+    sec
+    sbc *id
+    rts

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites_hide.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites_hide.s
@@ -1,0 +1,33 @@
+    .include    "global.s"
+
+    .title  "Metasprites"
+    .module Metasprites
+
+    .globl  ___current_metasprite, ___render_shadow_OAM
+
+    .area   _HOME
+
+; void __hide_metasprite(uint8_t id)
+
+___hide_metasprite::
+    asl
+    asl
+    tax
+    ldy #0
+___hide_metasprite_loop:
+    lda [*___current_metasprite],y
+    cmp #0x80
+    beq ___hide_metasprite_end
+    iny
+    iny
+    iny
+    iny
+    lda #240
+    sta _shadow_OAM+OAM_POS_Y,x
+    inx
+    inx
+    inx
+    inx
+    bne ___hide_metasprite_loop
+___hide_metasprite_end:
+    rts

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites_hide_spr.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites_hide_spr.s
@@ -1,0 +1,31 @@
+    .include    "global.s"
+
+    .title  "Metasprites"
+    .module Metasprites
+
+    .globl  ___render_shadow_OAM
+
+    .area   _HOME
+
+; void hide_sprites_range(UINT8 from, UINT8 to)
+
+_hide_sprites_range::
+    pha
+    txa
+    asl
+    asl
+    sta *.tmp
+    pla
+    asl
+    asl
+    tax
+    lda #240
+_hide_sprites_range_loop:
+    sta _shadow_OAM+OAM_POS_Y,x
+    inx
+    inx
+    inx
+    inx
+    cpx *.tmp
+    bne _hide_sprites_range_loop
+    rts


### PR DESCRIPTION
* Add implementation of move_metasprite in metasprites.s
* Add implementation of hide_metasprite in metasprites_hide.s
* Add implementation of hide_sprites_range in metasprites_hide_spr.s
* Enable examples/cross-platform/metasprites for NES