### PR TITLE
GB Examples: Remove invalid -p option from mkdir in compile.bat

### DIFF
--- a/gbdk-lib/examples/gb/template_minimal/Makefile
+++ b/gbdk-lib/examples/gb/template_minimal/Makefile
@@ -22,7 +22,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed/mkdir -p/mkdir/ | grep -v make >> compile.bat
 
 # Compile and link all source files in a single call to LCC
 $(BINS):	$(CSOURCES) $(ASMSOURCES)

--- a/gbdk-lib/examples/gb/template_minimal/Makefile
+++ b/gbdk-lib/examples/gb/template_minimal/Makefile
@@ -22,7 +22,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | sed/mkdir -p/mkdir/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ \-p/mkdir/ | grep -v make >> compile.bat
 
 # Compile and link all source files in a single call to LCC
 $(BINS):	$(CSOURCES) $(ASMSOURCES)


### PR DESCRIPTION
This was resulting in a `-p` directory being created.

### Before

```bat
REM Automatically generated from Makefile
mkdir -p obj
.\vendor\gbdk\bin\lcc   -c -o obj\main.o src\main.c
.\vendor\gbdk\bin\lcc   -c -o obj\dungeon_map.o res\dungeon_map.c
.\vendor\gbdk\bin\lcc   -c -o obj\dungeon_tiles.o res\dungeon_tiles.c
.\vendor\gbdk\bin\lcc   -o obj\Example.gb obj\main.o obj\dungeon_map.o obj\dungeon_tiles.o 
```

### After

```bat
REM Automatically generated from Makefile
mkdir obj
.\vendor\gbdk\bin\lcc   -c -o obj\main.o src\main.c
.\vendor\gbdk\bin\lcc   -c -o obj\dungeon_map.o res\dungeon_map.c
.\vendor\gbdk\bin\lcc   -c -o obj\dungeon_tiles.o res\dungeon_tiles.c
.\vendor\gbdk\bin\lcc   -o obj\Example.gb obj\main.o obj\dungeon_map.o obj\dungeon_tiles.o 
```