### PR TITLE
CI/CD: Build Examples: Upload build artifacts

### DIFF
--- a/.github/workflows/gbdk_build_examples.yml
+++ b/.github/workflows/gbdk_build_examples.yml
@@ -151,15 +151,13 @@ jobs:
         if: (matrix.name == 'Windows-x64') || (matrix.name == 'Windows-x32')
         shell: cmd
         run: |
-          dir
-          # Now build the examples for all platforms
-          cd gbdk-2020          
+          # For Windows build Examples is a separate stage due to commands getting skipped(?) after calling msys make
+          # Now build the examples
+          cd gbdk-2020
           cd build
           cd gbdk
           cd examples
-          dir
           msys2 -c 'make'
-          dir
           cd ..
           cd ..
           cd ..

--- a/.github/workflows/gbdk_build_examples.yml
+++ b/.github/workflows/gbdk_build_examples.yml
@@ -145,11 +145,14 @@ jobs:
           set SDCCDIR=%CD%\sdcc
           cd gbdk-2020
           msys2 -c 'make'
+          dir
           # Now build the examples for all platforms
           cd build
           cd gbdk
           cd examples
+          dir
           msys2 -c 'make'
+          dir
           cd ..
           cd ..
           cd ..

--- a/.github/workflows/gbdk_build_examples.yml
+++ b/.github/workflows/gbdk_build_examples.yml
@@ -145,8 +145,15 @@ jobs:
           set SDCCDIR=%CD%\sdcc
           cd gbdk-2020
           msys2 -c 'make'
+          cd ..
+
+      - name: Build Examples GBDK-2020 Windows
+        if: (matrix.name == 'Windows-x64') || (matrix.name == 'Windows-x32')
+        shell: cmd
+        run: |
           dir
           # Now build the examples for all platforms
+          cd gbdk-2020          
           cd build
           cd gbdk
           cd examples
@@ -169,6 +176,7 @@ jobs:
           tar czf ../package/${{ env.BUILD_PACKAGE_FILENAME }} gbdk/examples
           cd ..
           cd ..
+
       - name: Package build Windows
         if: (matrix.name == 'Windows-x64') || (matrix.name == 'Windows-x32')
         shell: cmd
@@ -179,6 +187,7 @@ jobs:
           7z a ../package/${{ env.BUILD_PACKAGE_FILENAME }} gbdk/examples
           cd ..
           cd ..
+
       - name: Store build
         if: (matrix.name == 'Linux-64') || (matrix.name == 'MacOS-64') || ('Windows-x64') || ('Windows-x32')
         uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Unless you are interested on recompiling the sources for some reason (like fixin
 
 - **Windows only**: Download and install [mingw](http://mingw-w64.org/)
 - Clone, download this repo or just get the source form the [releases](https://github.com/gbdk-2020/gbdk-2020/releases)
-- Download and install the **PATCHED** [sdcc builds](https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/tag/sdcc-12539-patched) from the separate repo for that (https://github.com/gbdk-2020/gbdk-2020-sdcc/releases/tag/sdcc-12539-patched).
+- Download and install the **PATCHED** [sdcc builds](https://github.com/gbdk-2020/gbdk-2020-sdcc/releases) from the separate repo for that (https://github.com/gbdk-2020/gbdk-2020-sdcc/releases).
 - On Linux **don't use package managers** The latest release available won't work, you need to compile or download one of the nightlies
 - Create **SDCCDIR** environment variable, that points into the folder, where you installed sdcc
 - Open command prompt or a terminal, go to the root directory of the repo and run **make**


### PR DESCRIPTION
- Save copies of the built examples as artifacts
- Change recommended and started by @michel-iwaniec + my Windows runner fix
