### PR TITLE
NES: Refactor nametable writes to use indirect writes via the vram transfer buffer when screen is not blanked

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/set_bk_attributes.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_bk_attributes.s
@@ -18,7 +18,6 @@
 
     .area   _HOME
 
-; TODO: Switch to use vram transfer buffer when screen not blanked
 .define .width  "_set_bkg_attributes_PARM_3"
 .define .height "_set_bkg_attributes_PARM_4"
 .define .tiles  "_set_bkg_attributes_PARM_5"
@@ -543,22 +542,22 @@ _flush_shadow_attributes_end:
 
 ;
 ; Flushes all dirty rows of _attribute_shadow by writing them to PPU memory
-; TODO: Support VRAM transfer buffer as well as direct mode.
 ;
 _flush_shadow_attributes_update_row:
     ; Update all 8 bytes of row for now, as each row in _attribute_row_dirty only stores 1 bit
     ; TODO: Could store 8 bytes and update range, at expense of 7 more bytes.
     lda *.tmp+1
-    sta PPUADDR
+    tax
     lda *.tmp
-    sta PPUADDR
+    jsr .ppu_stripe_begin_horizontal
     ; Write 8 bytes
     i = 0
     .rept 8
     lda _attribute_shadow+i,y
-    sta PPUDATA
+    jsr .ppu_stripe_write_byte
     i = i + 1
     .endm
+    jsr .ppu_stripe_end
     jmp _flush_shadow_attributes_next_row
 
 .attribute_set_dirty:

--- a/gbdk-lib/libc/targets/mos6502/nes/set_bk_ts.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_bk_ts.s
@@ -12,7 +12,6 @@
     .area   _HOME
 
 _set_bkg_tiles::
-    ; TODO: Switch to use vram transfer buffer when screen not blanked
     .define .width  "_set_bkg_tiles_PARM_3"
     .define .height "_set_bkg_tiles_PARM_4"
     .define .tiles  "_set_bkg_tiles_PARM_5"
@@ -24,6 +23,11 @@ _set_bkg_tiles::
     sta *.src_tiles+1
     lda *.height
     sta *.num_rows
+    ; Prefer vertical stripes if height > width
+    cmp *.width
+    beq _set_bkg_tiles_horizontalStripes
+    bcs _set_bkg_tiles_verticalStripes
+_set_bkg_tiles_horizontalStripes:
 1$:
     lda #0
     sta *.tmp+1
@@ -43,17 +47,18 @@ _set_bkg_tiles::
     ;
     lda *.tmp+1
     ora #0x20
-    sta PPUADDR
+    tax
     lda *.tmp
-    sta PPUADDR
+    jsr .ppu_stripe_begin_horizontal
     ldx *.width
     ldy #0
 2$:
     lda [*.src_tiles],y
     iny
-    sta PPUDATA
+    jsr .ppu_stripe_write_byte
     dex
     bne 2$
+    jsr .ppu_stripe_end
     ; .src_tiles += y
     tya
     clc
@@ -64,5 +69,59 @@ _set_bkg_tiles::
     sta *.src_tiles+1
     inc *.ypos
     dec *.num_rows
+    bne 1$
+    rts
+
+.define .num_cols  ".num_rows"
+
+_set_bkg_tiles_verticalStripes::
+    lda *.width
+    sta *.num_cols
+    ldy #0
+1$:
+    lda *.tiles
+    sta *.src_tiles
+    lda *.tiles+1
+    sta *.src_tiles+1
+    ;
+    lda #0
+    sta *.tmp+1
+    lda *.ypos
+    asl
+    rol *.tmp+1
+    asl
+    rol *.tmp+1
+    asl
+    rol *.tmp+1
+    asl
+    rol *.tmp+1
+    asl
+    rol *.tmp+1
+    ora *.xpos
+    sta *.tmp
+    ;
+    lda *.tmp+1
+    ora #0x20
+    tax
+    lda *.tmp
+    jsr .ppu_stripe_begin_vertical
+    ldx *.height
+2$:
+    lda [*.src_tiles],y
+    jsr .ppu_stripe_write_byte
+    ; .src_tiles += width
+    lda *.width
+    clc
+    adc *.src_tiles
+    sta *.src_tiles
+    lda #0
+    adc *.src_tiles+1
+    sta *.src_tiles+1
+    dex
+    bne 2$
+    jsr .ppu_stripe_end
+    iny
+    inc *.xpos
+    dec *.num_cols
     bne 1$
     rts


### PR DESCRIPTION
* Add helper subroutines ppu_stripe_begin(_horizontal/vertical), ppu_stripe_end and ppu_stripe_write_byte
* Update _set_bkg_tiles to use the new ppu_stripe_* subroutines
* Add _set_bkg_tiles code path for vertical stripes, and prefer this when width < height
* Update _flush_shadow_attributes_update_row to use the new ppu_stripe_* subroutines