### PR TITLE
LCC: if -autobank enabled, add -yoA if -yo not specified for makebin

### DIFF
--- a/docs/pages/05_banking_mbcs.md
+++ b/docs/pages/05_banking_mbcs.md
@@ -60,11 +60,13 @@ Note: You can use the `NONBANKED` keyword to define a function as non-banked if 
 ## Setting the MBC and number of ROM & RAM banks available
 
 At the link stage this is done with @ref lcc using pass-through switches for @ref makebin.
-  - `-Wl-yo<N>` where `<N>` is the number of ROM banks. 2, 4, 8, 16, 32, 64, 128, 256, 512
-    - `-Wl-yoA` may be used for automatic bank size.
-  - `-Wl-ya<N>` where `<N>` is the number of RAM banks. 2, 4, 8, 16, 32
-  - `-Wl-yt<N>` where `<N>` is the type of MBC cartridge (see chart below).
-    - Example: `Wl-yt0x1A`
+  - `-Wm-yo<N>` where `<N>` is the number of ROM banks. 2, 4, 8, 16, 32, 64, 128, 256, 512
+    - `-Wm-yoA` may be used for automatic bank size.
+  - `-Wm-ya<N>` where `<N>` is the number of RAM banks. 2, 4, 8, 16, 32
+  - `-Wm-yt<N>` where `<N>` is the type of MBC cartridge (see chart below).
+    - Example: `Wm-yt0x1A`
+  - If passing the above arguments to @ref makebin directly **without** using @ref lcc, then the `-Wm` part should be omitted.
+    - Note: Some makebin switches (such as `-yo A`) require a space when passed directly. See @ref makebin-settings for details.
 
 The MBC settings below are available when using the makebin `-Wl-yt<N>` switch.
 

--- a/docs/pages/10_release_notes.md
+++ b/docs/pages/10_release_notes.md
@@ -50,6 +50,8 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - Added `--bank=<num>` Add Bank Ref: 1 - 511 (default is none, with `--cout` only)
       - Fixed failure to flush data at end of compression (uncommitted bytes)
       - Fixed `Warning: File read size didn't match expected`
+    - @ref lcc "lcc"
+      - When `-autobank` is specified `lcc` will automatically add `-yoA` for @ref makebin if no `-yo*` entry is present
     - @ref utility_makecom "makecom"
       - Added `makecom` for post-processing msxdos binary
     - @ref makebin

--- a/gbdk-lib/examples/cross-platform/banks_autobank/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_autobank/Makefile
@@ -19,7 +19,8 @@ LCCFLAGS_msxdos  =
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 
-LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+# If -autobank is specified then lcc will automatically add -Wm-yoA if no -yo* entry is present
+LCCFLAGS += -Wl-j -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
 # LCCFLAGS += -debug # Uncomment to enable debug output
 # LCCFLAGS += -v     # Uncomment for lcc verbose output
 

--- a/gbdk-lib/examples/gb/sgb_border/Readme.md
+++ b/gbdk-lib/examples/gb/sgb_border/Readme.md
@@ -8,7 +8,7 @@ png2asset is used for converting the border.
 * The entire image should be 256 x 224 pixels
 * The game area in the center should be:
   * 160 x 144 pixels, from (48,40) to (207,183)
-  * The pixels in the game area at the center of the image should be set to 100% Alpha Transparency (as in the example image). If this is not done then the game area may share a palette color with other parts of the border leading to tile pattern flasing while the border loads.
+  * The pixels in the game area at the center of the image should be set to 100% Alpha Transparency (as in the example image). If this is not done then the game area may share a palette color with other parts of the border leading to tile pattern flashing while the border loads.
 * See the pandocs for additional details
   * https://gbdev.io/pandocs/SGB_Functions.html
   * https://gbdev.io/pandocs/SGB_Color_Palettes.html

--- a/gbdk-lib/examples/gb/sgb_border/border.c
+++ b/gbdk-lib/examples/gb/sgb_border/border.c
@@ -12,7 +12,7 @@
   - The pixels in the game area at the center of the image should be set
     to 100% Alpha Transparency (as in the example image). If this is not
     done then the game area may share a palette color with other parts
-    of the border leading to tile pattern flasing while the border loads.
+    of the border leading to tile pattern flashing while the border loads.
 
 - See the pandocs for additional details
   - https://gbdev.io/pandocs/SGB_Functions.html

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -294,6 +294,12 @@ int main(int argc, char *argv[]) {
                 else
                     sprintf(binFile, "%s", path_newext(outfile, EXT_ROM));
 
+                // makebin - if autobanking and no ROM bank size specified (-yo *) then add ROM auto-size (-yo A)
+                if ((autobankflag) && (find("-yo", mkbinlist) == 0)) {
+                    mkbinlist = append("-yo", mkbinlist);
+                    mkbinlist = append("A", mkbinlist);
+                }
+
                 compose(mkbin, mkbinlist, append(ihxFile, 0), append(binFile, 0));
                 if (callsys(av))
                     errcnt++;


### PR DESCRIPTION
- When -autobank is enabled adds "-yo", "A" to makebin list if no other "-yo*" entry is present
- Correct typo in docs related to makebin flags

Also, a SGB docs typo