### PR TITLE
GBC: Add cross-platform attribute setting functions

### DIFF
--- a/gbdk-lib/examples/cross-platform/logo/src/main.c
+++ b/gbdk-lib/examples/cross-platform/logo/src/main.c
@@ -2,9 +2,6 @@
 
 #include "GBDK_2020_logo.h"
 
-// TODO: Figure out why SMS/GG needs attributes enabled in png2asset, without actually using them...
-#define HAS_ATTRIBUTES (defined(GBDK_2020_logo_MAP_ATTRIBUTES_WIDTH) && !defined(SEGA))
-
 void main() {
     DISPLAY_OFF;
     fill_bkg_rect(0, 0, DEVICE_SCREEN_WIDTH, DEVICE_SCREEN_HEIGHT, 0);
@@ -18,13 +15,11 @@ void main() {
     set_bkg_palette(0, GBDK_2020_logo_PALETTE_COUNT, GBDK_2020_logo_palettes);
 #endif 
     set_native_tile_data(0, GBDK_2020_logo_TILE_COUNT, GBDK_2020_logo_tiles);
-#if HAS_ATTRIBUTES
     set_bkg_attributes((DEVICE_SCREEN_WIDTH - (GBDK_2020_logo_WIDTH >> 3)) >> 1, 
                        (DEVICE_SCREEN_HEIGHT - (GBDK_2020_logo_HEIGHT >> 3)) >> 1, 
                        GBDK_2020_logo_WIDTH >> 3, 
                        GBDK_2020_logo_HEIGHT >> 3, 
                        GBDK_2020_logo_map_attributes);
-#endif
     set_tile_map((DEVICE_SCREEN_WIDTH - (GBDK_2020_logo_WIDTH >> 3)) >> 1, 
                  (DEVICE_SCREEN_HEIGHT - (GBDK_2020_logo_HEIGHT >> 3)) >> 1, 
                  GBDK_2020_logo_WIDTH >> 3, 

--- a/gbdk-lib/examples/cross-platform/logo/src/main.c
+++ b/gbdk-lib/examples/cross-platform/logo/src/main.c
@@ -2,6 +2,9 @@
 
 #include "GBDK_2020_logo.h"
 
+// TODO: Figure out why SMS/GG needs attributes enabled in png2asset, without actually using them...
+#define HAS_ATTRIBUTES (defined(GBDK_2020_logo_MAP_ATTRIBUTES_WIDTH) && !defined(SEGA))
+
 void main() {
     DISPLAY_OFF;
     fill_bkg_rect(0, 0, DEVICE_SCREEN_WIDTH, DEVICE_SCREEN_HEIGHT, 0);
@@ -15,38 +18,18 @@ void main() {
     set_bkg_palette(0, GBDK_2020_logo_PALETTE_COUNT, GBDK_2020_logo_palettes);
 #endif 
     set_native_tile_data(0, GBDK_2020_logo_TILE_COUNT, GBDK_2020_logo_tiles);
-#if defined(SYSTEM_CGB)
-    if (_cpu == CGB_TYPE) {
-        VBK_REG = VBK_ATTRIBUTES;
-        set_tile_map((DEVICE_SCREEN_WIDTH - (GBDK_2020_logo_WIDTH >> 3)) >> 1, 
-                     (DEVICE_SCREEN_HEIGHT - (GBDK_2020_logo_HEIGHT >> 3)) >> 1, 
-                     GBDK_2020_logo_WIDTH >> 3, 
-                     GBDK_2020_logo_HEIGHT >> 3, 
-                     GBDK_2020_logo_map_attributes);
-        VBK_REG = VBK_TILES;
-    }
-#elif defined(SYSTEM_NES)
-    // Make sure tile coordinates are rounded to 2, to match attribute table
-    set_bkg_attributes(((DEVICE_SCREEN_WIDTH - (GBDK_2020_logo_WIDTH >> 3)) >> 1) & 0xFE,
-                       ((DEVICE_SCREEN_HEIGHT - (GBDK_2020_logo_HEIGHT >> 3)) >> 1) & 0xFE,
+#if HAS_ATTRIBUTES
+    set_bkg_attributes((DEVICE_SCREEN_WIDTH - (GBDK_2020_logo_WIDTH >> 3)) >> 1, 
+                       (DEVICE_SCREEN_HEIGHT - (GBDK_2020_logo_HEIGHT >> 3)) >> 1, 
                        GBDK_2020_logo_WIDTH >> 3, 
                        GBDK_2020_logo_HEIGHT >> 3, 
                        GBDK_2020_logo_map_attributes);
 #endif
-#if defined(SYSTEM_NES)
-    // Make sure tile coordinates are rounded to 2, to match attribute table
-    set_tile_map(((DEVICE_SCREEN_WIDTH - (GBDK_2020_logo_WIDTH >> 3)) >> 1) & 0xFE, 
-                 ((DEVICE_SCREEN_HEIGHT - (GBDK_2020_logo_HEIGHT >> 3)) >> 1) & 0xFE, 
-                 GBDK_2020_logo_WIDTH >> 3, 
-                 GBDK_2020_logo_HEIGHT >> 3, 
-                 GBDK_2020_logo_map);
-#else
     set_tile_map((DEVICE_SCREEN_WIDTH - (GBDK_2020_logo_WIDTH >> 3)) >> 1, 
                  (DEVICE_SCREEN_HEIGHT - (GBDK_2020_logo_HEIGHT >> 3)) >> 1, 
                  GBDK_2020_logo_WIDTH >> 3, 
                  GBDK_2020_logo_HEIGHT >> 3, 
                  GBDK_2020_logo_map);
-#endif
     SHOW_BKG;
     DISPLAY_ON;
 }

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -1082,6 +1082,60 @@ inline void set_bkg_based_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, cons
 }
 
 
+/** Sets a rectangular region of Background Tile Map Attributes.
+
+    @param x      X Start position in Background Map tile coordinates. Range 0 - 31
+    @param y      Y Start position in Background Map tile coordinates. Range 0 - 31
+    @param w      Width of area to set in tiles. Range 1 - 32
+    @param h      Height of area to set in tiles. Range 1 - 32
+    @param tiles  Pointer to source tile map data
+
+    Entries are copied from map at __tiles__ to the Background Tile Map starting at
+    __x__, __y__ writing across for __w__ tiles and down for __h__ tiles.
+
+    Use @ref set_bkg_submap_attributes() instead when:
+    \li Source map is wider than 32 tiles.
+    \li Writing a width that does not match the source map width __and__ more
+    than one row high at a time.
+
+    One byte per source tile map entry.
+
+    Writes that exceed coordinate 31 on the x or y axis will wrap around to
+    the Left and Top edges.
+
+    GBC Tile Attributes are defined as:
+    \li Bit 7 - Priority flag. When this is set, it puts the tile above the sprites
+              with colour 0 being transparent.
+              \n 0: Below sprites
+              \n 1: Above sprites
+              \n Note: @ref SHOW_BKG needs to be set for these priorities to take place.
+    \li Bit 6 - Vertical flip. Dictates which way up the tile is drawn vertically.
+              \n 0: Normal
+              \n 1: Flipped Vertically
+    \li Bit 5 - Horizontal flip. Dictates which way up the tile is drawn horizontally.
+              \n 0: Normal
+              \n 1: Flipped Horizontally
+    \li Bit 4 - Not used
+    \li Bit 3 - Character Bank specification. Dictates from which bank of
+              Background Tile Patterns the tile is taken.
+              \n 0: Bank 0
+              \n 1: Bank 1
+    \li Bit 2 - See bit 0.
+    \li Bit 1 - See bit 0.
+    \li Bit 0 - Bits 0-2 indicate which of the 7 BKG colour palettes the tile is
+              assigned.
+
+    @see SHOW_BKG
+    @see set_bkg_data, set_bkg_submap_attributes, set_win_tiles, set_tiles
+*/
+inline void set_bkg_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *tiles)
+{
+    VBK_REG = VBK_ATTRIBUTES;
+    set_bkg_tiles(x, y, w, h, tiles);
+    VBK_REG = VBK_TILES;
+}
+
+
 /** Sets a rectangular area of the Background Tile Map using a sub-region
     from a source tile map. Useful for scrolling implementations of maps
     larger than 32 x 32 tiles.
@@ -1156,6 +1210,59 @@ inline void set_bkg_based_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, con
     _submap_tile_offset = base_tile;
     set_bkg_submap(x, y, w, h, map, map_w);
     _submap_tile_offset = 0;
+}
+
+
+/** Sets a rectangular area of the Background Tile Map Attributes using a sub-region
+    from a source tile attribute map. Useful for scrolling implementations of maps
+    larger than 32 x 32 tiles.
+
+    @param x      X Start position in both the Source Tile Map and hardware Background Map tile coordinates. Range 0 - 255
+    @param y      Y Start position in both the Source Tile Map and hardware Background Map tile coordinates. Range 0 - 255
+    @param w      Width of area to set in tiles. Range 1 - 255
+    @param h      Height of area to set in tiles. Range 1 - 255
+    @param map    Pointer to source tile map data
+    @param map_w  Width of source tile map in tiles. Range 1 - 255
+
+    Entries are copied from __map__ to the Background Tile Map starting at
+    __x__, __y__ writing across for __w__ tiles and down for __h__ tiles,
+    using __map_w__ as the rowstride for the source tile map.
+
+    The __x__ and __y__ parameters are in Source Tile Map tile
+    coordinates. The location tiles will be written to on the
+    hardware Background Map is derived from those, but only uses
+    the lower 5 bits of each axis, for range of 0-31 (they are
+    bit-masked: `x & 0x1F` and `y & 0x1F`). As a result the two
+    coordinate systems are aligned together.
+
+    In order to transfer tile map data in a way where the
+    coordinate systems are not aligned, an offset from the
+    Source Tile Map pointer can be passed in:
+    `(map_ptr + x + (y * map_width))`.
+
+    For example, if you want the tile id at `1,2` from the source map to
+    show up at `0,0` on the hardware Background Map (instead of at `1,2`)
+    then modify the pointer address that is passed in:
+    `map_ptr + 1 + (2 * map_width)`
+
+    Use this instead of @ref set_bkg_tiles when the source map is wider than
+    32 tiles or when writing a width that does not match the source map width.
+
+    One byte per source tile map entry.
+
+    Writes that exceed coordinate 31 on the x or y axis will wrap around to
+    the Left and Top edges.
+
+    See @ref set_bkg_tiles for setting CGB attribute maps with @ref VBK_REG.
+
+    @see SHOW_BKG
+    @see set_bkg_data, set_bkg_attributes, set_win_submap, set_tiles
+*/
+inline void set_bkg_submap_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *map, uint8_t map_w)
+{
+    VBK_REG = VBK_ATTRIBUTES;
+    set_bkg_submap(x, y, w, h, map, map_w);
+    VBK_REG = VBK_TILES;
 }
 
 

--- a/gbdk-lib/include/sms/sms.h
+++ b/gbdk-lib/include/sms/sms.h
@@ -592,6 +592,13 @@ inline void set_win_based_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, cons
     _map_tile_offset = 0;
 }
 
+inline void set_bkg_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *tiles)
+{
+    VBK_REG = VBK_ATTRIBUTES;
+    set_bkg_tiles(x, y, w, h, tiles);
+    VBK_REG = VBK_TILES;
+}
+
 void set_tile_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t map_w, const uint8_t *map) Z88DK_CALLEE PRESERVES_REGS(iyh, iyl);
 void set_tile_submap_compat(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t map_w, const uint8_t *map) Z88DK_CALLEE PRESERVES_REGS(iyh, iyl);
 inline void set_bkg_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *map, uint8_t map_w) {
@@ -611,6 +618,13 @@ inline void set_win_based_submap(uint8_t x, uint8_t y, uint8_t w, uint8_t h, con
     _submap_tile_offset = base_tile;
     set_tile_submap_compat(x, y, w, h, map_w, map);
     _submap_tile_offset = 0;
+}
+
+inline void set_bkg_submap_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *map, uint8_t map_w)
+{
+    VBK_REG = VBK_ATTRIBUTES;
+    set_bkg_submap(x, y, w, h, map, map_w);
+    VBK_REG = VBK_TILES;
 }
 
 void fill_rect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint16_t tile) Z88DK_CALLEE PRESERVES_REGS(iyh, iyl);

