### PR TITLE
NES: Add random number generation to NES target

### DIFF
--- a/gbdk-lib/examples/cross-platform/randtest/Makefile
+++ b/gbdk-lib/examples/cross-platform/randtest/Makefile
@@ -6,19 +6,20 @@ LCC = $(GBDK_HOME)bin/lcc
 # Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
 # They can also be built/cleaned individually: "make gg" and "make gg-clean"
 # Possible are: gb gbc pocket megaduck sms gg
-TARGETS=gb pocket megaduck sms gg
+TARGETS=gb pocket megaduck sms gg nes
 
 # Configure platform specific LCC flags here:
-LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
-LCCFLAGS_pocket  = -Wl-yt0x1B # Usually the same as required for .gb
-LCCFLAGS_duck    = -Wl-yt0x1B # Usually the same as required for .gb
-LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_gb      = -Wl-yt0x1B -autobank # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wl-yt0x1B -autobank # Usually the same as required for .gb
+LCCFLAGS_duck    = -Wl-yt0x1B -autobank # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc -autobank # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
 LCCFLAGS_sms     =
 LCCFLAGS_gg      =
+LCCFLAGS_nes     =
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 
-LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
 # LCCFLAGS += -debug # Uncomment to enable debug output
 # LCCFLAGS += -v     # Uncomment for lcc verbose output
 

--- a/gbdk-lib/examples/cross-platform/randtest/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/randtest/Makefile.targets
@@ -48,3 +48,9 @@ gg-clean:
 gg:
 	${MAKE} build-target PORT=z80 PLAT=gg EXT=gg
 
+
+nes-clean:
+	${MAKE} clean-target EXT=nes
+nes:
+	${MAKE} build-target PORT=mos6502 PLAT=nes EXT=nes
+    

--- a/gbdk-lib/include/rand.h
+++ b/gbdk-lib/include/rand.h
@@ -25,7 +25,7 @@
 
     @see rand(), randw()
 */
-#if defined(__PORT_sm83)
+#if defined(__PORT_sm83) || defined(__PORT_mos6502)
 void initrand(uint16_t seed) OLDCALL;
 #elif defined(__PORT_z80)
 void initrand(uint16_t seed) Z88DK_FASTCALL;
@@ -68,7 +68,7 @@ uint16_t randw() OLDCALL;
 
     @see initrand() for suggestions about seed values, arand()
 */
-#if defined(__PORT_sm83)
+#if defined(__PORT_sm83) || defined(__PORT_mos6502)
 void initarand(uint16_t seed) OLDCALL;
 #elif defined(__PORT_z80)
 void initarand(uint16_t seed) Z88DK_FASTCALL;

--- a/gbdk-lib/libc/asm/mos6502/Makefile
+++ b/gbdk-lib/libc/asm/mos6502/Makefile
@@ -5,6 +5,7 @@ TOPDIR = ../../..
 THIS = mos6502
 
 ASSRC = __sdcc_indirect_jsr.s _memcpy.s _strcpy.s _strcmp.s \
+	rand.s \
 	_divuint.s _divsint.s _modsint.s _moduint.s \
 	_divulong.s _divslong.s _modulong.s _modslong.s \
 	_mulint.s \

--- a/gbdk-lib/libc/asm/mos6502/rand.s
+++ b/gbdk-lib/libc/asm/mos6502/rand.s
@@ -1,0 +1,61 @@
+;
+; Random number generation for mos6502.
+;
+; Re-implementation of rand / randw / inirand, originally from gbdk-lib/libc/asm/sm83/rand.s
+;
+; Also redirects arand / initarand to here, to avoid their extra memory cost.
+;
+
+.area ZP (PAG)
+___rand_seed::
+.randlo: .ds 1
+.randhi: .ds 1
+
+.area _HOME
+
+;
+; Returns an 8-bit / 16-bit rand value and updates the seed.
+;
+_arand::
+_rand::
+_randw::
+    ; rand += 17 * rand
+    lda *.randhi
+    sta *.tmp
+    lda *.randlo
+    asl
+    rol *.tmp
+    asl
+    rol *.tmp
+    asl
+    rol *.tmp
+    asl
+    rol *.tmp
+    ;
+    clc
+    adc *.randlo
+    sta *.randlo
+    lda *.tmp
+    adc *.randhi
+    sta *.randhi
+    ; rand += 0x5C93
+    lda *.randlo
+    clc
+    adc #<0x5C93
+    sta *.randlo
+    tax
+    lda *.randhi
+    adc #>0x5C93
+    sta *.randhi
+    ; Return high byte of random number for 8-bit. Swapped low/high for 16-bit
+    rts
+
+;
+; Sets the seed value.
+;
+_initarand::
+_initrand::
+.initrand::
+    sta *.randlo
+    stx *.randhi
+    rts


### PR DESCRIPTION
* Port rand / randw / initrand from sm83 to mos6502
* Point arand / initarand at rand / initrand, to conserve memory
* Update cross-platform/randtest to build for nes