### PR TITLE
Docs: Initial 4.1.0 migration notes, Release notes shim

### DIFF
--- a/docs/pages/04_coding_guidelines.md
+++ b/docs/pages/04_coding_guidelines.md
@@ -222,6 +222,7 @@ Also See:
 For many applications C is fast enough but in intensive functions are sometimes better written in assembly. This section deals with interfacing your core C program with fast assembly sub routines. 
 
 
+@anchor sdcc_calling_convention
 ## Calling convention
 
 SDCC in common with almost all C compilers prepends a `_` to any function names. For example the function `printf(...)` begins at the label `_printf::.` Note that all functions are declared global.

--- a/docs/pages/06b_supported_consoles.md
+++ b/docs/pages/06b_supported_consoles.md
@@ -44,16 +44,19 @@ MSXDOS requires an additional build step after makebin to create the final binar
   - `makecom <image.bin> [<image.noi>] <output.com>`
 
 
+@anchor console_port_plat_settings
 ## Console Port and Platform Settings
-  - Nintendo Game Boy / Game Boy Color
-    - @ref lcc : `-mgbz80:gb`
-    - port:`gbz80`, plat:`gb`
+Note: Starting with GBDK-2020 4.1.0 and SDCC 4.2, the Game Boy and related clones use `sm83` for the port instead of `gbz80`
+
+  - Nintendo Game Boy / Game Boy Color    
+    - @ref lcc : `-msm83:gb`
+    - port:`sm83`, plat:`gb`
   - Analogue Pocket
-    - @ref lcc : `-mgbz80:ap`
-    - port:`gbz80`, plat:`ap`
+    - @ref lcc : `-msm83:ap`
+    - port:`sm83`, plat:`ap`
   - Mega Duck / Cougar Boy
-    - @ref lcc : `-mgbz80:duck`
-    - port:`gbz80`, plat:`duck`
+    - @ref lcc : `-msm83:duck`
+    - port:`sm83`, plat:`duck`
 
   - Sega Master System
     - @ref lcc : `-mz80:sms`

--- a/docs/pages/08_faq.md
+++ b/docs/pages/08_faq.md
@@ -30,6 +30,10 @@
     - See @ref setting_mbc_and_rom_ram_banks <!-- -->  
 
 # Errors / Compiling / Toolchain
+  @anchor faq_gbz80_sm83_old_port_name_error
+  - What does the error `old "gbz80" SDCC PORT name specified (in "-mgbz80:gb"). Use "sm83" instead. You must update your build settings.` mean?
+    - The `PORT` name for the Game Boy and related clones changed from `gbz80` to `sm83`. You must change your Makefile, Build settings, etc to use the new name. Additional details in the @ref console_port_plat_settings "Console Port and Platform Settings" section.  <!-- -->  
+
   @anchor faq_sdcc_peephole_instruction_error
   - What does `z80instructionSize() failed to parse line node, assuming 999 bytes` mean?
     - This is a known issue with SDCC Peephole Optimizer parsing and can be ignored. A bug report has been filed for it. <!-- -->  

--- a/docs/pages/09_migrating_new_versions.md
+++ b/docs/pages/09_migrating_new_versions.md
@@ -2,14 +2,21 @@
 
 This section contains information that may be useful to know or important when upgrading to a newer GBDK release.
 
-# GBDK 2020 versions
+# GBDK-2020 versions
 
-## Porting to GBDK 2020 4.0.6
+
+## Porting to GBDK-2020 4.1.0
+  - GBDK now requires SDCC 4.2 or higher with GBDK-2020 patches for the the z80 linker
+    - The default calling convention changed in SDCC 4.2, see @ref sdcc_calling_convention "Calling Conventions" for more details.
+    - The SDCC `PORT` name for the Game Boy and related clones changed from `gbz80` to `sm83`. Additional details in the @ref console_port_plat_settings "Console Port and Platform Settings" section and @ref faq_gbz80_sm83_old_port_name_error "FAQ entry". @ref LCC will error out if the old `PORT` name is passed in.
+
+
+## Porting to GBDK-2020 4.0.6
   - Renamed `bgb_emu.h` to `emu_debug.h` and BGB_* functions to EMU_*
     - Aliases for the BGB_* ones and a `bgb_emu.h` shim are present for backward compatibility, but updating to the new naming is recommended
 
 
