### PR TITLE
NES: Enable support for INCBIN macro

### DIFF
--- a/gbdk-lib/examples/cross-platform/incbin/Makefile
+++ b/gbdk-lib/examples/cross-platform/incbin/Makefile
@@ -6,19 +6,20 @@ LCC = $(GBDK_HOME)bin/lcc
 # Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
 # They can also be built/cleaned individually: "make gg" and "make gg-clean"
 # Possible are: gb gbc pocket megaduck sms gg
-TARGETS=gb pocket megaduck sms gg
+TARGETS=gb pocket megaduck sms gg nes
 
 # Configure platform specific LCC flags here:
-LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
-LCCFLAGS_pocket  = -Wl-yt0x1B # Usually the same as required for .gb
-LCCFLAGS_duck    = -Wl-yt0x1B # Usually the same as required for .gb
-LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
-LCCFLAGS_sms     =
-LCCFLAGS_gg      =
+LCCFLAGS_gb      = -Wl-yt0x1B -autobank # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wl-yt0x1B -autobank # Usually the same as required for .gb
+LCCFLAGS_duck    = -Wl-yt0x1B -autobank # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc -autobank # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_sms     = -autobank
+LCCFLAGS_gg      = -autobank
+LCCFLAGS_nes     =
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 
-LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
 # LCCFLAGS += -debug # Uncomment to enable debug output
 # LCCFLAGS += -v     # Uncomment for lcc verbose output
 

--- a/gbdk-lib/examples/cross-platform/incbin/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/incbin/Makefile.targets
@@ -48,3 +48,7 @@ gg-clean:
 gg:
 	${MAKE} build-target PORT=z80 PLAT=gg EXT=gg
 
+nes-clean:
+	${MAKE} clean-target EXT=nes
+nes:
+	${MAKE} build-target PORT=mos6502 PLAT=nes EXT=nes

--- a/gbdk-lib/include/gbdk/incbin.h
+++ b/gbdk-lib/include/gbdk/incbin.h
@@ -65,6 +65,23 @@ extern const void __bank_ ## VARNAME;
     Use @ref INCBIN_EXTERN() within another source file
     to make the variable and it's data accesible there.
 */
+#if defined(__TARGET_nes)
+// mos6502 target does not support banking yet - omit "__banked" keyword, and assume bank is 0 in asm code
+#define INCBIN(VARNAME, FILEPATH) void __func_ ## VARNAME() __naked { \
+__asm \
+_ ## VARNAME:: \
+1$: \
+    .incbin FILEPATH \
+2$: \
+    ___size_ ## VARNAME = (2$-1$) \
+    .globl ___size_ ## VARNAME \
+    .local b___func_ ## VARNAME \
+    ___bank_ ## VARNAME = 0 \
+    .globl ___bank_ ## VARNAME \
+__endasm; \
+}
+#else
+// Use __banked keyword and 'b' prefix for other targets
 #define INCBIN(VARNAME, FILEPATH) void __func_ ## VARNAME() __banked __naked { \
 __asm \
 _ ## VARNAME:: \
@@ -78,7 +95,6 @@ _ ## VARNAME:: \
     .globl ___bank_ ## VARNAME \
 __endasm; \
 }
+#endif
 
 #endif // _INCBIN_H
-
-


### PR DESCRIPTION
* Add work-around for lack of banking support for mos6502 in sdcc compiler / assembler in include/gbdk/incbin.h
* Enable cross-platform/incbin example for nes in Makefile