### PR TITLE
NES: Add FAST_DIV8 / FAST_MOD8 macros

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -119,3 +119,26 @@
         ;; Main user routine
         .globl  _main
 
+.macro DIV_PART divident divisor ?lbl
+        rol divident
+        rol
+        sec
+        sbc divisor
+        bcs lbl
+        adc divisor
+lbl:
+.endm
+.macro FAST_DIV8 divident divisor
+        ; returns quotient in A
+        .rept 8
+                DIV_PART divident divisor
+        .endm
+        lda divident
+        eor #0xFF
+.endm
+.macro FAST_MOD8 divident divisor
+        ; returns modulus in A
+        .rept 8
+                DIV_PART divident divisor
+        .endm
+.endm


### PR DESCRIPTION
* Port FAST_DIV8 and FAST_MOD8 macros in gbdk-lib/libc/targets/z80/sms/global.s to gbdk-lib/libc/targets/mos6502/nes/global.s