### PR TITLE
NES: Fix NES sprite properties

### DIFF
--- a/gbdk-lib/include/nes/metasprites.h
+++ b/gbdk-lib/include/nes/metasprites.h
@@ -82,7 +82,8 @@ typedef struct metasprite_t {
 } metasprite_t;
 
 #define metasprite_end -128
-#define METASPR_ITEM(dy,dx,dt,a) {(dy),(dx),(dt),(a)}
+#define FLAGS_GB_TO_NES(a) (((a & 0x40) << 1) | ((a & 0x20) << 1) | (a & 0x3))
+#define METASPR_ITEM(dy,dx,dt,a) {(dy),(dx),(dt),FLAGS_GB_TO_NES(a)}
 #define METASPR_TERM {metasprite_end}
 
 extern const void * __current_metasprite;

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites.s
@@ -76,7 +76,6 @@ ___move_metasprite_loop:
     sta _shadow_OAM+OAM_TILE_INDEX,x
     lda [*___current_metasprite],y      ; props
     iny
-    ; TODO: Handle attributes in png2asset
     sta _shadow_OAM+OAM_ATTRIBUTES,x
     inx
     inx
@@ -112,7 +111,6 @@ ___move_metasprite_vflip_loop:
     lda [*___current_metasprite],y      ; props
     eor #OAMF_XFLIP
     iny
-    ; TODO: Handle attributes in png2asset
     sta _shadow_OAM+OAM_ATTRIBUTES,x
     inx
     inx
@@ -149,7 +147,6 @@ ___move_metasprite_hflip_loop:
     lda [*___current_metasprite],y      ; props
     eor #OAMF_YFLIP
     iny
-    ; TODO: Handle attributes in png2asset
     sta _shadow_OAM+OAM_ATTRIBUTES,x
     inx
     inx
@@ -186,7 +183,6 @@ ___move_metasprite_hvflip_loop:
     lda [*___current_metasprite],y      ; props
     eor #OAMF_YFLIP+OAMF_XFLIP
     iny
-    ; TODO: Handle attributes in png2asset
     sta _shadow_OAM+OAM_ATTRIBUTES,x
     inx
     inx


### PR DESCRIPTION
* Add new C macro FLAGS_GB_TO_NES to gbdk-lib/include/nes/metasprites.h, to convert GB sprite flags to NES format
* Use macros in METASPR_ITEM definition to trigger the conversion
* Remove "TODO:" comments from gbdk-lib/libc/targets/mos6502/nes/metasprites.s