### PR TITLE
SMS: Enable examples/cross-platform/large_map for SMS

### DIFF
--- a/gbdk-lib/examples/cross-platform/large_map/Makefile
+++ b/gbdk-lib/examples/cross-platform/large_map/Makefile
@@ -6,7 +6,7 @@ LCC = $(GBDK_HOME)bin/lcc
 # Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
 # They can also be built/cleaned individually: "make gg" and "make gg-clean"
 # Possible are: gb gbc pocket megaduck sms gg
-TARGETS=gb gg
+TARGETS=gb gg sms
 
 # Configure platform specific LCC flags here:
 LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)

--- a/gbdk-lib/examples/cross-platform/large_map/src/large_map.c
+++ b/gbdk-lib/examples/cross-platform/large_map/src/large_map.c
@@ -5,13 +5,21 @@
 #include "bigmap_map.h"
 #include "bigmap_tiles.h"
 
-#define camera_max_y ((bigmap_mapHeight - 18) * 8) 
-#define camera_max_x ((bigmap_mapWidth - 20) * 8) 
+#define camera_max_y ((bigmap_mapHeight - DEVICE_SCREEN_HEIGHT) * 8) 
+#define camera_max_x ((bigmap_mapWidth - DEVICE_SCREEN_WIDTH) * 8) 
 
 #if defined(SEGA)
   #define WRAP_SCROLL_Y(y) ((y) % 224u)
+  // For SMS, artifacts are already invisible as screen buffer size is larger than screen size
+  #define SCROLL_Y_OFFSET 0
 #elif defined(NINTENDO)
   #define WRAP_SCROLL_Y(y) y
+  // For GB, artifacts are already invisible as screen buffer size is larger than screen size
+  #define SCROLL_Y_OFFSET 0
+#else
+  #define WRAP_SCROLL_Y(y) ((y) % 240u)
+  // For other systems assume height of 240 and adjust Y-scroll 4 pixels down to partly hide artifacts in NTSC overscan
+  #define SCROLL_Y_OFFSET 4
 #endif
 
 #define MIN(A,B) ((A)<(B)?(A):(B))
@@ -25,16 +33,55 @@ uint8_t map_pos_x, map_pos_y, old_map_pos_x, old_map_pos_y;
 // redraw flag, indicates that camera position was changed
 uint8_t redraw;
 
