### PR TITLE
NES: Increase total ROM space, as a work-around for lack of bank-switching

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -129,7 +129,7 @@ _attribute_row_dirty::                  .ds 1
         .area _HEAP
         .area _HEAP_END
 
-.area CODE
+.area CODEFIXED
 
 .bndry 0x100
 .identity::

--- a/gbdk-support/lcc/targets.c
+++ b/gbdk-support/lcc/targets.c
@@ -35,9 +35,9 @@ arg_entry llist0_defaults_msxdos[] = {
 // NES
 arg_entry llist0_defaults_nes[] = {
     {.searchkey= "DATA=",        .addflag= "-b",.addvalue= "DATA=0x300",         .found = false},
-    {.searchkey= "CODE=",        .addflag= "-b",.addvalue= "CODE=0xC000",        .found = false},
+    {.searchkey= "CODE=",        .addflag= "-b",.addvalue= "CODE=0x8000",        .found = false},
+    {.searchkey= "CODEFIXED=",   .addflag= "-b",.addvalue= "CODEFIXED=0xE000",   .found = false},
     {.searchkey= "VECTORS=",     .addflag= "-b",.addvalue= "VECTORS=0xFFFA",     .found = false},
-    {.searchkey= "_CODE_1=",     .addflag= "-b",.addvalue= "_CODE_1=0x8000",     .found = false},
     {.searchkey= "ZP=",          .addflag= "-b",.addvalue= "ZP=0x30",            .found = false},
 };
 


### PR DESCRIPTION
* Make generic CODE segment start at 0x8000
* Introduce new segment 8kB CODEFIXED at 0xE000 dedicated to crt0, leaving remaining 24kB to CODE