### PR TITLE
Cross-platform metasprite flipping support:

### DIFF
--- a/gbdk-lib/examples/cross-platform/metasprites/Makefile
+++ b/gbdk-lib/examples/cross-platform/metasprites/Makefile
@@ -58,7 +58,7 @@ all: $(TARGETS)
 # -c ...   : Set C output file
 # Convert metasprite .pngs in res/ -> .c files in obj/<platform ext>/src/
 $(RESOBJSRC)/%.c:	$(RESDIR)/%.png
-	$(PNG2ASSET) $< -sh 48 -spr8x16 -noflip -c $@
+	$(PNG2ASSET) $< -sh 48 -spr8x8 -noflip -c $@
 
 # Compile the Metasprite pngs that were converted to .c files
 # .c files in obj/<platform ext>/src/ -> .o files in obj/

--- a/gbdk-lib/examples/cross-platform/metasprites/src/metasprites.c
+++ b/gbdk-lib/examples/cross-platform/metasprites/src/metasprites.c
@@ -1,3 +1,30 @@
+//
+// Cross-platform metasprites example.
+//
+// This examples demonstrates the following features in GBDK's metasprite support.
+//
+// * Drawing a metasprite with optional X/Y flipping using hardware flipping
+// * Drawing a metasprite with optional X/Y flipping using duplicated tiles
+// * Drawing a metasprite with different sub-palettes
+//
+// The flipping of tiles is handled by setting X/Y flip bits on those targets that
+// support it in hardware.
+//
+// For targets that don't have hardware support for flipping, a fallback is provided by
+// uploading duplicate tiles flipped in X and Y, and using the base_tile parameter of 
+// move_metasprite_* to draw the flipped tiles.
+// 
+// For targets that support sprite sub-palettes (GBC and NES), the base_props parameter
+// of move_metasprite_* is used to switch between 4 different sub-palettes.
+// Note that SMS and GG do NOT support sub-palettes for sprites, and this example
+// will display the same colors when built for these targets.
+//
+// Joypad buttons:
+// 
+// cursor -> Moves metasprite position in X/Y
+// A      -> Rotates the metasprite through X/Y flip states, and then through sub-palettes
+// B      -> Animates the metasprite
+
 #include <stdint.h>
 
 #include <gbdk/platform.h>
@@ -30,6 +57,56 @@ uint8_t PosF;
 uint8_t hide, jitter;
 uint8_t idx, rot;
 