-## Porting to GBDK 2020 4.0.5
+## Porting to GBDK-2020 4.0.5
   - GBDK now requires SDCC 12259 or higher with GBDK-2020 patches
   - @ref utility_png2asset "png2asset" is the new name for the `png2mtspr` utility
   - @ref lcc : Changed default output format when not specified from `.ihx` to `.gb` (or other active rom extension)
@@ -21,22 +28,22 @@ This section contains information that may be useful to know or important when u
   - The following header files which are now cross platform were moved from `gb/` to `gbdk/`: `bcd.h`, `console.h`, `far_ptr.h`, `font.h`, `gbdecompress.h`, `gbdk-lib.h`, `incbin.h`, `metasprites.h`, `platform.h`, `version.h`
     - When including them use `#include <gbdk/...>` instead of `#include <gb/>`
   
-## Porting to GBDK 2020 4.0.4
+## Porting to GBDK-2020 4.0.4
   - GBDK now requires SDCC 12238 or higher
   - Made sample.h, cgb.h and sgb.h independent from gb.h
 
 
-## Porting to GBDK 2020 4.0.3
+## Porting to GBDK-2020 4.0.3
   - No significant changes required
 
 
-## Porting to GBDK 2020 4.0.2
+## Porting to GBDK-2020 4.0.2
  - The default font has been reduced from 256 to 96 characters.
    - Code using special characters may need to be updated.
    - The off-by-1 character index offset was removed for fonts. Old fonts with the offset need to be re-adjusted.
 
 
-## Porting to GBDK 2020 4.0.1
+## Porting to GBDK-2020 4.0.1
  - __Important!__ : The `WRAM` memory region is no longer automatically initialized to zeros during startup.
    - Any variables which are declared without being initialized may have __indeterminate values instead of 0__ on startup. This might reveal previously hidden bugs in your code.
    - Check your code for variables that are not initialized before use.
@@ -45,7 +52,7 @@ This section contains information that may be useful to know or important when u
  - `set_*_tiles()` now wrap maps around horizontal and vertical boundaries correctly. Code relying on it not wrapping correctly may be affected.
 
 
-## Porting to GBDK 2020 4.0
+## Porting to GBDK-2020 4.0
  - GBDK now requires SDCC 4.0.3 or higher
  - The old linker `link-gbz80` has been REMOVED, the linker @ref sdldgb from SDCC is used.
    - Due to the linker change, there are no longer warnings about multiple writes to the same ROM address.
@@ -54,17 +61,17 @@ This section contains information that may be useful to know or important when u
  - OAM symbol has been renamed to `_shadow_OAM`, that allows accessing shadow OAM directly from C code
 
 
-## Porting to GBDK 2020 3.2
+## Porting to GBDK-2020 3.2
   - No significant changes required
 
-## Porting to GBDK 2020 3.1.1
+## Porting to GBDK-2020 3.1.1
   - No significant changes required
 
