### PR TITLE
NES: Support setting tile data indirectly via vram transfer buffer when display is on

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -80,7 +80,7 @@ __crt0_NMI_insideNMI:                   .ds 1
 __crt0_ScrollHV:                        .ds 1
 __crt0_drawListValid:                   .ds 1
 __crt0_drawListNumDelayCycles_x8:       .ds 1
-__crt0_drawListPosW:                    .ds 1
+__crt0_drawListPosW::                   .ds 1
 __crt0_textPPUAddr:                     .ds 2
 __crt0_NMITEMP:                         .ds 4
 __crt0_textTemp:                        .ds 1
@@ -90,7 +90,7 @@ _bkg_scroll_x::                         .ds 1
 _bkg_scroll_y::                         .ds 1
 _attribute_row_dirty::                  .ds 1
 .crt0_textStringBegin:                  .ds 1
-.crt0_forced_blanking:                  .ds 1
+.crt0_forced_blanking::                 .ds 1
 
         ;; ****************************************
 
@@ -696,9 +696,9 @@ _display_on::
     clc
     adc #VRAM_HDR_SIZEOF
     sta *__crt0_drawListPosW
-    ; __crt0_drawListNumDelayCycles_x8 -= 7 (assumes carry clear)
+    ; __crt0_drawListNumDelayCycles_x8 -= 6 (assumes carry clear)
     lda *__crt0_drawListNumDelayCycles_x8
-    sbc #6
+    sbc #5
     sta *__crt0_drawListNumDelayCycles_x8
     ldy *__crt0_textTemp
     rts
@@ -721,10 +721,12 @@ _display_on::
     tya
     sec
     sbc *.crt0_textStringBegin
-    sec
     sbc #VRAM_HDR_SIZEOF
     ldy *.crt0_textStringBegin
     sta _vram_transfer_buffer+VRAM_HDR_LENGTH,y
+    lda *__crt0_drawListNumDelayCycles_x8
+    sbc _vram_transfer_buffer+VRAM_HDR_LENGTH,y
+    sta *__crt0_drawListNumDelayCycles_x8
     VRAM_BUFFER_UNLOCK
     ldy *__crt0_textTemp
     rts
@@ -742,7 +744,6 @@ _display_on::
     ldy *__crt0_drawListPosW
     sta _vram_transfer_buffer,y
     inc *__crt0_drawListPosW
-    dec *__crt0_drawListNumDelayCycles_x8
     ldy *__crt0_textTemp
     rts
 

--- a/gbdk-lib/libc/targets/mos6502/nes/set_data.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_data.s
@@ -6,6 +6,7 @@
     _set_tile_data_PARM_3::     .ds 2
     _set_tile_data_PARM_4::     .ds 1
     src:                        .ds 2
+    tmpX:                       .ds 1
 
     .area   _HOME
 
@@ -62,6 +63,9 @@ _set_sprite_data::
     rol
     asl *.tmp
     rol
+    bit *.crt0_forced_blanking
+    bpl .copy_tiles_indirect
+    ; Direct write
     sta PPUADDR
     lda *.tmp
     sta PPUADDR
@@ -82,6 +86,43 @@ _set_sprite_data::
     sta *src+1
     dex
     bne .copy_tiles_loop
+    rts
+
+.copy_tiles_indirect:
+    sta *.tmp+1
+.copy_tiles_indirect_loop:
+    stx *tmpX
+    ;
+    ldx *.tmp+1
+    lda *.tmp
+    jsr .ppu_stripe_begin_horizontal
+    ;
+    ldx *__crt0_drawListPosW
+    ldy #0
+    jsr .copy_tiles_indirect_2planes
+    lda .identity+16,x
+    sta *__crt0_drawListPosW
+    jsr .ppu_stripe_end
+    ; src += 16
+    lda *src
+    clc
+    adc #16
+    sta *src
+    lda *src+1
+    adc #0
+    sta *src+1
+    ; tmp += 16
+    lda *.tmp
+    clc
+    adc #16
+    sta *.tmp
+    lda *.tmp+1
+    adc #0
+    sta *.tmp+1
+    ;
+    ldx *tmpX
+    dex
+    bne .copy_tiles_indirect_loop
     rts
 
 .copy_tiles_1plane:
@@ -124,5 +165,64 @@ _set_sprite_data::
     iny
     iny
     sta PPUDATA
+    ;
+    rts
+
+.copy_tiles_indirect_2planes:
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+0,x
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+8,x
+    ;
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+1,x
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+9,x
+    ;
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+2,x
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+10,x
+    ;
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+3,x
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+11,x
+    ;
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+4,x
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+12,x
+    ;
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+5,x
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+13,x
+    ;
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+6,x
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+14,x
+    ;
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+7,x
+    lda [*src],y
+    iny
+    sta _vram_transfer_buffer+15,x
     ;
     rts


### PR DESCRIPTION
* Fix bug with .ppu_stripe_begin subtracting 1 x8-cycle too many
* Remove decrementing of *__crt0_drawListNumDelayCycles_x8 .ppu_stripe_write_byte, and make .ppu_stripe_end calculate cycles from number of bytes written
* Update _set_tile_data to write the 16 bytes of a tile via ppu_stripe* functions when display is on
* Update _fill_bkg_rect to write bytes via the ppu_stripe_ functions, and prefer vertical stripes when height > width