### PR TITLE
NES: Fix bug with global initialized data being initialized to zero

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -10,6 +10,8 @@
 
 ; OAM CPU page
 _shadow_OAM             = 0x200
+; Attribute shadow (64 bytes, leaving 56 bytes available for CPU stack)
+_attribute_shadow       = 0x188
 ; Transfer buffer (lower half of hardware stack)
 _vram_transfer_buffer   = 0x100
 
@@ -97,9 +99,6 @@ _attribute_row_dirty::                  .ds 1
         ;; For malloc
         .area _HEAP
         .area _HEAP_END
-
-.area DATA
-_attribute_shadow::     .ds 64
 
 .area CODE
 

--- a/gbdk-lib/libc/targets/mos6502/nes/set_bk_attributes.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_bk_attributes.s
@@ -89,9 +89,11 @@ _set_bkg_attributes::
     asl
     asl
     ora *.xpos
-    ora #<_attribute_shadow
+    clc
+    adc #<_attribute_shadow
     sta *.dst
     lda #>_attribute_shadow
+    adc #0
     sta *.dst+1
     jsr .attribute_set_dirty
     ; Branch into distinct routines based on whether x / y are aligned


### PR DESCRIPTION
* Remove _attribute_shadow from DATA segment
* Place _attribute_shadow at 0x188 to coexist with CPU stack / vram transfer buffer
* Remove assumption on _attribute_shadow being 256-byte aligned in _set_bkg_attributes, by replacing OR of address / index with addition