### PR TITLE
Docs: header file updates

### DIFF
--- a/docs/config/gbdk-2020-doxyfile
+++ b/docs/config/gbdk-2020-doxyfile
@@ -2169,10 +2169,10 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-# Define __PORT_gbz80 fixes some functions that would get missed in
+# Define __PORT_sm83 fixes some functions that would get missed in
 # headers that are shared by multiple platforms. Use the Game Boy
 # versions by default
-PREDEFINED=__PORT_gbz80 __TARGET_gb
+PREDEFINED=__PORT_sm83 __TARGET_gb
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/pages/09_migrating_new_versions.md
+++ b/docs/pages/09_migrating_new_versions.md
@@ -8,7 +8,7 @@ This section contains information that may be useful to know or important when u
 ## Porting to GBDK-2020 4.1.0
   - GBDK now requires SDCC 4.2 or higher with GBDK-2020 patches for the the z80 linker
     - The default calling convention changed in SDCC 4.2, see @ref sdcc_calling_convention "Calling Conventions" for more details.
-    - The SDCC `PORT` name for the Game Boy and related clones changed from `gbz80` to `sm83`. Additional details in the @ref console_port_plat_settings "Console Port and Platform Settings" section and @ref faq_gbz80_sm83_old_port_name_error "FAQ entry". @ref LCC will error out if the old `PORT` name is passed in.
+    - The SDCC `PORT` name for the Game Boy and related clones changed from `gbz80` to `sm83`. Additional details in the @ref console_port_plat_settings "Console Port and Platform Settings" section and @ref faq_gbz80_sm83_old_port_name_error "FAQ entry". @ref lcc will error out if the old `PORT` name is passed in.
 
 
 ## Porting to GBDK-2020 4.0.6

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -821,7 +821,35 @@ inline void set_2bpp_palette(uint16_t palette) {
 }
 
 extern uint16_t _current_1bpp_colors;
+
+/** Sets the Foreground and Background colors used by the set_*_1bpp_*() functions
+    @param fgcolor  Foreground color
+    @param bgcolor  Background color
+    @param mode     Draw Mode
+
+    See @ref set_1bpp_colors for details.
+*/
 void set_1bpp_colors_ex(uint8_t fgcolor, uint8_t bgcolor, uint8_t mode) OLDCALL;
+
+/** Sets the Foreground and Background colors used by the set_*_1bpp_*() functions
+    @param fgcolor  Foreground color to use
+    @param bgcolor  Background color to use
+
+    The default colors are:
+    \li Foreground: DMG_BLACK
+    \li Background: DMG_WHITE
+
+    Example:
+    \code{.c}
+    // Use DMG_BLACK as the Foreground color and DMG_LITE_GRAY
+    // as the Background color when loading 1bpp tile data.
+    set_1bpp_colors(DMG_BLACK, DMG_LITE_GRAY);
+    \endcode
+
+
+    @see DMG_BLACK, DMG_DARK_GRAY, DMG_LITE_GRAY, DMG_WHITE
+    @see set_bkg_1bpp_data, set_win_1bpp_data, set_sprite_1bpp_data
+*/
 inline void set_1bpp_colors(uint8_t fgcolor, uint8_t bgcolor) {
     set_1bpp_colors_ex(fgcolor, bgcolor, 0);
 }
@@ -856,10 +884,13 @@ void set_bkg_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data) OLD
     which gets expanded into 2 bits-per-pixel.
 
     For a given bit that represent a pixel:
-    \li 0 will be expanded into color 0
-    \li 1 will be expanded into color 1, 2 or 3 depending on color argument
+    \li 0 will be expanded into the Background color
+    \li 1 will be expanded into the Foreground color
+
+    See @ref set_1bpp_colors for details about setting the Foreground and Background colors.
 
     @see SHOW_BKG, HIDE_BKG, set_bkg_tiles
+    @see set_win_1bpp_data, set_sprite_1bpp_data
 */
 void set_bkg_1bpp_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data) OLDCALL PRESERVES_REGS(b, c);
 
@@ -1126,7 +1157,14 @@ void set_win_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data) OLD
     This is the same as @ref set_bkg_1bpp_data, since the Window Layer and
     Background Layer share the same Tile pattern data.
 
-    @see set_bkg_data, set_bkg_1bpp_data, set_win_data
+    For a given bit that represent a pixel:
+    \li 0 will be expanded into the Background color
+    \li 1 will be expanded into the Foreground color
+
+    See @ref set_1bpp_colors for details about setting the Foreground and Background colors.
+
+    @see set_bkg_data, set_bkg_1bpp_data, set_win_data, set_1bpp_colors
+    @see set_bkg_1bpp_data, set_sprite_1bpp_data
 */
 void set_win_1bpp_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data) OLDCALL PRESERVES_REGS(b, c);
 
