### PR TITLE
lcc: Fix non-working -E preprocessor only #423

### DIFF
--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -64,7 +64,7 @@ static struct {
 		{ "mkbin", "%sdccdir%makebin" },
 		{ "crt0dir", "%libdir%%plat%/crt0.o"},
 		{ "libs_include", "-k %libdir%%port%/ -l %port%.lib -k %libdir%%plat%/ -l %plat%.lib"},
-                { "mkcom", "%sdccdir%makecom"}
+				{ "mkcom", "%sdccdir%makecom"}
 };
 
 static char *getTokenVal(const char *key)
@@ -187,13 +187,13 @@ static void buildArgs(char **args, const char *template)
 // If order is changed here, file type handling MUST be updated
 // in lcc.c: "switch (suffix(name, suffixes, 5)) {"
 char *suffixes[] = {
-    EXT_C,               // 0
-    EXT_I,               // 1
-    EXT_ASM ";" EXT_S,   // 2
-    EXT_O   ";" EXT_OBJ, // 3
-    EXT_IHX,             // 4
-    EXT_GB,              // 5
-    0
+	EXT_C,					// 0
+	EXT_I,			 		// 1
+	EXT_ASM ";" EXT_S,		// 2
+	EXT_O   ";" EXT_OBJ,	// 3
+	EXT_IHX,				// 4
+	EXT_GB,					// 5
+	0
 };
 
 char inputs[256] = "";
@@ -270,7 +270,7 @@ int option(char *arg) {
 			// Error out and warn user when old gbz80 PORT name is used instead of sm83
 			if (!strcmp("gbz80", words[0])) {
 				fprintf(stderr, "Error: %s: old \"gbz80\" SDCC PORT name specified (in \"%s\"). Use \"sm83\" instead. "
-				                "You must update your build settings.\n", progname, arg);
+								"You must update your build settings.\n", progname, arg);
 				exit(-1);
 			}
 
@@ -305,7 +305,7 @@ void finalise(void)
 	buildArgs(ld, _class->ld);
 	buildArgs(ihxcheck, _class->ihxcheck);
 	buildArgs(mkbin, _class->mkbin);
-        if (strlen(_class->postproc) != 0) buildArgs(postproc, _class->postproc); else postproc[0] = '\0';
+		if (strlen(_class->postproc) != 0) buildArgs(postproc, _class->postproc); else postproc[0] = '\0';
 	rom_extension = strdup(_class->rom_extension);
 	llist0_defaults = _class->llist0_defaults;
 	llist0_defaults_len = _class->llist0_defaults_len;

--- a/gbdk-support/lcc/gb.h
+++ b/gbdk-support/lcc/gb.h
@@ -6,6 +6,7 @@
 #define SUFX_NOMATCH -1
 
 #define EXT_C    ".c"
+#define EXT_H    ".h"
 #define EXT_I    ".i"
 #define EXT_ASM  ".asm"
 #define EXT_S    ".s"
@@ -14,6 +15,9 @@
 #define EXT_IHX  ".ihx"
 #define EXT_LK   ".lk"
 #define EXT_ROM  ".rom"
+#define EXT_LST  ".lst"
+#define EXT_SYM  ".sym"
+#define EXT_ADB  ".adb"
 
 // ROM file extensions
 #define EXT_GB     ".gb"

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -86,7 +86,7 @@ static List mkbinlist;		/* loader files, flags */
 #define L_ARGS 0
 #define L_FILES 1
 #define L_LKFILES 2
-static List llist[3];       /* [2] = .lkfiles, [1] = linker object file list, [0] = linker flags */
+static List llist[3];	   /* [2] = .lkfiles, [1] = linker object file list, [0] = linker flags */
 
 static List alist;		/* assembler flags */
 List clist;		/* compiler flags */
