### PR TITLE
png2asset: Make props in generated metasprites cross-platform

### DIFF
--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -80,6 +80,10 @@
     @see set_sprite_prop()
 */
 #define S_PRIORITY   0x80U
+/** Defines how palette number is encoded in OAM.
+    Required for the png2asset tool's metasprite output.
+*/
+#define S_PAL(n)     n
 
 /* Interrupt flags */
 /** Disable calling of interrupt service routines

--- a/gbdk-lib/include/msx/msx.h
+++ b/gbdk-lib/include/msx/msx.h
@@ -74,6 +74,10 @@
 /** If set the background tile priority.
  */
 #define S_PRIORITY   0x10U
+/** Defines how palette number is encoded in OAM.
+    Required for the png2asset tool's metasprite output.
+*/
+#define S_PAL(n)     n
 
 // VDP helper macros
 #define __WRITE_VDP_REG(REG, v) shadow_##REG=(v);__critical{VDP_CMD=(shadow_##REG),VDP_CMD=REG;}

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -109,6 +109,10 @@ void set_sprite_palette_entry(uint8_t palette, uint8_t entry, palette_color_t rg
     @see set_sprite_prop()
 */
 #define S_PRIORITY   0x20U
+/** Defines how palette number is encoded in OAM.
+    Required for the png2asset tool's metasprite output.
+*/
+#define S_PAL(n)     n
 
 /* DMG Palettes */
 #define DMG_BLACK     0x03

--- a/gbdk-lib/include/sms/sms.h
+++ b/gbdk-lib/include/sms/sms.h
@@ -78,6 +78,10 @@
 /** If set the background tile priority.
  */
 #define S_PRIORITY   0x10U
+/** Dummy function used by other platforms.
+    Required for the png2asset tool's metasprite output.
+*/
+#define S_PAL(n)     0
 
 // VDP helper macros
 #define __WRITE_VDP_REG(REG, v) shadow_##REG=(v);__critical{VDP_CMD=(shadow_##REG),VDP_CMD=REG;}

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites.s
@@ -76,7 +76,6 @@ ___move_metasprite_loop:
     sta _shadow_OAM+OAM_TILE_INDEX,x
     lda [*___current_metasprite],y      ; props
     iny
-    ; TODO: Handle attributes in png2asset
     sta _shadow_OAM+OAM_ATTRIBUTES,x
     inx
     inx
@@ -112,7 +111,6 @@ ___move_metasprite_vflip_loop:
     lda [*___current_metasprite],y      ; props
     eor #OAMF_XFLIP
     iny
-    ; TODO: Handle attributes in png2asset
     sta _shadow_OAM+OAM_ATTRIBUTES,x
     inx
     inx
@@ -149,7 +147,6 @@ ___move_metasprite_hflip_loop:
     lda [*___current_metasprite],y      ; props
     eor #OAMF_YFLIP
     iny
-    ; TODO: Handle attributes in png2asset
     sta _shadow_OAM+OAM_ATTRIBUTES,x
     inx
     inx
@@ -186,7 +183,6 @@ ___move_metasprite_hvflip_loop:
     lda [*___current_metasprite],y      ; props
     eor #OAMF_YFLIP+OAMF_XFLIP
     iny
-    ; TODO: Handle attributes in png2asset
     sta _shadow_OAM+OAM_ATTRIBUTES,x
     inx
     inx

--- a/gbdk-support/png2asset/png2asset.cpp
+++ b/gbdk-support/png2asset/png2asset.cpp
@@ -1367,12 +1367,21 @@ bool export_c_file(void) {
 			for(vector< MetaSprite >::iterator it = sprites.begin(); it != sprites.end(); ++ it)
 			{
 				fprintf(file, "const metasprite_t %s_metasprite%d[] = {\n", data_name.c_str(), (int)(it - sprites.begin()));
-				fprintf(file, "\t");
 				for(MetaSprite::iterator it2 = (*it).begin(); it2 != (*it).end(); ++ it2)
-				{
-					fprintf(file, "METASPR_ITEM(%d, %d, %d, %d), ", (*it2).offset_y, (*it2).offset_x, (*it2).offset_idx, (*it2).props);
+				{                    
+					int pal_idx = (*it2).props & 0xF;
+                    int flip_x = ((*it2).props >> 5) & 1;
+                    int flip_y = ((*it2).props >> 6) & 1;
+					fprintf(file,
+					        "\tMETASPR_ITEM(%d, %d, %d, S_PAL(%d)%s%s),\n",
+					        (*it2).offset_y,
+					        (*it2).offset_x,
+					        (*it2).offset_idx,
+					        pal_idx,
+					        flip_x ? " | S_FLIPX" : "",
+					        flip_y ? " | S_FLIPY" : "");
 				}
-				fprintf(file, "METASPR_TERM\n");
+				fprintf(file, "\tMETASPR_TERM\n");
 				fprintf(file, "};\n\n");
 			}
 


### PR DESCRIPTION
* Update printing of METASPR_ITEM in png2asset to extract X/Y flip and palette number, print them as symbolic names S_FLIPX, S_FLIPY and S_PAL(...)
* (...and adjust output formatting to one METASPR_ITEM per line, for better readability)
* Add #define for S_PAL to gb.h, nes.h, msx.h and sms.h
* Remove "TODO:" comments from gbdk-lib/libc/targets/mos6502/nes/metasprites.s