### PR TITLE
Add sub-palette switching to cross-platform/metasprites example (for GBC and NES)

### DIFF
--- a/gbdk-lib/examples/cross-platform/metasprites/Makefile
+++ b/gbdk-lib/examples/cross-platform/metasprites/Makefile
@@ -7,7 +7,7 @@ PNG2ASSET = $(GBDK_HOME)/bin/png2asset
 # Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
 # They can also be built/cleaned individually: "make gg" and "make gg-clean"
 # Possible are: gb gbc pocket megaduck sms gg
-TARGETS=gb pocket megaduck sms gg nes
+TARGETS=gb gbc pocket megaduck sms gg nes
 
 # Configure platform specific LCC flags here:
 LCCFLAGS_gb      = -Wl-yt0x1B -autobank # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)


### PR DESCRIPTION
* Extend rot variable to switch between palettes after every X/Y/XY flip rotation, and apply to move_metasprite_* calls
* Setup pink, cyan and green palettes for GBC/NES to visualize switching
* Enable gbc as target in Makefile