@@ -288,34 +288,34 @@ int main(int argc, char *argv[]) {
 		{
 			if(errcnt == 0)
 			{
-                // makebin - use output filename unless there is a post-process step
-                if (strlen(postproc) == 0)
-                    sprintf(binFile, "%s", outfile);
-                else
-                    sprintf(binFile, "%s", path_newext(outfile, EXT_ROM));
+				// makebin - use output filename unless there is a post-process step
+				if (strlen(postproc) == 0)
+					sprintf(binFile, "%s", outfile);
+				else
+					sprintf(binFile, "%s", path_newext(outfile, EXT_ROM));
 
-                // makebin - if autobanking and no ROM bank size specified (-yo *) then add ROM auto-size (-yo A)
-                if ((autobankflag) && (find("-yo", mkbinlist) == 0)) {
-                    mkbinlist = append("-yo", mkbinlist);
-                    mkbinlist = append("A", mkbinlist);
-                }
+				// makebin - if autobanking and no ROM bank size specified (-yo *) then add ROM auto-size (-yo A)
+				if ((autobankflag) && (find("-yo", mkbinlist) == 0)) {
+					mkbinlist = append("-yo", mkbinlist);
+					mkbinlist = append("A", mkbinlist);
+				}
 
-                compose(mkbin, mkbinlist, append(ihxFile, 0), append(binFile, 0));
-                if (callsys(av))
-                    errcnt++;
+				compose(mkbin, mkbinlist, append(ihxFile, 0), append(binFile, 0));
+				if (callsys(av))
+					errcnt++;
 
-                // post-process step (such as makecom), if applicable
-                if ((strlen(postproc) != 0) && (errcnt == 0)) {
-                    compose(postproc, append(binFile, 0), append(outfile, 0), 0);
-                    if (callsys(av))
-                        errcnt++;
-                }
+				// post-process step (such as makecom), if applicable
+				if ((strlen(postproc) != 0) && (errcnt == 0)) {
+					compose(postproc, append(binFile, 0), append(outfile, 0), 0);
+					if (callsys(av))
+						errcnt++;
+				}
 			}
 		}
 	}
 	rm(rmlist);
-    if (verbose > 0)
-        fprintf(stderr, "\n");
+	if (verbose > 0)
+		fprintf(stderr, "\n");
 	return errcnt ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 
@@ -408,7 +408,7 @@ char *basepath(char *name) {
 }
 
 // path_stripext - return a new string of path [name] with extension removed