-## Porting to GBDK 2020 3.1
+## Porting to GBDK-2020 3.1
   - Behavior formerly enabled by USE_SFR_FOR_REG is on by default now (no need to specify it, it isn't a tested `#ifdef` anymore). check here why:
     https://gbdev.gg8.se/forums/viewtopic.php?id=697
 
-## Porting to GBDK 2020 3.0.1
+## Porting to GBDK-2020 3.0.1
  - LCC was upgraded to use SDCC v4.0. Makefile changes may be required
    - The symbol format changed. To get bgb compatible symbols turn on `.noi` output (LCC argument: `-Wl-j` or `-debug`) and use `-Wm-yS`
    - ?? Suggested: With LCC argument: `-Wa-l` (sdasgb:`-a   All user symbols made global`)

--- a/docs/pages/10_release_notes.md
+++ b/docs/pages/10_release_notes.md
@@ -1,11 +1,16 @@
 @page docs_releases GBDK Releases
 
-The GBDK 2020 releases can be found on Github:
+The GBDK-2020 releases can be found on Github:
 https://github.com/gbdk-2020/gbdk-2020/releases
 
 
-# GBDK 2020 Release Notes
-## GBDK 2020 4.0.6
+# GBDK-2020 Release Notes
+
+## GBDK-2020 4.1.0
+  2022
+
+
+## GBDK-2020 4.0.6
   2022/02
   - Building GBDK
     - Changed to target older version of macOS (10.10) when building for better compatibility
@@ -56,7 +61,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
     - Added new section: Migrating From Pre-GBDK-2020 Tutorials
 
 
-## GBDK 2020 4.0.5
+## GBDK-2020 4.0.5
   2021/09
   - Includes SDCC version 12539 with GBDK-2020 patches for Z80
   - Known Issues
@@ -117,7 +122,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
     - Various doc updates and improvements
   
 
-## GBDK 2020 4.0.4
+## GBDK-2020 4.0.4
   2021/06
   - Library
     - Support SDCC INITIALIZER area (SDCC ~12207+)
@@ -154,7 +159,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
     - Various doc updates and improvements
 
 
-## GBDK 2020 4.0.3
+## GBDK-2020 4.0.3
   2021/03
   - Library
     - Added @ref set_vram_byte()
@@ -182,7 +187,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
     - Added PDF version of docs
  
 
-## GBDK 2020 4.0.2
+## GBDK-2020 4.0.2
   2021/01/17
   - Includes SDCC snapshot build version 12016 (has a fix for duplicate debug symbols generated from inlined header functions which GBDK 4.0+ uses)
   - Updated documentation
@@ -202,7 +207,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
   - Examples: Added bgb debug example
 
 
-## GBDK 2020 4.0.1
+## GBDK-2020 4.0.1
   2020/11/14
   - Updated API documentation
   - IHX is checked for correctness before the makebin stage. That allows to warn about overwriting the same ROM addresses (SDCC toolchain does not check this anymore).
@@ -222,7 +227,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - Fix output not working if target is -o some_filename.ihx
 
 
-## GBDK 2020 4.0
+## GBDK-2020 4.0
   2020/10/01
   - GBDK now requires SDCC 4.0.3 or higher, that has fully working toolchain. Old link-gbz80 linker is not used anymore, sdldgb and makebin are used to link objects and produce binary roms; maccer tool is no longer needed either
     - SDCC 4.0.3 has much better code generator which produces smaller and faster code. Code is twice faster
@@ -245,19 +250,19 @@ https://github.com/gbdk-2020/gbdk-2020/releases
     - quoted paths with spaces are working now
 
 
-## GBDK 2020 3.2
+## GBDK-2020 3.2
   2020/06/05
   - Fixed OAM initialization that was causing a bad access to VRAM
   - Interrupt handlers now wait for lcd controller mode 0 or 1 by default to prevent access to inaccessible VRAM in several functions (like set_bkg_tiles)
   - Several optimizations here and there
 
 
-## GBDK 2020 3.1.1
+## GBDK-2020 3.1.1
   2020/05/17
   - Fixed issues with libgcc_s_dw2-1.dll
 
 
-## GBDK 2020 3.1
+## GBDK-2020 3.1
   2020/05/16
   - Banked functions are working! The patcher is fully integrated in link-gbz80, no extra tools are needed. It is based on Toxa's work
     - Check this post for more info
@@ -276,15 +281,15 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       https://gbdev.gg8.se/forums/viewtopic.php?id=710
 
 
-## GBDK 2020 3.0.1
+## GBDK-2020 3.0.1
   2020/04/12
   - Updated SDCC to v.4.0
   - Updated LCC to work with the new compiler
 
 
-## GBDK 2020 3.0
+## GBDK-2020 3.0
   2020/04/12
-  - Initial GBDK 2020 release  
+  - Initial GBDK-2020 release  
   Updated SDCC to v4.0
   The new linker is not working so the old version is still there
   There is an issue with sdagb compiling drawing.s (the JP in 


### PR DESCRIPTION
- A little naming tidy up as well
- gbz80 to sm83 info
- calling convention change