### PR TITLE
Docs 4.1.0 - Licensing, SDAS manual, fix wrong link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,14 +5,24 @@
 See the relevant licensing files in the LICENSES folder for details on the entries below
 
 
-### GBDK Library & Makefiles:
+### For the End User
+Q: What license information is required when distributing the compiled ROM (binary) of my game?
+
+A: There is no requirement to include or credit any of the GBDK-2020 licenses or authors, although credit of GBDK-2020 is appreciated.
+   This is different and separate from redistributing the GBDK-2020 dev environment itself (or the GBDK-2020 sources) which does require the licenses.
+
+
+### GBDK Library & Makefiles, SDCC:
 GPLv2+LE (linking exception). Some files from SDCC, some from the historical GBDK that were originally LGPL and have been relicensed to GPLv2+LE (linking exception) to match the SDCC ones in 2022 by permission of original authors.
 - LICENSE_SDCC
 - LICENSE_GPLV2_LE
 
+When patches are used for some SDCC tools they can be found at:
+https://github.com/gbdk-2020/gbdk-2020-sdcc
 
-### Crash handler in the GBDK Library
-MIT License: https://github.com/ISSOtm/gb-starter-kit/
+
+### Optional Crash handler in the GBDK Library
+zlib License: https://github.com/ISSOtm/gb-starter-kit/
 - LICENSE_crashhandler
 
 

--- a/docs/pages/02_links_and_tools.md
+++ b/docs/pages/02_links_and_tools.md
@@ -9,6 +9,9 @@ This is a brief list of useful tools and information. It is not meant to be comp
   http://sdcc.sourceforge.net/doc/sdccman.pdf  
   http://sdcc.sourceforge.net
 
+  - The SDCC assembler and linker (sdas / asxxxx and aslink) manual.  
+  https://sourceforge.net/p/sdcc/code/HEAD/tree/trunk/sdcc/sdas/doc/asmlnk.txt
+
 
 @anchor links_help_and_community
 # Getting Help

--- a/docs/pages/08_faq.md
+++ b/docs/pages/08_faq.md
@@ -7,6 +7,11 @@
     - The simplest way is to use the Game Boy sound hardware directly. See the @ref examples_sound_sample "Sound Example" for a way to test out sounds on the hardware.
     - Further discussion on using the Sound Example rom can be found in the ZGB wiki. Note that some example code there is ZGB specific and not part of the base GBDK API: https://github.com/Zal0/ZGB/wiki/Sounds <!-- -->
 
+# Licensing
+  - What license information is required when distributing the compiled ROM (binary) of my game or program?
+    - There is no requirement to include or credit any of the GBDK-2020 licenses or authors, although credit of GBDK-2020 is appreciated.
+    - This is different and separate from redistributing the GBDK-2020 dev environment itself (or the GBDK-2020 sources) which does require the licenses. <!-- -->
+
 # Graphics and Resources
   - How do I use a tile map when its tiles don't start at index zero?
     - The two main options are:

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -1083,12 +1083,12 @@ extern uint8_t _submap_tile_offset;
     @param map_w     Width of source tile map in tiles. Range 1 - 255
     @param base_tile Offset each tile ID entry of the source map by this value. Range 1 - 255
 
-    This is identical to @ref set_bkg_based_submap() except that it
+    This is identical to @ref set_bkg_submap() except that it
     adds the __base_tile__ parameter for when a tile map's tiles don't
     start at index zero. (For example, the tiles used by the map
     range from 100 -> 120 in VRAM instead of 0 -> 20).
 
-    @see set_bkg_based_submap for more details
+    @see set_bkg_submap for more details
 */
 inline void set_bkg_based_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *map, uint8_t map_w, uint8_t base_tile) {
     _submap_tile_offset = base_tile;

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -548,12 +548,12 @@ extern uint8_t _submap_tile_offset;
     @param map_w  Width of source tile map in tiles. Range 1 - 255
     @param base_tile Offset each tile ID entry of the source map by this value. Range 1 - 255
 
-    This is identical to @ref set_bkg_based_submap() except that it
+    This is identical to @ref set_bkg_submap() except that it
     adds the __base_tile__ parameter for when a tile map's tiles don't
     start at index zero. (For example, the tiles used by the map
     range from 100 -> 120 in VRAM instead of 0 -> 20).
 
-    @see set_bkg_based_submap for more details
+    @see set_bkg_submap for more details
 */
 inline void set_bkg_based_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *map, uint8_t map_w, uint8_t base_tile) {
     _submap_tile_offset = base_tile;

--- a/licenses/LICENSE_crashhandler
+++ b/licenses/LICENSE_crashhandler
@@ -1,26 +1,21 @@
-For the Crash Handler in the GBDK Library
-See:
-https://github.com/ISSOtm/gb-starter-kit/blob/master/LICENSE
+(The version in GBDK was adapted by Toxa from gb-starter-kit: https://github.com/ISSOtm/gb-starter-kit)
 
+zlib License
 
-MIT License
+Copyright (c) 2020-2022 Eldred Habert
 
-Copyright (c) 2020 Eldred Habert
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.


### PR DESCRIPTION
- Update crash handler license to zlib
- FAQ entry for license requrements of a compiled ROM
- Link to sdas / aslink manual
-Docs: Incorrect reference for set_bkg_submap