### PR TITLE
NES: Refactor attributes to use 8x8 attribute coordinate system, to be more consistent with other platforms

### DIFF
--- a/gbdk-lib/examples/cross-platform/logo/src/main.c
+++ b/gbdk-lib/examples/cross-platform/logo/src/main.c
@@ -26,11 +26,11 @@ void main() {
         VBK_REG = VBK_TILES;
     }
 #elif defined(SYSTEM_NES)
-    // Make sure attribute coordinates are rounded to 2
-    set_bkg_attributes((((DEVICE_SCREEN_WIDTH - (GBDK_2020_logo_WIDTH >> 3)) >> 1) & 0xFE) >> 1, 
-                       (((DEVICE_SCREEN_HEIGHT - (GBDK_2020_logo_HEIGHT >> 3)) >> 1) & 0xFE) >> 1, 
-                       GBDK_2020_logo_MAP_ATTRIBUTES_WIDTH, 
-                       GBDK_2020_logo_MAP_ATTRIBUTES_HEIGHT, 
+    // Make sure tile coordinates are rounded to 2, to match attribute table
+    set_bkg_attributes(((DEVICE_SCREEN_WIDTH - (GBDK_2020_logo_WIDTH >> 3)) >> 1) & 0xFE,
+                       ((DEVICE_SCREEN_HEIGHT - (GBDK_2020_logo_HEIGHT >> 3)) >> 1) & 0xFE,
+                       GBDK_2020_logo_WIDTH >> 3, 
+                       GBDK_2020_logo_HEIGHT >> 3, 
                        GBDK_2020_logo_map_attributes);
 #endif
 #if defined(SYSTEM_NES)

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -487,7 +487,58 @@ void set_bkg_1bpp_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data
 void set_bkg_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *tiles) OLDCALL;
 #define set_tile_map set_bkg_tiles
 
-void set_bkg_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *attributes) OLDCALL;
+/** Sets a rectangular region of Background Tile Map Attributes.
+
+    @param x      X Start position in Background Map tile coordinates. Range 0 - 15
+    @param y      Y Start position in Background Map tile coordinates. Range 0 - 14
+    @param w      Width of area to set in tiles. Range 1 - 16
+    @param h      Height of area to set in tiles. Range 1 - 15
+    @param tiles  Pointer to source tile map data
+
+    Entries are copied from map at __tiles__ to the Background Tile Map starting at
+    __x__, __y__ writing across for __w__ tiles and down for __h__ tiles.
+
+    NES 16x16 Tile Attributes are tightly packed into 4 attributes per byte,
+    with each 16x16 area of a 32x32 pixel block using the bits as follows:
+    D1-D0: Top-left 16x16 pixels
+    D3-D2: Top-right 16x16 pixels
+    D5-D4: Bottom-left 16x16 pixels
+    D7-D6: Bottom-right 16x16 pixels
+    
+    https://www.nesdev.org/wiki/PPU_attribute_tables
+
+    @see SHOW_BKG
+    @see set_bkg_data, set_bkg_submap_attributes, set_win_tiles, set_tiles
+*/
+void set_bkg_attributes_nes16x16(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *attributes) OLDCALL;
+
+/** Sets a rectangular region of Background Tile Map Attributes.
+
+    Entries are copied from map at __tiles__ to the Background Tile Map starting at
+    __x__, __y__ writing across for __w__ tiles and down for __h__ tiles.
+
+    Use @ref set_bkg_submap_attributes() instead when:
+    \li Source map is wider than 32 tiles.
+    \li Writing a width that does not match the source map width __and__ more
+    than one row high at a time.
+
+    One byte per source tile map entry.
+
+    Writes that exceed coordinate 31 on the x or y axis will wrap around to
+    the Left and Top edges.
+
+    Please note that this is just a wrapper function for set_bkg_attributes_nes16x16
+    and divides the coordinates and dimensions by 2 to achieve this.
+    It is intended to make code more portable by using the same coordinate system
+    that systems with the much more common 8x8 attribute resolution would use.
+
+    @see SHOW_BKG
+    @see set_bkg_data, set_bkg_submap_attributes, set_win_tiles, set_tiles
+*/
+inline void set_bkg_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *attributes)
+{
+    set_bkg_attributes_nes16x16(x >> 1, y >> 1, (w + 1) >> 1, (h + 1) >> 1, attributes);
+}
 
 extern uint8_t _map_tile_offset;
 

--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -10,7 +10,8 @@ CSRC = crlf.c
 ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	font.s font_color.s set_data.s set_1bit_data.s color.s mode.s \
 	metasprites.s metasprites_hide.s metasprites_hide_spr.s \
-	set_bk_ts.s set_tile_submap.s fill_rect_bk.s set_bk_attributes.s \
+	set_bk_ts.s set_tile_submap.s fill_rect_bk.s \
+	set_bk_attributes.s flush_attributes.s \
 	nes_palettes.s \
 	pad.s pad_ex.s \
 	rle_decompress.s \

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -89,6 +89,7 @@ __crt0_textTemp:                        .ds 1
 _bkg_scroll_x::                         .ds 1
 _bkg_scroll_y::                         .ds 1
 _attribute_row_dirty::                  .ds 1
