### PR TITLE
Eliminate code duplication in sms metasprites code:

### DIFF
--- a/gbdk-lib/libc/targets/z80/gg/Makefile
+++ b/gbdk-lib/libc/targets/z80/gg/Makefile
@@ -16,7 +16,8 @@ ASSRC =	set_interrupts.s \
 	coords_to_address.s \
 	set_tile.s \
 	sms_fill_rect.s sms_fill_rect_xy.s sms_fill_rect_compat.s sms_fill_rect_xy_compat.s \
-	sms_metasprites.s sms_metasprites_flip.s sms_metasprites_hide.s sms_metasprites_hide_spr.s \
+	sms_metasprites.s sms_metasprites_flipx.s sms_metasprites_flipy.s sms_metasprites_flipxy.s \
+	sms_metasprites_hide.s sms_metasprites_hide_spr.s \
 	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	font.s color.s \
 	putchar.s \

--- a/gbdk-lib/libc/targets/z80/sms/Makefile
+++ b/gbdk-lib/libc/targets/z80/sms/Makefile
@@ -16,7 +16,8 @@ ASSRC =	set_interrupts.s \
 	coords_to_address.s \
 	set_tile.s \
 	sms_fill_rect.s sms_fill_rect_xy.s sms_fill_rect_compat.s sms_fill_rect_xy_compat.s \
-	sms_metasprites.s sms_metasprites_flip.s sms_metasprites_hide.s sms_metasprites_hide_spr.s \
+	sms_metasprites.s sms_metasprites_flipx.s sms_metasprites_flipy.s sms_metasprites_flipxy.s \
+	sms_metasprites_hide.s sms_metasprites_hide_spr.s \
 	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	font.s color.s \
 	putchar.s \

--- a/gbdk-lib/libc/targets/z80/sms_metasprites.s
+++ b/gbdk-lib/libc/targets/z80/sms_metasprites.s
@@ -1,4 +1,5 @@
         .include    "global.s"
+        .include    "sms_metasprites_macro.s"
 
         .title  "Metasprites"
         .module Metasprites
@@ -22,61 +23,4 @@ ___render_shadow_OAM::
 ; uint8_t __move_metasprite(uint8_t id, uint8_t x, uint8_t y) __z88dk_callee __preserves_regs(iyh,iyl);
 
 ___move_metasprite::
-        ld      hl, #4
-        add     hl, sp
-
-        ld      b, (hl)
-        dec     hl
-        ld      c, (hl)
-        dec     hl
-        ld      e, (hl)
-
-        ld      hl, (___current_metasprite)
-
-        ld      a, (___render_shadow_OAM)
-        ld      d, a
-1$:
-        ld      a, (hl)         ; dy
-        inc     hl
-        cp      #0x80
-        jp      z, 2$
-        add     b        
-        ld      b, a
-        cp      #0xD0
-        jp      nz, 3$
-        ld      a, #0xC0
-3$:
-        ld      (de), a
-
-        push    de
-
-        ld      a, e
-        add     a
-        add     #0x40
-        ld      e, a
-
-        ld      a, (hl)         ; dx
-        inc     hl
-        add     c
-        ld      c, a
-        ld      (de), a
-        inc     e
-
-        ld      a, (___current_base_tile)
-        add     (hl)            ; tile
-        inc     hl
-        ld      (de), a
-
-        pop     de
-        inc     e
-
-        jp      1$
-2$:
-        pop     hl
-        pop     bc
-        inc     sp
-        push    hl
-        ld      a, e
-        sub     c
-        ld      l, a
-        ret
+    MOVE_METASPRITE_BODY 0,0

--- a/gbdk-lib/libc/targets/z80/sms_metasprites_flipx.s
+++ b/gbdk-lib/libc/targets/z80/sms_metasprites_flipx.s
@@ -1,0 +1,14 @@
+        .include    "global.s"
+        .include    "sms_metasprites_macro.s"
+
+        .title  "Metasprites"
+        .module Metasprites
+
+        .area   _DATA
+
+        .globl ___current_metasprite, ___current_base_tile, ___render_shadow_OAM
+
+        .area   _CODE
+
+___move_metasprite_flipx::
+    MOVE_METASPRITE_BODY 1,0

--- a/gbdk-lib/libc/targets/z80/sms_metasprites_flipxy.s
+++ b/gbdk-lib/libc/targets/z80/sms_metasprites_flipxy.s
@@ -1,0 +1,14 @@
+        .include    "global.s"
+        .include    "sms_metasprites_macro.s"
+
+        .title  "Metasprites"
+        .module Metasprites
+
+        .area   _DATA
+
+        .globl ___current_metasprite, ___current_base_tile, ___render_shadow_OAM
+
+        .area   _CODE
+
+___move_metasprite_flipxy::
+    MOVE_METASPRITE_BODY 1,1

--- a/gbdk-lib/libc/targets/z80/sms_metasprites_flipy.s
+++ b/gbdk-lib/libc/targets/z80/sms_metasprites_flipy.s
@@ -1,0 +1,14 @@
+        .include    "global.s"
+        .include    "sms_metasprites_macro.s"
+
+        .title  "Metasprites"
+        .module Metasprites
+
+        .area   _DATA
+
+        .globl ___current_metasprite, ___current_base_tile, ___render_shadow_OAM
+
+        .area   _CODE
+
+___move_metasprite_flipy::
+    MOVE_METASPRITE_BODY 0,1

--- a/gbdk-lib/libc/targets/z80/sms_metasprites_macro.s
+++ b/gbdk-lib/libc/targets/z80/sms_metasprites_macro.s
@@ -1,14 +1,7 @@
-        .include    "global.s"
-
-        .title  "Metasprites"
-        .module Metasprites
-
-        .area   _DATA
-
-        .globl ___current_metasprite, ___current_base_tile, ___render_shadow_OAM
-
-        .area   _CODE
-
+;
+; Helper macro to remove code duplication in sms_metasprites[_flipx|_flipy_flipxy]
+; While still allowing them to be linked separately.
+;
 .macro MOVE_METASPRITE_BODY neg_dx neg_dy
         ld      hl, #4
         add     hl, sp
@@ -75,12 +68,3 @@
         ld      l, a
         ret
 .endm
-
-___move_metasprite_flipx::
-    MOVE_METASPRITE_BODY 1,0
-
-___move_metasprite_flipy::
-    MOVE_METASPRITE_BODY 0,1
-
-___move_metasprite_flipxy::
-    MOVE_METASPRITE_BODY 1,1


### PR DESCRIPTION
* Put MOVE_METASPRITE_BODY into an include file sms_metasprites_macro.s
* Have each flip combination (noflip/flipx/flipy/flipxy) include and use the macro