### PR TITLE
Rename HARDWARE_SPRITE_CAN_FLIP_* defines to align with new flipx/flipy naming

### DIFF
--- a/gbdk-lib/examples/cross-platform/metasprites/src/metasprites.c
+++ b/gbdk-lib/examples/cross-platform/metasprites/src/metasprites.c
@@ -126,13 +126,13 @@ void main(void) {
             hide_metasprite(sprite_metasprites[idx], SPR_NUM_START);
         else
             switch (rot) {
-#if HARDWARE_SPRITE_CAN_FLIP_V
+#if HARDWARE_SPRITE_CAN_FLIP_Y
                 case 1: hiwater = move_metasprite_flipy(sprite_metasprites[idx], TILE_NUM_START, 0, SPR_NUM_START, (PosX >> 4), (PosY >> 4)); break;
 #endif
-#if HARDWARE_SPRITE_CAN_FLIP_H && HARDWARE_SPRITE_CAN_FLIP_V
+#if HARDWARE_SPRITE_CAN_FLIP_X && HARDWARE_SPRITE_CAN_FLIP_Y
                 case 2: hiwater = move_metasprite_flipxy(sprite_metasprites[idx], TILE_NUM_START, 0, SPR_NUM_START, (PosX >> 4), (PosY >> 4)); break;
 #endif
-#if HARDWARE_SPRITE_CAN_FLIP_H
+#if HARDWARE_SPRITE_CAN_FLIP_X
                 case 3: hiwater = move_metasprite_flipx(sprite_metasprites[idx], TILE_NUM_START, 0, SPR_NUM_START, (PosX >> 4), (PosY >> 4)); break;
 #endif
                 default: hiwater = move_metasprite_ex(sprite_metasprites[idx], TILE_NUM_START, 0, SPR_NUM_START, (PosX >> 4), (PosY >> 4)); break;

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -1584,13 +1584,13 @@ __REG _shadow_OAM_base;
 */
 #define MAX_HARDWARE_SPRITES 40
 
-/** True if sprite hardware can flip sprites horizontally
+/** True if sprite hardware can flip sprites by X
 */
-#define HARDWARE_SPRITE_CAN_FLIP_H 1
+#define HARDWARE_SPRITE_CAN_FLIP_X 1
 
-/** True if sprite hardware can flip sprites vertically
+/** True if sprite hardware can flip sprites by Y
 */
-#define HARDWARE_SPRITE_CAN_FLIP_V 1
+#define HARDWARE_SPRITE_CAN_FLIP_Y 1
 
 /** Enable OAM DMA copy each VBlank and set it to transfer any 256-byte aligned array
 */

--- a/gbdk-lib/include/msx/msx.h
+++ b/gbdk-lib/include/msx/msx.h
@@ -635,13 +635,13 @@ extern volatile uint8_t _shadow_OAM_OFF;
 */
 #define MAX_HARDWARE_SPRITES 32
 
-/** True if sprite hardware can flip sprites horizontally
+/** True if sprite hardware can flip sprites by X
 */
-#define HARDWARE_SPRITE_CAN_FLIP_H 0
+#define HARDWARE_SPRITE_CAN_FLIP_X 0
 
-/** True if sprite hardware can flip sprites vertically
+/** True if sprite hardware can flip sprites by Y
 */
-#define HARDWARE_SPRITE_CAN_FLIP_V 0
+#define HARDWARE_SPRITE_CAN_FLIP_Y 0
 
 /** Sets address of 256-byte aligned array of shadow OAM to be transferred on each VBlank
 */

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -708,13 +708,13 @@ extern uint8_t _shadow_OAM_base;
 */
 #define MAX_HARDWARE_SPRITES 64
 
-/** True if sprite hardware can flip sprites horizontally
+/** True if sprite hardware can flip sprites by X
 */
-#define HARDWARE_SPRITE_CAN_FLIP_H 1
+#define HARDWARE_SPRITE_CAN_FLIP_X 1
 
-/** True if sprite hardware can flip sprites vertically
+/** True if sprite hardware can flip sprites by Y
 */
-#define HARDWARE_SPRITE_CAN_FLIP_V 1
+#define HARDWARE_SPRITE_CAN_FLIP_Y 1
 
 /** Enable OAM DMA copy each VBlank and set it to transfer any 256-byte aligned array
 */

--- a/gbdk-lib/include/sms/sms.h
+++ b/gbdk-lib/include/sms/sms.h
@@ -666,13 +666,13 @@ extern volatile uint8_t _shadow_OAM_OFF;
 */
 #define MAX_HARDWARE_SPRITES 64
 
-/** True if sprite hardware can flip sprites horizontally
+/** True if sprite hardware can flip sprites by X
 */
-#define HARDWARE_SPRITE_CAN_FLIP_H 0
+#define HARDWARE_SPRITE_CAN_FLIP_X 0
 
-/** True if sprite hardware can flip sprites vertically
+/** True if sprite hardware can flip sprites by Y
 */
-#define HARDWARE_SPRITE_CAN_FLIP_V 0
+#define HARDWARE_SPRITE_CAN_FLIP_Y 0
 
 /** Sets address of 256-byte aligned array of shadow OAM to be transferred on each VBlank
 */


### PR DESCRIPTION
* HARDWARE_SPRITE_CAN_FLIP_H -> HARDWARE_SPRITE_CAN_FLIP_X
* HARDWARE_SPRITE_CAN_FLIP_V -> HARDWARE_SPRITE_CAN_FLIP_Y