+unsigned char flipped_data[16];
+
+size_t num_tiles;
+
+// Table for fast reversing of bits in a byte - used for flipping in X
+UBYTE reverse_bits[256] = {
+    0x00,0x80,0x40,0xC0,0x20,0xA0,0x60,0xE0,0x10,0x90,0x50,0xD0,0x30,0xB0,0x70,0xF0,
+    0x08,0x88,0x48,0xC8,0x28,0xA8,0x68,0xE8,0x18,0x98,0x58,0xD8,0x38,0xB8,0x78,0xF8,
+    0x04,0x84,0x44,0xC4,0x24,0xA4,0x64,0xE4,0x14,0x94,0x54,0xD4,0x34,0xB4,0x74,0xF4,
+    0x0C,0x8C,0x4C,0xCC,0x2C,0xAC,0x6C,0xEC,0x1C,0x9C,0x5C,0xDC,0x3C,0xBC,0x7C,0xFC,
+    0x02,0x82,0x42,0xC2,0x22,0xA2,0x62,0xE2,0x12,0x92,0x52,0xD2,0x32,0xB2,0x72,0xF2,
+    0x0A,0x8A,0x4A,0xCA,0x2A,0xAA,0x6A,0xEA,0x1A,0x9A,0x5A,0xDA,0x3A,0xBA,0x7A,0xFA,
+    0x06,0x86,0x46,0xC6,0x26,0xA6,0x66,0xE6,0x16,0x96,0x56,0xD6,0x36,0xB6,0x76,0xF6,
+    0x0E,0x8E,0x4E,0xCE,0x2E,0xAE,0x6E,0xEE,0x1E,0x9E,0x5E,0xDE,0x3E,0xBE,0x7E,0xFE,
+    0x01,0x81,0x41,0xC1,0x21,0xA1,0x61,0xE1,0x11,0x91,0x51,0xD1,0x31,0xB1,0x71,0xF1,
+    0x09,0x89,0x49,0xC9,0x29,0xA9,0x69,0xE9,0x19,0x99,0x59,0xD9,0x39,0xB9,0x79,0xF9,
+    0x05,0x85,0x45,0xC5,0x25,0xA5,0x65,0xE5,0x15,0x95,0x55,0xD5,0x35,0xB5,0x75,0xF5,
+    0x0D,0x8D,0x4D,0xCD,0x2D,0xAD,0x6D,0xED,0x1D,0x9D,0x5D,0xDD,0x3D,0xBD,0x7D,0xFD,
+    0x03,0x83,0x43,0xC3,0x23,0xA3,0x63,0xE3,0x13,0x93,0x53,0xD3,0x33,0xB3,0x73,0xF3,
+    0x0B,0x8B,0x4B,0xCB,0x2B,0xAB,0x6B,0xEB,0x1B,0x9B,0x5B,0xDB,0x3B,0xBB,0x7B,0xFB,
+    0x07,0x87,0x47,0xC7,0x27,0xA7,0x67,0xE7,0x17,0x97,0x57,0xD7,0x37,0xB7,0x77,0xF7,
+    0x0F,0x8F,0x4F,0xCF,0x2F,0xAF,0x6F,0xEF,0x1F,0x9F,0x5F,0xDF,0x3F,0xBF,0x7F,0xFF
+};
+
+// Helper function to flip tile
+void set_tile(UBYTE tile_idx, UBYTE* data, UBYTE flip_x, UBYTE flip_y)
+{
+    size_t i;
+    for(i = 0; i < 8; i++)
+    {
+        size_t y = flip_y ? (7-i) : i; 
+        flipped_data[2*i] = flip_x ? reverse_bits[data[2*y]] : data[2*y];
+        flipped_data[2*i+1] = flip_x ? reverse_bits[data[2*y+1]] : data[2*y+1];
+    }
+    set_sprite_data(tile_idx, 1, flipped_data);
+}
+
+uint8_t get_tile_offset(uint8_t flipx, uint8_t flipy)
+{
+    uint8_t offset = 0;
+#if !HARDWARE_SPRITE_CAN_FLIP_Y
+    offset += flipy ? num_tiles : 0;
+#endif
+#if !HARDWARE_SPRITE_CAN_FLIP_X
+    offset <<= 1;
+    offset += flipx ? num_tiles : 0;
+#endif
+    return offset;
+}
+
 const palette_color_t gray_pal[4] = {   RGB8(255,255,255),
                                         RGB8(170,170,170),
                                         RGB8(85,85,85),
@@ -49,6 +126,7 @@ const palette_color_t green_pal[4] = {  RGB8(255,255,255),
 
 // main funxction
 void main(void) {
+    size_t i;
     DISPLAY_OFF;
 
 #if defined(GAMEBOY)
@@ -69,8 +147,21 @@ void main(void) {
     // set tile data for background
     set_bkg_data(0, 1, pattern);
 
-    // Load metasprite tile data into VRAM
-    set_sprite_data(TILE_NUM_START, sizeof(sprite_tiles) >> 4, sprite_tiles);
+    // Load metasprite tile data into VRAM, one tile at a time
+    num_tiles = sizeof(sprite_tiles) >> 4;
+    for(i = 0; i < num_tiles; i++)
+    {
+        set_tile(i + get_tile_offset(0, 0), sprite_tiles + (i << 4), 0, 0);
+#if !HARDWARE_SPRITE_CAN_FLIP_X
+        set_tile(i + get_tile_offset(1, 0), sprite_tiles + (i << 4), 1, 0);
+#endif
+#if !HARDWARE_SPRITE_CAN_FLIP_Y
+        set_tile(i + get_tile_offset(0, 1), sprite_tiles + (i << 4), 0, 1);
+#endif
+#if !HARDWARE_SPRITE_CAN_FLIP_X && !HARDWARE_SPRITE_CAN_FLIP_Y
+        set_tile(i + get_tile_offset(1, 1), sprite_tiles + (i << 4), 1, 1);
+#endif
+    }
 
     // show bkg and sprites
     SHOW_BKG; SHOW_SPRITES;
@@ -118,21 +209,14 @@ void main(void) {
             PosF |= ACC_X;
         }
 
-
-        // Press A button to show/hide metasprite
-        if ((joypads.joy0 & J_A) && (!jitter)) {
-            hide = (!hide);
-            jitter = 20;
-        }
-
         // Press B button to cycle through metasprite animations
-        if ((joypads.joy0 & J_B) && (!jitter) && (!hide)) {
+        if ((joypads.joy0 & J_B) && (!jitter)) {
             idx++; if (idx >= (sizeof(sprite_metasprites) >> 1)) idx = 0;
             jitter = 10;
         }
 
-        // Press SELECT button to cycle metasprite through Normal/Flip-Y/Flip-XY/Flip-X
-        if ((joypads.joy0 & J_SELECT) && (!jitter) && (!hide)) {
+        // Press A button to cycle metasprite through Normal/Flip-Y/Flip-XY/Flip-X and sub-pals
+        if ((joypads.joy0 & J_A) && (!jitter)) {
             rot++; rot &= 0xF;
             jitter = 20;
         }
@@ -157,16 +241,38 @@ void main(void) {
         {
             uint8_t subpal = rot >> 2;
             switch (rot & 0x3) {
-#if HARDWARE_SPRITE_CAN_FLIP_Y
-                case 1: hiwater = move_metasprite_flipy(sprite_metasprites[idx], TILE_NUM_START, subpal, SPR_NUM_START, (PosX >> 4), (PosY >> 4)); break;
-#endif
-#if HARDWARE_SPRITE_CAN_FLIP_X && HARDWARE_SPRITE_CAN_FLIP_Y
-                case 2: hiwater = move_metasprite_flipxy(sprite_metasprites[idx], TILE_NUM_START, subpal, SPR_NUM_START, (PosX >> 4), (PosY >> 4)); break;
-#endif
-#if HARDWARE_SPRITE_CAN_FLIP_X
-                case 3: hiwater = move_metasprite_flipx(sprite_metasprites[idx], TILE_NUM_START, subpal, SPR_NUM_START, (PosX >> 4), (PosY >> 4)); break;
-#endif
-                default: hiwater = move_metasprite_ex(sprite_metasprites[idx], TILE_NUM_START, subpal, SPR_NUM_START, (PosX >> 4), (PosY >> 4)); break;
+                case 1:
+                    hiwater = move_metasprite_flipy(    sprite_metasprites[idx],
+                                                        TILE_NUM_START + get_tile_offset(0, 1),
+                                                        subpal,
+                                                        SPR_NUM_START,
+                                                        (PosX >> 4),
+                                                        (PosY >> 4));
+                    break;
+                case 2:
+                    hiwater = move_metasprite_flipxy(   sprite_metasprites[idx],
+                                                        TILE_NUM_START + get_tile_offset(1, 1),
+                                                        subpal,
+                                                        SPR_NUM_START,
+                                                        (PosX >> 4),
+                                                        (PosY >> 4));
+                    break;
+                case 3:
+                    hiwater = move_metasprite_flipx(sprite_metasprites[idx],
+                                                    TILE_NUM_START + get_tile_offset(1, 0),
+                                                    subpal,
+                                                    SPR_NUM_START,
+                                                    (PosX >> 4),
+                                                    (PosY >> 4));
+                    break;
+                default:
+                    hiwater = move_metasprite_ex(   sprite_metasprites[idx],
+                                                    TILE_NUM_START + get_tile_offset(0, 0),
+                                                    subpal,
+                                                    SPR_NUM_START,
+                                                    (PosX >> 4),
+                                                    (PosY >> 4));
+                    break;
             };
         }
 

--- a/gbdk-lib/include/sms/metasprites.h
+++ b/gbdk-lib/include/sms/metasprites.h
@@ -65,6 +65,9 @@ extern uint8_t __render_shadow_OAM;
 
 
 static uint8_t __move_metasprite(uint8_t id, uint8_t x, uint8_t y) Z88DK_CALLEE PRESERVES_REGS(iyh, iyl);
+static uint8_t __move_metasprite_flipx(uint8_t id, uint8_t x, uint8_t y) Z88DK_CALLEE PRESERVES_REGS(iyh, iyl);
+static uint8_t __move_metasprite_flipy(uint8_t id, uint8_t x, uint8_t y) Z88DK_CALLEE PRESERVES_REGS(iyh, iyl);
+static uint8_t __move_metasprite_flipxy(uint8_t id, uint8_t x, uint8_t y) Z88DK_CALLEE PRESERVES_REGS(iyh, iyl);
 static void __hide_metasprite(uint8_t id) Z88DK_FASTCALL PRESERVES_REGS(iyh, iyl);
 
 /**
@@ -106,6 +109,90 @@ inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_til
     __current_metasprite = metasprite; 
     __current_base_tile = base_tile;
     return __move_metasprite(base_sprite, x, y); 
+}
+
+/** Moves metasprite to the absolute position x and y, __flipped by X__
+
+    @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
+    @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_sprite  Number of the first hardware sprite to be used by the metasprite
+    @param x            Absolute x coordinate of the sprite
+    @param y            Absolute y coordinate of the sprite
+
+    Same as @ref move_metasprite(), but with the metasprite flipped by X.
+
+    Sets:
+    \li __current_metasprite = metasprite;
+    \li __current_base_tile = base_tile;
+
+    Note: Overwrites OAM sprite properties (such as palette), see
+          @ref metasprite_and_sprite_properties "Metasprites and sprite properties".
+
+    @return Number of hardware sprites used to draw this metasprite
+
+    @see move_metasprite()
+*/
+inline uint8_t move_metasprite_flipx(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, uint8_t x, uint8_t y) {
+    base_prop;
+    __current_metasprite = metasprite;
+    __current_base_tile = base_tile;
+    return __move_metasprite_flipx(base_sprite, x - 8, y);
+}
+
+/** Moves metasprite to the absolute position x and y, __flipped by Y__
+
+    @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
+    @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_sprite  Number of the first hardware sprite to be used by the metasprite
+    @param x            Absolute x coordinate of the sprite
+    @param y            Absolute y coordinate of the sprite
+
+    Same as @ref move_metasprite(), but with the metasprite flipped by Y.
+
+    Sets:
+    \li __current_metasprite = metasprite;
+    \li __current_base_tile = base_tile;
+
+    Note: Overwrites OAM sprite properties (such as palette), see
+          @ref metasprite_and_sprite_properties "Metasprites and sprite properties".
+
+    @return Number of hardware sprites used to draw this metasprite
+
+    @see move_metasprite()
+*/
+inline uint8_t move_metasprite_flipy(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, uint8_t x, uint8_t y) {
+    base_prop;
+    __current_metasprite = metasprite;
+    __current_base_tile = base_tile;
+    return __move_metasprite_flipy(base_sprite, x, y - ((__READ_VDP_REG(VDP_R1) & R1_SPR_8X16) ? 16 : 8) );
+}
+
+/** Moves metasprite to the absolute position x and y, __flipped by X and Y__
+
+    @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
+    @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_sprite  Number of the first hardware sprite to be used by the metasprite
+    @param x            Absolute x coordinate of the sprite
+    @param y            Absolute y coordinate of the sprite
+
+    Same as @ref move_metasprite(), but with the metasprite flipped by X and Y.
+
+    Sets:
+    \li __current_metasprite = metasprite;
+    \li __current_base_tile = base_tile;
+
+    Note: Overwrites OAM sprite properties (such as palette), see
+          @ref metasprite_and_sprite_properties "Metasprites and sprite properties".
+
+    @return Number of hardware sprites used to draw this metasprite
+
+    @see move_metasprite()
+*/
+inline uint8_t move_metasprite_flipxy(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, uint8_t x, uint8_t y) {
+    base_prop;
+    __current_metasprite = metasprite;
+    __current_base_tile = base_tile;
+    return __move_metasprite_flipxy(base_sprite, x - 8, y - ((__READ_VDP_REG(VDP_R1) & R1_SPR_8X16) ? 16 : 8));
 }
 
 /** Hides a metasprite from the screen

--- a/gbdk-lib/libc/targets/z80/sms_metasprites.s
+++ b/gbdk-lib/libc/targets/z80/sms_metasprites.s
@@ -21,7 +21,7 @@ ___render_shadow_OAM::
 
 ; uint8_t __move_metasprite(uint8_t id, uint8_t x, uint8_t y) __z88dk_callee __preserves_regs(iyh,iyl);
 
-___move_metasprite::
+.macro MOVE_METASPRITE_BODY neg_dx neg_dy
         ld      hl, #4
         add     hl, sp
 
@@ -40,6 +40,9 @@ ___move_metasprite::
         inc     hl
         cp      #0x80
         jp      z, 2$
+.ifne neg_dy
+        neg                     ; apply flipy (or no-op)
+.endif
         add     b        
         ld      b, a
         cp      #0xD0
@@ -57,6 +60,9 @@ ___move_metasprite::
 
         ld      a, (hl)         ; dx
         inc     hl
+.ifne neg_dx
+        neg                     ; apply flipx (or no-op)
+.endif
         add     c
         ld      c, a
         ld      (de), a
@@ -80,3 +86,16 @@ ___move_metasprite::
         sub     c
         ld      l, a
         ret
+.endm
+
+___move_metasprite::
+    MOVE_METASPRITE_BODY 0,0
+
+___move_metasprite_flipx::
+    MOVE_METASPRITE_BODY 1,0
+
+___move_metasprite_flipy::
+    MOVE_METASPRITE_BODY 0,1
+
+___move_metasprite_flipxy::
+    MOVE_METASPRITE_BODY 1,1


### PR DESCRIPTION
* Change sms_metasprites to have 4 permutations for flipping combinations, using a generic macro for function bodies
* Change examples/cross-platform/metasprites to duplicate uploaded tiles by X and Y depending on HARDWARE_SPRITE_CAN_FLIP_X/Y defines
* Change examples/cross-platform/metasprites to use 8x8 sprites, to make all duplicated tiles fit tile memory on sms/gg
* Remove hide / show metasprite functionality in examples/cross-platform/metasprites
* Move rotation to A button, to make compatible with 2-button SMS joypad