--- a/gbdk-support/png2asset/png2asset.cpp
+++ b/gbdk-support/png2asset/png2asset.cpp
@@ -1300,12 +1300,17 @@ bool export_h_file(void) {
 			{
 				fprintf(file, "extern const unsigned char %s_map[%d];\n", data_name.c_str(), (unsigned int)map.size());
 
-				if(use_map_attributes) {
-					if(map_attributes.size()) {
+				if(use_map_attributes && map_attributes.size()) {
 						fprintf(file, "extern const unsigned char %s_map_attributes[%d];\n", data_name.c_str(), (unsigned int)map_attributes.size());
-					}
 				}
-				else if ((includeTileData) && (use_structs)) {
+				else
+				{
+					// Some platforms (like SMS/GG) encode attributes as part of map
+					// For compatibility, add a define that makes _map_attributes equal _map,
+					// so that set_bkg_attributes can work the same on these platforms
+					fprintf(file, "#define %s_map_attributes %s_map\n", data_name.c_str(), data_name.c_str());
+				}
+				if (!use_map_attributes && (includeTileData) && (use_structs)) {
 					fprintf(file, "extern const unsigned char* %s_tile_pals[%d];\n", data_name.c_str(), (unsigned int)tiles.size());
 				}
 			}


### PR DESCRIPTION
* Add inline functions set_bkg_attributes / set_bkg_submap_attributes to gb.h
* Make these functions temporarily switch in attribute memory, call set_bkg_tiles / set_bkg_submap, then switch out attribute memory
* Update examples/cross-platform/logo to use set_bkg_attributes for all platforms having attributes
* Remove NES-specific round-to-two in examples/cross-platform/logo to simplify example, as the logo image fulfills this criteria