@@ -1360,10 +1398,13 @@ void set_sprite_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data) 
     which gets expanded into 2 bits-per-pixel.
 
     For a given bit that represent a pixel:
-    \li 0 will be expanded into color 0
-    \li 1 will be expanded into color 3
+    \li 0 will be expanded into the Background color
+    \li 1 will be expanded into the Foreground color
+
+    See @ref set_1bpp_colors for details about setting the Foreground and Background colors.
 
     @see SHOW_SPRITES, HIDE_SPRITES, set_sprite_tile
+    @see set_bkg_1bpp_data, set_win_1bpp_data
 */
 void set_sprite_1bpp_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data) OLDCALL PRESERVES_REGS(b, c);
 

--- a/gbdk-lib/include/gb/gbdecompress.h
+++ b/gbdk-lib/include/gb/gbdecompress.h
@@ -16,7 +16,12 @@
     @param sour   Pointer to source gb-compressed data
     @param dest   Pointer to destination buffer/address
 
-    @see gb_decompress_bkg_data, gb_decompress_win_data, gb_decompress_sprite_data
+    Will decompress __all__ of it's data to destination without
+    stopping until the end of compressed data is reached. It is
+    not possible to set a limit, so ensure the destination buffer
+    has sufficient space to avoid an overflow.
+
+    @see gb_decompress_bkg_data, gb_decompress_win_data, gb_decompress_sprite_data, rle_decompress
  */
 uint16_t gb_decompress(const uint8_t * sour, uint8_t * dest) OLDCALL PRESERVES_REGS(b, c);
 
@@ -27,6 +32,11 @@ uint16_t gb_decompress(const uint8_t * sour, uint8_t * dest) OLDCALL PRESERVES_R
     @param sour        Pointer to (gb-compressed 2 bpp) source Tile Pattern data.
 
     Note: This function avoids writes during modes 2 & 3
+
+    Will decompress __all__ of it's data to destination without
+    stopping until the end of compressed data is reached. It is
+    not possible to set a limit, so ensure the destination buffer
+    has sufficient space to avoid an overflow.
 
     @see gb_decompress_bkg_data, gb_decompress_win_data, gb_decompress_sprite_data
 */
@@ -43,6 +53,11 @@ void gb_decompress_bkg_data(uint8_t first_tile, const uint8_t * sour) OLDCALL PR
 
     Note: This function avoids writes during modes 2 & 3
 
+    Will decompress __all__ of it's data to destination without
+    stopping until the end of compressed data is reached. It is
+    not possible to set a limit, so ensure the destination buffer
+    has sufficient space to avoid an overflow.
+
     @see gb_decompress, gb_decompress_bkg_data, gb_decompress_sprite_data
  */
 void gb_decompress_win_data(uint8_t first_tile, const uint8_t * sour) OLDCALL PRESERVES_REGS(b, c);
@@ -54,6 +69,11 @@ void gb_decompress_win_data(uint8_t first_tile, const uint8_t * sour) OLDCALL PR
     @param sour        Pointer to source compressed data
 
     Note: This function avoids writes during modes 2 & 3
+
+    Will decompress __all__ of it's data to destination without
+    stopping until the end of compressed data is reached. It is
+    not possible to set a limit, so ensure the destination buffer
+    has sufficient space to avoid an overflow.
 
     @see gb_decompress, gb_decompress_bkg_data, gb_decompress_win_data
  */

--- a/gbdk-lib/include/gbdk/rledecompress.h
+++ b/gbdk-lib/include/gbdk/rledecompress.h
@@ -26,7 +26,8 @@ uint8_t rle_init(void * data) OLDCALL;
 /** Decompress RLE compressed data into __dest__ for length __len__ bytes
 
     @param dest   Pointer to destination buffer/address
-    @param len    number of bytes to decompress
+    @param len    Number of bytes to decompress
+    @return       Returns `0` if compression is complete, `1` if there is more data to decompress
 
     Before calling this function @ref rle_init must be called
     one time to initialize the RLE decompressor.


### PR DESCRIPTION
- Docs: updates for *_decompress() 
- Docs: doxygen reference fix for lcc 
- Docs: 1bpp graphics api info
-  Doxygen: update header file constant gbz80 -> sm83. Fixes initrand() doxygen warnings