+_attribute_column_dirty::               .ds 1
 .crt0_textStringBegin:                  .ds 1
 .crt0_forced_blanking::                 .ds 1
 

--- a/gbdk-lib/libc/targets/mos6502/nes/flush_attributes.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/flush_attributes.s
@@ -1,0 +1,110 @@
+    .include    "global.s"
+
+    .area   _HOME
+    
+_flush_shadow_attributes::
+    jsr _flush_shadow_attributes_rows
+    jmp _flush_shadow_attributes_columns
+
+;
+; Writes every row of attributes from _shadow_attributes that's been marked
+; as dirty in the _attribute_row_dirty byte to PPU memory.
+;
+_flush_shadow_attributes_rows:
+    lda #<PPU_AT0
+    sta *.tmp
+    lda #>PPU_AT0
+    sta *.tmp+1
+    ldy #0
+_flush_shadow_attributes_row_loop:
+    lsr *_attribute_row_dirty
+    bcc 1$
+    jmp _flush_shadow_attributes_update_row
+1$:
+    beq _flush_shadow_attributes_end
+_flush_shadow_attributes_next_row:
+    ; Y += 8
+    tya
+    clc
+    adc #8
+    tay
+    ; .tmp += 8
+    lda *.tmp
+    adc #8
+    sta *.tmp
+    jmp _flush_shadow_attributes_row_loop
+_flush_shadow_attributes_end:
+    rts
+
+;
+; Flushes all dirty rows of _attribute_shadow by writing them to PPU memory
+;
+_flush_shadow_attributes_update_row:
+    ; Update all 8 bytes of row for now, as each row in _attribute_row_dirty only stores 1 bit
+    ; TODO: Could store 8 bytes and update range, at expense of 7 more bytes.
+    lda *.tmp+1
+    tax
+    lda *.tmp
+    jsr .ppu_stripe_begin_horizontal
+    ; Write 8 bytes
+    i = 0
+    .rept 8
+    lda _attribute_shadow+i,y
+    jsr .ppu_stripe_write_byte
+    i = i + 1
+    .endm
+    jsr .ppu_stripe_end
+    jmp _flush_shadow_attributes_next_row
+
+;
+; Writes every column of attributes from _shadow_attributes that's been marked
+; as dirty in the _attribute_column_dirty byte to PPU memory.
+;
+;
+_flush_shadow_attributes_columns:
+    lda #<PPU_AT0
+    sta *.tmp
+    lda #>PPU_AT0
+    sta *.tmp+1
+    ldy #0
+_flush_shadow_attributes_columns_loop:
+    lsr *_attribute_column_dirty
+    bcc 1$
+    jmp _flush_shadow_attributes_update_column
+1$:
+    beq _flush_shadow_attributes_columns_end
+_flush_shadow_attributes_columns_next_column:
+    ; Y += 1
+    iny
+    ; .tmp += 1
+    inc *.tmp
+    jmp _flush_shadow_attributes_columns_loop
+_flush_shadow_attributes_columns_end:
+    rts
+
+;
+; Flushes all dirty rows of _attribute_shadow by writing them to PPU memory
+;
+_flush_shadow_attributes_update_column:
+    ; Update all 8 bytes of column for now, as each column in _attribute_column_dirty only stores 1 bit
+    ; As PPU has no increment-by-8 feature, split writes into 4 separate stripes 2 bytes each
+    ; TODO: Could make a dedicated unrolled transfer routine in nmi handler that writes all 8 bytes as one stripe.
+    i = 0
+    .rept 4
+    lda *.tmp+1
+    tax
+    lda *.tmp
+    jsr .ppu_stripe_begin_vertical
+    lda _attribute_shadow+8*i,y
+    jsr .ppu_stripe_write_byte
+    lda _attribute_shadow+8*i+32,y
+    jsr .ppu_stripe_write_byte
+    jsr .ppu_stripe_end
+    ;
+    lda *.tmp
+    clc
+    adc #8
+    sta *.tmp
+    i = i + 1
+    .endm
+    jmp _flush_shadow_attributes_columns_next_column


### PR DESCRIPTION
* Move _flush_shadow_attributes subroutine to its own file flush_attributes.s
* Add bitfield _attribute_column_dirty, and add handling of dirtied columns to _flush_attributes
* Update cross-platform/logo/src/main.c to use 8x8 coordinate system for NES

png2asset:
* Fix bug in PackMapAttributes where height was always being set to width
* Refactor BuildPalettesAndAttributes palette search into its own function FindOrCreateSubPalette
* Change BuildPalettesAndAttributes to force subPalIndex to 0 instead of causing segfault when there's too many colors for an attribute region
* Add new function AlignMapAttributes to ensure map is properly aligned for set_bkg_submap
* Change #define MAP_ATTRIBUTES_WIDTH/HEIGHT to use new 8x8 coordinate system