### PR TITLE
LCC: fix for --sdccbindir= broken in commit c1398c2afaa90af8d8c945f39c2c02be531b95f2

### DIFF
--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -871,9 +871,13 @@ static void interrupt(int n) {
 static void opt(char *arg) {
 	switch (arg[1]) {	/* multi-character options */
 	case '-':	// --* options
-		if (strcmp(arg, "--save-preproc") == 0)
+		if (strcmp(arg, "--save-preproc") == 0) {
 			Eflag_preproc_to_file = true;
-		return;
+			return;
+		}
+		// If no match for "--*" options here then break instead of
+		// return in case they need to get processed in option() below
+		break;
 	case 'W':	/* -Wxarg */
 		if (arg[2] && arg[3])
 			switch (arg[2]) {


### PR DESCRIPTION
- Unmatched '-' entries need to fall through to option() in gb.c for additional testing