+inline uint8_t update_column_left(uint8_t map_pos_x)
+{
+#if (DEVICE_SCREEN_BUFFER_WIDTH == DEVICE_SCREEN_WIDTH)
+    return map_pos_x + 1;
+#else
+    return map_pos_x;
+#endif
+}
+
+inline uint8_t update_column_right(uint8_t map_pos_x)
+{
+    return map_pos_x + DEVICE_SCREEN_WIDTH;
+}
+
+inline uint8_t update_row_top(uint8_t map_pos_y)
+{
+#if (DEVICE_SCREEN_BUFFER_HEIGHT == DEVICE_SCREEN_HEIGHT)
+    return map_pos_y + 1;
+#else
+    return map_pos_y;
+#endif
+}
+
+inline uint8_t update_row_bottom(uint8_t map_pos_y)
+{
+    return map_pos_y + DEVICE_SCREEN_HEIGHT;
+}
+
 void set_camera() {
     // update hardware scroll position
-    move_bkg(camera_x, WRAP_SCROLL_Y(camera_y));
+    move_bkg(camera_x, WRAP_SCROLL_Y(camera_y + SCROLL_Y_OFFSET));
     // up or down
     map_pos_y = (uint8_t)(camera_y >> 3u);
     if (map_pos_y != old_map_pos_y) { 
         if (camera_y < old_camera_y) {
-            set_bkg_submap(map_pos_x, map_pos_y, MIN(21u, bigmap_mapWidth-map_pos_x), 1, bigmap_map, bigmap_mapWidth);
+            set_bkg_submap(map_pos_x,
+                           update_row_top(map_pos_y),
+                           MIN(DEVICE_SCREEN_WIDTH + 1, bigmap_mapWidth-map_pos_x),
+                           1,
+                           bigmap_map,
+                           bigmap_mapWidth);
         } else {
-            if ((bigmap_mapHeight - 18u) > map_pos_y) set_bkg_submap(map_pos_x, map_pos_y + 18u, MIN(21u, bigmap_mapWidth-map_pos_x), 1, bigmap_map, bigmap_mapWidth);     
+            if ((bigmap_mapHeight - DEVICE_SCREEN_HEIGHT) > map_pos_y)
+                set_bkg_submap(map_pos_x,
+                               update_row_bottom(map_pos_y),
+                               MIN(DEVICE_SCREEN_WIDTH + 1, bigmap_mapWidth-map_pos_x),
+                               1,
+                               bigmap_map,
+                               bigmap_mapWidth);     
         }
         old_map_pos_y = map_pos_y; 
     }
@@ -42,9 +89,20 @@ void set_camera() {
     map_pos_x = (uint8_t)(camera_x >> 3u);
     if (map_pos_x != old_map_pos_x) {
         if (camera_x < old_camera_x) {
-            set_bkg_submap(map_pos_x, map_pos_y, 1, MIN(19u, bigmap_mapHeight - map_pos_y), bigmap_map, bigmap_mapWidth);     
+            set_bkg_submap(update_column_left(map_pos_x),
+                           map_pos_y,
+                           1,
+                           MIN(DEVICE_SCREEN_HEIGHT + 1, bigmap_mapHeight - map_pos_y),
+                           bigmap_map,
+                           bigmap_mapWidth);     
         } else {
-            if ((bigmap_mapWidth - 20u) > map_pos_x) set_bkg_submap(map_pos_x + 20u, map_pos_y, 1, MIN(19u, bigmap_mapHeight - map_pos_y), bigmap_map, bigmap_mapWidth);     
+            if ((bigmap_mapWidth - DEVICE_SCREEN_WIDTH) > map_pos_x)
+                set_bkg_submap(update_column_right(map_pos_x),
+                               map_pos_y,
+                               1,
+                               MIN(DEVICE_SCREEN_HEIGHT + 1, bigmap_mapHeight - map_pos_y),
+                               bigmap_map,
+                               bigmap_mapWidth);
         }
         old_map_pos_x = map_pos_x;
     }
@@ -54,19 +112,24 @@ void set_camera() {
 
 void main(){
     DISPLAY_OFF;
-    set_2bpp_palette(COMPAT_PALETTE(11,5,4,3));
     set_bkg_data(0, 241u, bigmap_tiles);
 
     map_pos_x = map_pos_y = 0; 
     old_map_pos_x = old_map_pos_y = 255;
-    set_bkg_submap(map_pos_x, map_pos_y, 20, 18, bigmap_map, bigmap_mapWidth);
+    set_bkg_submap(map_pos_x, map_pos_y, DEVICE_SCREEN_WIDTH, DEVICE_SCREEN_HEIGHT, bigmap_map, bigmap_mapWidth);
     
     camera_x = camera_y = 0;
     old_camera_x = camera_x; old_camera_y = camera_y;
 
     redraw = FALSE;
 
-    move_bkg(camera_x, WRAP_SCROLL_Y(camera_y));
+    move_bkg(camera_x, WRAP_SCROLL_Y(camera_y + SCROLL_Y_OFFSET));
+#if DEVICE_SCREEN_BUFFER_WIDTH == DEVICE_SCREEN_WIDTH
+        // On platforms where screen buffer has no more space than physical screen,
+        // the next map column will be written to the leftmost screen column.
+        // So we blank the leftmost column to hide visual artifacts where possible.
+        HIDE_LEFT_COLUMN;
+#endif
     SHOW_BKG;
     DISPLAY_ON;
     while (TRUE) {


### PR DESCRIPTION
* Remove set_2pp_palette(COMPAT_PALETTE(11,5,4,3)) call, to make colors more consistent across all targets
* Replace hardcoded width / height of 20 / 18 with DEVICE_SCREEN_WIDTH / DEVICE_SCREEN_HEIGHT
* Add blanking of leftmost column if DEVICE_SCREEN_BUFFER_WIDTH == DEVICE_SCREEN_WIDTH
* Add helper functions update_column_left / right and update_row_top / bottom, to define update column / row per-target
* Update WRAP_SCROLL for SMS's 224-high nametable - and default to NES's 240-high nametable for all other targets
* Add SCROLL_Y_OFFSET constant for adjusting final scroll on a per-target basis, to hide scrolling artifacts
* Enable sms target in Makefile