### PR TITLE
NES: Add support for RLE decompression

### DIFF
--- a/gbdk-lib/examples/cross-platform/rle_map/Makefile
+++ b/gbdk-lib/examples/cross-platform/rle_map/Makefile
@@ -9,7 +9,7 @@ LCC = $(GBDK_HOME)bin/lcc
 # They can also be built/cleaned individually: "make gg" and "make gg-clean"
 # Possible are: gb gbc pocket megaduck sms gg
 #TARGETS=gb pocket sms gg
-TARGETS=gb gg sms
+TARGETS=gb gg sms nes
 
 # Configure platform specific LCC flags here:
 LCCFLAGS_gb      = -Wl-yt0x19 -Wl-yo4 -Wm-yS -Wm-yn"$(PROJECTNAME)"
@@ -17,11 +17,12 @@ LCCFLAGS_pocket  = -Wl-yt0x19 -Wl-yo4 -Wm-yS -Wm-yn"$(PROJECTNAME)"
 LCCFLAGS_duck    = -Wl-yt0x19 -Wl-yo4 -Wm-yS -Wm-yn"$(PROJECTNAME)"
 LCCFLAGS_sms     = -Wl-yo4 -Wm-yS
 LCCFLAGS_gg      = -Wl-yo4 -Wm-yS
+LCCFLAGS_nes     = 
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 
 # LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
-LCCFLAGS += -Wl-j
+LCCFLAGS += -Wl-u -Wl-j
 # LCCFLAGS += -debug # Uncomment to enable debug output
 # LCCFLAGS += -v     # Uncomment for lcc verbose output
 

--- a/gbdk-lib/examples/cross-platform/rle_map/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/rle_map/Makefile.targets
@@ -48,3 +48,7 @@ gg-clean:
 gg:
 	${MAKE} build-target PORT=z80 PLAT=gg EXT=gg
 
+nes-clean:
+	${MAKE} clean-target EXT=nes
+nes:
+	${MAKE} build-target PORT=mos6502 PLAT=nes EXT=nes

--- a/gbdk-lib/include/gbdk/rledecompress.h
+++ b/gbdk-lib/include/gbdk/rledecompress.h
@@ -14,7 +14,7 @@
 
 #define RLE_STOP 0
 
-#if defined(__TARGET_gb) || defined(__TARGET_ap) || defined(__TARGET_duck)
+#if defined(__TARGET_gb) || defined(__TARGET_ap) || defined(__TARGET_duck) || defined(__TARGET_nes)
 /** Initialize the RLE decompressor with RLE data at address __data__
 
     @param data   Pointer to start of RLE compressed data

--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -13,6 +13,7 @@ ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	set_bk_ts.s fill_rect_bk.s set_bk_attributes.s \
 	nes_palettes.s \
 	pad.s pad_ex.s \
+	rle_decompress.s \
 	crt0.s
 
 CRT0 =	crt0.s

--- a/gbdk-lib/libc/targets/mos6502/rle_decompress.s
+++ b/gbdk-lib/libc/targets/mos6502/rle_decompress.s
@@ -1,0 +1,149 @@
+    .include "global.s"
+
+    .module RLE_DECOMPRESS
+
+    .area ZP (PAG)
+rle_cursor:
+        .ds 0x02
+rle_counter:
+        .ds 0x01
+rle_current:
+        .ds 0x01
+rle_code_ptr:
+        .ds 0x02
+
+    .area   OSEG (PAG, OVR)
+_rle_decompress_PARM_2::        .ds 1
+.rle_output:                   .ds 2
+
+    .define .out_len "_rle_decompress_PARM_2"
+
+    .area   _HOME
+
+.macro RLE_ADVANCE_CURSOR
+    tya
+    clc
+    adc *rle_cursor
+    sta *rle_cursor
+    lda #0
+    adc *rle_cursor+1
+    sta *rle_cursor+1
+.endm
+
+.macro RLE_ADVANCE_OUTPUT
+    tya
+    clc
+    adc *.rle_output
+    sta *.rle_output
+    lda #0
+    adc *.rle_output+1
+    sta *.rle_output+1
+.endm
+
+.macro RLE_SET_CODE_PTR code_address
+    lda #<code_address
+    sta *rle_code_ptr
+    lda #>code_address
+    sta *(rle_code_ptr+1)
+.endm
+
+_rle_init::
+    sta *rle_cursor
+    stx *(rle_cursor+1)
+    RLE_SET_CODE_PTR _rle_decompress_read_token_entry
+    lda	#0x01
+    rts
+
+_rle_decompress_eof:
+    RLE_SET_CODE_PTR _rle_decompress_eof
+    lda #0
+    rts
+
+_rle_decompress::
+    jmp [*rle_code_ptr]
+    
+_rle_decompress_read_token_entry:
+    sta *.rle_output
+    stx *(.rle_output+1)
+    ldx *.out_len
+    ldy #0
+_rle_decompress_read_token:
+    lda [*rle_cursor],y
+    beq _rle_decompress_eof
+    bmi _rle_decompress_read_token_repeat
+    ; RLE_TYPE_RAND
+    sta *rle_counter
+    RLE_SET_CODE_PTR _rle_decompress_process_rand_entry
+    inc *rle_cursor
+    beq 1$
+    jmp _rle_decompress_process_rand
+1$:
+    inc *rle_cursor+1
+    jmp _rle_decompress_process_rand
+_rle_decompress_read_token_repeat:
+    ; RLE_TYPE_REPEAT
+    sta *rle_counter
+    RLE_SET_CODE_PTR _rle_decompress_process_repeat_entry
+    inc *rle_cursor
+    beq 2$
+    lda [*rle_cursor],y
+    sta *rle_current
+    inc *rle_cursor
+    bne 1$
+    inc *(rle_cursor+1)
+1$:
+    jmp _rle_decompress_process_repeat
+2$:
+    inc *(rle_cursor+1)
+    lda [*rle_cursor],y
+    sta *rle_current
+    inc *rle_cursor
+    jmp _rle_decompress_process_repeat
+
+_rle_decompress_process_rand_entry:
+    sta *.rle_output
+    stx *(.rle_output+1)
+    ldx *.out_len
+    ldy #0
+_rle_decompress_process_rand:
+1$:
+    cpx #0
+    beq _rle_decompress_process_rand_yield
+    lda [*rle_cursor],y
+    sta [*.rle_output],y
+    dex
+    iny
+    dec *rle_counter
+    bne 1$
+    RLE_ADVANCE_CURSOR
+    RLE_ADVANCE_OUTPUT
+    ldy #0
+    jmp _rle_decompress_read_token
+
+_rle_decompress_process_rand_yield:
+    RLE_ADVANCE_CURSOR
+    lda #1
+    rts
+
+_rle_decompress_process_repeat_entry:
+    sta *.rle_output
+    stx *(.rle_output+1)
+    ldx *.out_len
+    ldy #0
+_rle_decompress_process_repeat:
+    lda *rle_current
+1$:
+    cpx #0
+    beq _rle_decompress_process_repeat_yield
+    sta [*.rle_output],y
+    dex
+    iny
+    inc *rle_counter
+    bne 1$
+    RLE_ADVANCE_OUTPUT
+    ldy #0
+    jmp _rle_decompress_read_token
+
+_rle_decompress_process_repeat_yield:
+    lda #1
+    rts


### PR DESCRIPTION
* Add 6502 assembly RLE implementation in gbdk/libc/targets/mos6502/rle_decompress.s
* Enable examples/cross-platform/rle_map for NES