-//              e.g. /usr/drh/foo.c => /usr/drh/foo
+//			  e.g. /usr/drh/foo.c => /usr/drh/foo
 char *path_stripext(char *name) {
 	char * copy_str = strsave(name);
 	char * end_str = copy_str + strlen(copy_str);
@@ -427,9 +427,9 @@ char *path_stripext(char *name) {
 
 
 // path_newext - return a new string of path [name] with extension replaced
-//              e.g. /usr/drh/foo.c => /usr/drh/foo
+//			  e.g. /usr/drh/foo.c => /usr/drh/foo
 char *path_newext(char *name, char *new_ext) {
-     return stringf("%s%s", path_stripext(name), new_ext);
+	 return stringf("%s%s", path_stripext(name), new_ext);
 }
 
 
@@ -480,11 +480,11 @@ void removeQuotes(char* src, char* dst)
 	while(*src != '\0')
 	{
 		if(*src != '\"')
-    {
-      if(*dst != *src)
+	{
+	  if(*dst != *src)
 				*(dst) = *src;
-      dst ++;
-    }
+	  dst ++;
+	}
 		src ++;
 	}
   if(*dst != '\0')
@@ -563,7 +563,7 @@ static int callsys(char **av) {
 #ifdef __WIN32__
 				fixQuotes(*it); //On windows quotes must be kept, and fixed
 #else
-        removeQuotes(*it, *it); //On macos, quotes must be fully removed from args
+		removeQuotes(*it, *it); //On macos, quotes must be fully removed from args
 #endif
 			}
 			//For future reference:
@@ -900,7 +900,7 @@ static void opt(char *arg) {
 						llist[L_LKFILES] = append(stringf(&arg[5]), llist[L_LKFILES]);
 					} else {
 						//sdldgb requires spaces between -k and the path
-						llist[L_ARGS] = append(stringf("%c%c", arg[3], arg[4]), llist[L_ARGS]);     //splitting the args into 2 works on Win and Linux
+						llist[L_ARGS] = append(stringf("%c%c", arg[3], arg[4]), llist[L_ARGS]);	 //splitting the args into 2 works on Win and Linux
 						if (arg[5]) {
 							llist[L_ARGS] = append(&arg[5], llist[L_ARGS]);  // Add filename separately if present
 						}
@@ -946,9 +946,9 @@ static void opt(char *arg) {
 	case 'd':	/* -dn */
 		if (strcmp(arg, "-debug") == 0) {
 			// Load default debug options
-			clist    = append("--debug", clist);  // Debug for sdcc compiler
-			llist[L_ARGS] = append("-y", llist[L_ARGS]);    // Enable .cdb output for sdldgb linker
-			llist[L_ARGS] = append("-j", llist[L_ARGS]);    // Enable .noi output
+			clist	= append("--debug", clist);  // Debug for sdcc compiler
+			llist[L_ARGS] = append("-y", llist[L_ARGS]);	// Enable .cdb output for sdldgb linker
+			llist[L_ARGS] = append("-j", llist[L_ARGS]);	// Enable .noi output
 			return;
 		}
 
@@ -1028,7 +1028,7 @@ static void opt(char *arg) {
 	}
 	if (arg[2] == 0)
 		switch (arg[1]) {	/* single-character options */
-		case 'S':        // Requested compile to assembly only
+		case 'S':		// Requested compile to assembly only
 			Sflag++;
 			option(arg); // Update composing the compile stage, use of -S instead of -c
 			return;
@@ -1166,29 +1166,29 @@ char *tempname(char *suffix) {
 //
 static void handle_autobanking(void) {
 
-    // bankpack will be populated if supported by active port:platform
-    if (bankpack[0][0] != '\0') {
+	// bankpack will be populated if supported by active port:platform
+	if (bankpack[0][0] != '\0') {
 
-        char * bankpack_linkerfile_name = tempname(EXT_LK);
-        rmlist = append(bankpack_linkerfile_name, rmlist); // Delete the linkerfile when done
-        // Always use a linkerfile when using bankpack through lcc
-        // Writes all input object files out to [bankpack_linkerfile_name]
-        bankpack_flags = append(stringf("%s%s","-lkout=", bankpack_linkerfile_name), bankpack_flags);
+		char * bankpack_linkerfile_name = tempname(EXT_LK);
+		rmlist = append(bankpack_linkerfile_name, rmlist); // Delete the linkerfile when done
+		// Always use a linkerfile when using bankpack through lcc
+		// Writes all input object files out to [bankpack_linkerfile_name]
+		bankpack_flags = append(stringf("%s%s","-lkout=", bankpack_linkerfile_name), bankpack_flags);
 
-        // Add linkerfile entries (usually *.lk) to the bankpack arg list if any are present
-        bankpack_flags = list_add_to_another(bankpack_flags, llist[L_LKFILES], "-lkin=", NULL);
+		// Add linkerfile entries (usually *.lk) to the bankpack arg list if any are present
+		bankpack_flags = list_add_to_another(bankpack_flags, llist[L_LKFILES], "-lkin=", NULL);
 
-        // Prepare the bankpack command line, then execute it
-        compose(bankpack, bankpack_flags, llist[L_FILES], 0);
-        if (callsys(av))
-            errcnt++;
+		// Prepare the bankpack command line, then execute it
+		compose(bankpack, bankpack_flags, llist[L_FILES], 0);
+		if (callsys(av))
+			errcnt++;
 
-        // Clear out the objects file and linkerfiles from their lists
-        // Then replace them with the filename passed to bankpack for "-lkout="
-        llist[L_FILES]   = list_remove_all(llist[L_FILES]);
-        llist[L_LKFILES] = list_remove_all(llist[L_LKFILES]);
-        llist[L_LKFILES] = append(stringf("%s", bankpack_linkerfile_name), llist[L_LKFILES]);
-    }
-    else
-        fprintf(stderr, "Warning: bankpack enabled but not supported by active port:platform\n");
+		// Clear out the objects file and linkerfiles from their lists
+		// Then replace them with the filename passed to bankpack for "-lkout="
+		llist[L_FILES]   = list_remove_all(llist[L_FILES]);
+		llist[L_LKFILES] = list_remove_all(llist[L_LKFILES]);
+		llist[L_LKFILES] = append(stringf("%s", bankpack_linkerfile_name), llist[L_LKFILES]);
+	}
+	else
+		fprintf(stderr, "Warning: bankpack enabled but not supported by active port:platform\n");
 }

--- a/gbdk-support/lcc/targets.c
+++ b/gbdk-support/lcc/targets.c
@@ -48,119 +48,126 @@ arg_entry llist0_defaults_nes[] = {
 // $3 is the output file
 CLASS classes[] = {
     // GB
-    { "sm83",      // port
-        "gb",       // plat
-        "gb",       // default_plat
-        EXT_GB,     // ROM file extension
-        "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
-        "%includedefault%",
-        "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
-        "%as_gb% %asdefault% $1 $3 $2",
-        "%bankpack% $1 $2",
-        "%ld_gb% -n -i $1 %libs_include% $3 %crt0dir% $2",
-        "%ihxcheck% $2 $1",
-        "%mkbin% -yN -Z $1 $2 $3",  // -yN: Don't paste in the Nintendo logo bytes for gameboy and clones (-Z)
-        "",
-        llist0_defaults_gb, ARRAY_LEN(llist0_defaults_gb),
+    { .port         = "sm83",
+      .plat         = "gb",
+      .default_plat = "gb",
+      .rom_extension=  EXT_GB,
+      .cpp          = "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
+      .include      = "%includedefault%",
+      .com          = "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
+      .as           = "%as_gb% %asdefault% $1 $3 $2",
+      .bankpack     = "%bankpack% $1 $2",
+      .ld           = "%ld_gb% -n -i $1 %libs_include% $3 %crt0dir% $2",
+      .ihxcheck     = "%ihxcheck% $2 $1",
+      .mkbin        = "%mkbin% -yN -Z $1 $2 $3",  // -yN: Don't paste in the Nintendo logo bytes for gameboy and clones (-Z)
+      .postproc     = "",
+      .llist0_defaults    = llist0_defaults_gb,
+      .llist0_defaults_len= ARRAY_LEN(llist0_defaults_gb),
     },
     // Analogue Pocket
-    { "sm83",      // port
-        "ap",       // plat
-        "ap",       // default_plat
-        EXT_AP,     // ROM file extension
-        "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
-        "%includedefault%",
-        "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
-        "%as_gb% %asdefault% $1 $3 $2",
-        "%bankpack% $1 $2",
-        "%ld_gb% -n -i $1 %libs_include% $3 %crt0dir% $2",
-        "%ihxcheck% $2 $1",
-        "%mkbin% -yN -Z $1 $2 $3",  // -yN: Don't paste in the Nintendo logo bytes for gameboy and clones (-Z)
-        "",
-        llist0_defaults_gb, ARRAY_LEN(llist0_defaults_gb), // Use GB linker list defaults
+    { .port         = "sm83",
+      .plat         = "ap",
+      .default_plat = "ap",
+      .rom_extension=  EXT_AP,
+      .cpp          = "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
+      .include      = "%includedefault%",
+      .com          = "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
+      .as           = "%as_gb% %asdefault% $1 $3 $2",
+      .bankpack     = "%bankpack% $1 $2",
+      .ld           = "%ld_gb% -n -i $1 %libs_include% $3 %crt0dir% $2",
+      .ihxcheck     = "%ihxcheck% $2 $1",
+      .mkbin        = "%mkbin% -yN -Z $1 $2 $3",  // -yN: Don't paste in the Nintendo logo bytes for gameboy and clones (-Z)
+      .postproc     = "",
+      .llist0_defaults    = llist0_defaults_gb,
+      .llist0_defaults_len= ARRAY_LEN(llist0_defaults_gb), // Use GB linker list defaults
     },
     // Megaduck
-    { "sm83",      // port
-        "duck",     // plat
-        "duck",     // default_plat
-        EXT_DUCK,   // ROM file extension
-        "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
-        "%includedefault%",
-        "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
-        "%as_gb% %asdefault% $1 $3 $2",
-        "%bankpack% $1 $2",
-        "%ld_gb% -n -i $1 %libs_include% $3 %crt0dir% $2",
-        "%ihxcheck% $2 $1",
-        "%mkbin% -yN -Z $1 $2 $3",  // -yN: Don't paste in the Nintendo logo bytes for gameboy and clones (-Z)
-        "",
-        llist0_defaults_gb, ARRAY_LEN(llist0_defaults_gb), // Use GB linker list defaults
+    { .port         = "sm83",
+      .plat         = "duck",
+      .default_plat = "duck",
+      .rom_extension=  EXT_DUCK,
+      .cpp          = "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
+      .include      = "%includedefault%",
+      .com          = "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
+      .as           = "%as_gb% %asdefault% $1 $3 $2",
+      .bankpack     = "%bankpack% $1 $2",
+      .ld           = "%ld_gb% -n -i $1 %libs_include% $3 %crt0dir% $2",
+      .ihxcheck     = "%ihxcheck% $2 $1",
+      .mkbin        = "%mkbin% -yN -Z $1 $2 $3",  // -yN: Don't paste in the Nintendo logo bytes for gameboy and clones (-Z)
+      .postproc     = "",
+      .llist0_defaults    = llist0_defaults_gb,
+      .llist0_defaults_len= ARRAY_LEN(llist0_defaults_gb), // Use GB linker list defaults
     },
 
     // SMS
-    { "z80",        // port
-        "sms",      // plat
-        "sms",      // default_plat
-        EXT_SMS,    // ROM file extension
-        "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
-        "%includedefault%",
-        "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
-        "%as_z80% %asdefault% $1 $3 $2",
-        "%bankpack% -plat=sms $1 $2",
-        "%ld_z80% -a sms -n -i $1 %libs_include% $3 %crt0dir% $2",
-        "%ihxcheck% $2 $1",
-        "%mkbin% -S -xj 4 $1 $2 $3",
-        "",
-        llist0_defaults_sms, ARRAY_LEN(llist0_defaults_sms),
+    { .port         = "z80",
+      .plat         = "sms",
+      .default_plat = "sms",
+      .rom_extension=  EXT_SMS,
+      .cpp          = "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
+      .include      = "%includedefault%",
+      .com          = "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
+      .as           = "%as_z80% %asdefault% $1 $3 $2",
+      .bankpack     = "%bankpack% -plat=sms $1 $2",
+      .ld           = "%ld_z80% -a sms -n -i $1 %libs_include% $3 %crt0dir% $2",
+      .ihxcheck     = "%ihxcheck% $2 $1",
+      .mkbin        = "%mkbin% -S -xj 4 $1 $2 $3",
+      .postproc     = "",
+      .llist0_defaults    = llist0_defaults_sms,
+      .llist0_defaults_len= ARRAY_LEN(llist0_defaults_sms),
     },
     // GG
-    { "z80",        // port
-        "gg",       // plat
-        "gg",       // default_plat
-        EXT_GG,     // ROM file extension
-        "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
-        "%includedefault%",
-        "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
-        "%as_z80% %asdefault% $1 $3 $2",
-        "%bankpack% -plat=sms $1 $2",
-        "%ld_z80% -a sms -n -i $1 %libs_include% $3 %crt0dir% $2",
-        "%ihxcheck% $2 $1",
-        "%mkbin% -S $1 $2 $3",
-        "",
-        llist0_defaults_sms, ARRAY_LEN(llist0_defaults_sms),  // Use SMS linker list defaults
+    { .port         = "z80",
+      .plat         = "gg",
+      .default_plat = "gg",
+      .rom_extension=  EXT_GG,
+      .cpp          = "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
+      .include      = "%includedefault%",
+      .com          = "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
+      .as           = "%as_z80% %asdefault% $1 $3 $2",
+      .bankpack     = "%bankpack% -plat=sms $1 $2",
+      .ld           = "%ld_z80% -a sms -n -i $1 %libs_include% $3 %crt0dir% $2",
+      .ihxcheck     = "%ihxcheck% $2 $1",
+      .mkbin        = "%mkbin% -S $1 $2 $3",
+      .postproc     = "",
+      .llist0_defaults    = llist0_defaults_sms,
+      .llist0_defaults_len= ARRAY_LEN(llist0_defaults_sms),  // Use SMS linker list defaults
     },
 
     // MSX
-    { "z80",        // port
-        "msxdos",   // plat
-        "msxdos",   // default_plat
-        EXT_MSXDOS, // ROM file extension
-        "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
-        "%includedefault%",
-        "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
-        "%as_z80% %asdefault% $1 $3 $2",
-        "%bankpack% -plat=sms $1 $2",
-        "%ld_z80% -a sms -n -i -j $1 %libs_include% $3 %crt0dir% $2",
-        "%ihxcheck% $2 $1",
-        "%mkbin% $1 $2 $3",
-        "%mkcom% $1 $2",
-        llist0_defaults_msxdos, ARRAY_LEN(llist0_defaults_msxdos),
+    { .port         = "z80",
+      .plat         = "msxdos",
+      .default_plat = "msxdos",
+      .rom_extension=  EXT_MSXDOS,
+      .cpp          = "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
+      .include      = "%includedefault%",
+      .com          = "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
+      .as           = "%as_z80% %asdefault% $1 $3 $2",
+      .bankpack     = "%bankpack% -plat=sms $1 $2",
+      .ld           = "%ld_z80% -a sms -n -i -j $1 %libs_include% $3 %crt0dir% $2",
+      .ihxcheck     = "%ihxcheck% $2 $1",
+      .mkbin        = "%mkbin% $1 $2 $3",
+      .postproc     = "%mkcom% $1 $2",
+      .llist0_defaults    = llist0_defaults_msxdos,
+      .llist0_defaults_len= ARRAY_LEN(llist0_defaults_msxdos),
     },
 
     // NES
-    { "mos6502",        // port
-        "nes",   // plat
-        "nes",   // default_plat
-        EXT_NES, // ROM file extension
-        "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
-        "%includedefault%",
-        "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
-        "%as_6500% %asdefault% $1 $3 $2",
-        "%bankpack% -plat=nes $1 $2",
-        "%ld% -n -i -j $1 %libs_include% $3 %crt0dir% $2",
-        "%ihxcheck% $2 $1",
-        "%mkbin% -N -yo 2 -yS $2 $3",
-        "",
-        llist0_defaults_nes, ARRAY_LEN(llist0_defaults_nes),
+    { .port         = "mos6502",
+      .plat         = "nes",
+      .default_plat = "nes",
+      .rom_extension=  EXT_NES,
+      .cpp          = "%cpp% %cppdefault% -DINT_16_BITS $1 $2 $3",
+      .include      = "%includedefault%",
+      .com          = "%com% %comdefault% -Wa%asdefault% -DINT_16_BITS $1 %comflag% $2 -o $3",
+      .as           = "%as_6500% %asdefault% $1 $3 $2",
+      .bankpack     = "%bankpack% -plat=nes $1 $2",
+      .ld           = "%ld% -n -i -j $1 %libs_include% $3 %crt0dir% $2",
+      .ihxcheck     = "%ihxcheck% $2 $1",
+      .mkbin        = "%mkbin% -N -yo 2 -yS $2 $3",
+      .postproc     = "",
+      .llist0_defaults    = llist0_defaults_nes,
+      .llist0_defaults_len= ARRAY_LEN(llist0_defaults_nes),
     }
 
 };


### PR DESCRIPTION
- Allow -E output to stdout
- Add --save-preproc to write output to .i files
- Update preprocess-only port/plat values to match new way used for compile command string
- Change a couple more extensions to use constants
- This follows the existing convention for -c and -S where the output file is just the input file with the path stripped off and placed into the working dir (with new extension). Not actually sure that's what anyone wants, but not gonna rock that boat for now.
- Improve targets.c readability with more designated initializers
- Clean up some spaces/tabs mixing