### PR TITLE
ihxcheck: Check and warn for bank overflows under specific conditions

### DIFF
--- a/gbdk-support/ihxcheck/areas.c
+++ b/gbdk-support/ihxcheck/areas.c
@@ -13,6 +13,8 @@
 
 #define AREA_GROW_SIZE 500
 
+extern bank_info banks[];
+
 area_item * arealist;
 uint32_t    arealist_size;
 uint32_t    arealist_count;
@@ -39,9 +41,15 @@ static uint32_t addrs_check_overlap(uint32_t a_start, uint32_t a_end, uint32_t b
     } else {
         size_used = min(b_end, a_end) - max(b_start, a_start) + 1; // Calculate minimum overlap
 
-        printf("WARNING: Multiple write of %5d bytes at 0x%x -> 0x%x (%x -> %x, %x -> %x)\n",
-                size_used, max(b_start, a_start), min(b_end, a_end),
-                a_start, a_end, b_start, b_end);
+        uint32_t overlap_start = max(a_start, b_start);
+        uint32_t overlap_end   = min(a_end, b_end);
+
+        // Flag a multiple write warning in the bank where the overflow ENDS
+        // Used later to check for overflows
+        banks[BANK_NUM(overlap_end)].had_multiple_write_warning = true;
+
+        printf("Warning: Multiple write of %5d bytes at 0x%x -> 0x%x writes:(0x%x -> 0x%x, 0x%x -> 0x%x)\n",
+                size_used, overlap_start, overlap_end, a_start, a_end, b_start, b_end);
     }
     return size_used;
 }

--- a/gbdk-support/ihxcheck/areas.h
+++ b/gbdk-support/ihxcheck/areas.h
@@ -11,6 +11,14 @@ typedef struct area_item {
     uint32_t length;
 } area_item;
 
+typedef struct bank_info {
+    bool     overflowed_into;
+    uint16_t overflow_from;
+    bool     had_multiple_write_warning;
+} bank_info;
+
+#define BANKS_MAX_COUNT  512
+#define BANK_NUM(addr)  ((addr & 0xFFFFC000U) >> 14)
 
 void areas_init(void);
 void areas_cleanup(void);


### PR DESCRIPTION
* A multiple write to the same address must occur. The address where the overlap ends is used as BANK.

* There must also be a write which spans multiple banks, the ending address of that must match BANK. The starting addresses is the OVERFLOW-FROM BANK.