### PR TITLE
NES: Add metasprite clipping support

### DIFF
--- a/gbdk-lib/examples/cross-platform/metasprites/src/metasprites.c
+++ b/gbdk-lib/examples/cross-platform/metasprites/src/metasprites.c
@@ -54,7 +54,7 @@ const uint8_t pattern[] = {0x80,0x80,0x40,0x40,0x20,0x20,0x10,0x10,0x08,0x08,0x0
 #define TILE_NUM_START 0
 
 // sprite coords
-uint16_t PosX, PosY;
+int16_t PosX, PosY;
 int16_t SpdX, SpdY;
 uint8_t PosF;
 uint8_t hide, jitter;

--- a/gbdk-lib/include/nes/metasprites.h
+++ b/gbdk-lib/include/nes/metasprites.h
@@ -91,13 +91,13 @@ extern uint8_t __current_base_prop;
 extern uint8_t __render_shadow_OAM;
 
 
-static uint8_t __move_metasprite(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
-static uint8_t __move_metasprite_flipx(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
-static uint8_t __move_metasprite_flipy(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
-static uint8_t __move_metasprite_flipxy(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
-static uint8_t __move_metasprite_vflip(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
-static uint8_t __move_metasprite_hflip(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
-static uint8_t __move_metasprite_hvflip(uint8_t id, uint8_t x, uint8_t y) OLDCALL;
+static uint8_t __move_metasprite(uint8_t id, int16_t x, int16_t y) OLDCALL;
+static uint8_t __move_metasprite_flipx(uint8_t id, int16_t x, int16_t y) OLDCALL;
+static uint8_t __move_metasprite_flipy(uint8_t id, int16_t x, int16_t y) OLDCALL;
+static uint8_t __move_metasprite_flipxy(uint8_t id, int16_t x, int16_t y) OLDCALL;
+static uint8_t __move_metasprite_vflip(uint8_t id, int16_t x, int16_t y) OLDCALL;
+static uint8_t __move_metasprite_hflip(uint8_t id, int16_t x, int16_t y) OLDCALL;
+static uint8_t __move_metasprite_hvflip(uint8_t id, int16_t x, int16_t y) OLDCALL;
 static void __hide_metasprite(uint8_t id) OLDCALL;
 
 /**
@@ -129,7 +129,7 @@ void hide_sprites_range(UINT8 from, UINT8 to) OLDCALL;
 
     @return Number of hardware sprites used to draw this metasprite
  */
-inline uint8_t move_metasprite_ex(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, uint8_t x, uint8_t y) {
+inline uint8_t move_metasprite_ex(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, int16_t x, int16_t y) {
     base_prop;
     __current_metasprite = metasprite;
     __current_base_tile = base_tile;
@@ -139,7 +139,7 @@ inline uint8_t move_metasprite_ex(const metasprite_t * metasprite, uint8_t base_
 
 /** Obsolete
 */
-inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
+inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, int16_t x, int16_t y) {
     __current_metasprite = metasprite;
     __current_base_tile = base_tile;
     __current_base_prop = 0;
@@ -167,7 +167,7 @@ inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_til
 
     @see move_metasprite()
 */
-inline uint8_t move_metasprite_flipx(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, uint8_t x, uint8_t y) {
+inline uint8_t move_metasprite_flipx(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, int16_t x, int16_t y) {
     base_prop;
     __current_metasprite = metasprite;
     __current_base_tile = base_tile;
@@ -177,7 +177,7 @@ inline uint8_t move_metasprite_flipx(const metasprite_t * metasprite, uint8_t ba
 
 /** Obsolete
 */
-inline uint8_t move_metasprite_vflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
+inline uint8_t move_metasprite_vflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, int16_t x, int16_t y) {
     __current_metasprite = metasprite;
     __current_base_tile = base_tile;
     __current_base_prop = 0;
@@ -206,7 +206,7 @@ inline uint8_t move_metasprite_vflip(const metasprite_t * metasprite, uint8_t ba
 
     @see move_metasprite()
 */
-inline uint8_t move_metasprite_flipy(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, uint8_t x, uint8_t y) {
+inline uint8_t move_metasprite_flipy(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, int16_t x, int16_t y) {
     base_prop;
     __current_metasprite = metasprite;
     __current_base_tile = base_tile;
@@ -216,7 +216,7 @@ inline uint8_t move_metasprite_flipy(const metasprite_t * metasprite, uint8_t ba
 
 /** Obsolete
 */
-inline uint8_t move_metasprite_hflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
+inline uint8_t move_metasprite_hflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, int16_t x, int16_t y) {
     __current_metasprite = metasprite;
     __current_base_tile = base_tile;
     __current_base_prop = 0;
@@ -244,7 +244,7 @@ inline uint8_t move_metasprite_hflip(const metasprite_t * metasprite, uint8_t ba
 
     @see move_metasprite()
 */
-inline uint8_t move_metasprite_flipxy(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, uint8_t x, uint8_t y) {
+inline uint8_t move_metasprite_flipxy(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, int16_t x, int16_t y) {
     base_prop;
     __current_metasprite = metasprite;
     __current_base_tile = base_tile;
@@ -254,7 +254,7 @@ inline uint8_t move_metasprite_flipxy(const metasprite_t * metasprite, uint8_t b
 
 /** Obsolete
 */
-inline uint8_t move_metasprite_hvflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
+inline uint8_t move_metasprite_hvflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, int16_t x, int16_t y) {
     __current_metasprite = metasprite;
     __current_base_tile = base_tile;
     __current_base_prop = 0;

--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -9,7 +9,9 @@ CSRC = crlf.c
 
 ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	font.s font_color.s set_data.s set_1bit_data.s color.s mode.s \
-	metasprites.s metasprites_hide.s metasprites_hide_spr.s \
+	metasprites.s metasprites_flipx.s metasprites_flipy.s metasprites_flipxy.s \
+	metasprites_common.s \
+	metasprites_hide.s metasprites_hide_spr.s \
 	set_bk_ts.s set_tile_submap.s fill_rect_bk.s \
 	set_bk_attributes.s set_tile_submap_attributes.s flush_attributes.s \
 	nes_palettes.s \

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites.s
@@ -4,75 +4,48 @@
     .module Metasprites
 
     .area	OSEG (PAG, OVR)
+    ___move_metasprite_PARM_2:: .ds 2
+    ___move_metasprite_PARM_3:: .ds 2
     ___current_metasprite::     .ds 2
     ___current_base_tile::      .ds 1
     ___current_base_prop::      .ds 1
-    ___move_metasprite_hflip_PARM_3::
-    ___move_metasprite_vflip_PARM_3::
-    ___move_metasprite_hvflip_PARM_3::
-    ___move_metasprite_flipx_PARM_3::
-    ___move_metasprite_flipy_PARM_3::
-    ___move_metasprite_flipxy_PARM_3::
-    ___move_metasprite_PARM_3:: .ds 2
-
-    .area   _INITIALIZED
-    ___render_shadow_OAM:: .ds     0x01
-
-    .area   _INITIALIZER
-    .db     #>_shadow_OAM
 
     .area   _HOME
 
-.define xPos  ".tmp"
+.define xPos  "___move_metasprite_PARM_2"
 .define yPos  "___move_metasprite_PARM_3"
-.define id    ".tmp+1"
 
-.move_metasprite_prologue:
-    sta *id
-    stx xPos
-    asl
-    asl
-    tax
-    ; Make 8x16 mode bit fetch from second pattern table by setting bit0 of tile index
-    lda *_shadow_PPUCTRL
-    lsr
-    lsr
-    lsr
-    lsr
-    lsr
-    and #1
-    ora *___current_base_tile
-    sta *___current_base_tile
-    ldy #0
-    rts
+; uint8_t __move_metasprite(uint8_t id, int16_t x, int16_t y)
 
-.move_metasprite_epilogue:
-    ; Return number of hardware sprites used
-    txa
-    lsr
-    lsr
-    sec
-    sbc *id
-    rts
-
-; uint8_t __move_metasprite(uint8_t id, uint8_t x, uint8_t y)
 ___move_metasprite::
     jsr .move_metasprite_prologue
 ___move_metasprite_loop:
     lda [*___current_metasprite],y      ; dy
-    iny
-    cmp #0x80
-    beq ___move_metasprite_end
+    bmi ___move_metasprite_dyNeg
     clc
     adc *yPos
     sta *yPos
+    bcc 1$
+    inc *yPos+1
+1$:
+___move_metasprite_loop_writePosY:
     sta _shadow_OAM+OAM_POS_Y,x
-    lda *xPos
-    clc
-    adc [*___current_metasprite],y      ; dx
+    lda *yPos+1
+    bne ___move_metasprite_outsideY
     iny
+    lda [*___current_metasprite],y      ; dx
+    bmi ___move_metasprite_dxNeg
+    clc
+    adc *xPos
     sta *xPos
+    bcc 2$
+    inc *xPos+1
+2$:
+___move_metasprite_loop_writePosX:
     sta _shadow_OAM+OAM_POS_X,x
+    lda *xPos+1
+    bne ___move_metasprite_outsideX
+    iny
     lda [*___current_metasprite],y      ; tile index
     iny
     clc
@@ -90,115 +63,49 @@ ___move_metasprite_loop:
 ___move_metasprite_end:
     jmp .move_metasprite_epilogue
 
-; uint8_t __move_metasprite_vflip(uint8_t id, uint8_t x, uint8_t y)
-___move_metasprite_flipx::
-___move_metasprite_vflip::
-    jsr .move_metasprite_prologue
-___move_metasprite_vflip_loop:
-    lda [*___current_metasprite],y      ; dy
-    iny
-    cmp #0x80
-    beq ___move_metasprite_vflip_end
+___move_metasprite_dxNeg:
     clc
-    adc *yPos
-    sta *yPos
-    sta _shadow_OAM+OAM_POS_Y,x
-    lda *xPos
-    sec
-    sbc [*___current_metasprite],y      ; dx
-    iny
+    adc *xPos
     sta *xPos
-    sta _shadow_OAM+OAM_POS_X,x
-    lda [*___current_metasprite],y      ; tile index
-    iny
-    clc
-    adc *___current_base_tile
-    sta _shadow_OAM+OAM_TILE_INDEX,x
-    lda [*___current_metasprite],y      ; props
-    adc *___current_base_prop
-    eor #OAMF_XFLIP
-    iny
-    sta _shadow_OAM+OAM_ATTRIBUTES,x
-    inx
-    inx
-    inx
-    inx
-    bne ___move_metasprite_vflip_loop
-___move_metasprite_vflip_end:
-    jmp .move_metasprite_epilogue
+    bcs 1$
+    dec *xPos+1
+1$:
+    jmp ___move_metasprite_loop_writePosX
 
-; uint8_t __move_metasprite_hflip(uint8_t id, uint8_t x, uint8_t y)
-___move_metasprite_flipy::
-___move_metasprite_hflip::
-    jsr .move_metasprite_prologue
-___move_metasprite_hflip_loop:
-    lda [*___current_metasprite],y      ; dy
-    iny
+___move_metasprite_dyNeg:
     cmp #0x80
-    beq ___move_metasprite_hflip_end
-    eor #0xFF
-    sec
+    beq ___move_metasprite_end
+    clc
     adc *yPos
     sta *yPos
-    sta _shadow_OAM+OAM_POS_Y,x
-    lda *xPos
-    clc
-    adc [*___current_metasprite],y      ; dx
-    iny
-    sta *xPos
-    sta _shadow_OAM+OAM_POS_X,x
-    lda [*___current_metasprite],y      ; tile index
-    iny
-    clc
-    adc *___current_base_tile
-    sta _shadow_OAM+OAM_TILE_INDEX,x
-    lda [*___current_metasprite],y      ; props
-    adc *___current_base_prop
-    eor #OAMF_YFLIP
-    iny
-    sta _shadow_OAM+OAM_ATTRIBUTES,x
-    inx
-    inx
-    inx
-    inx
-    bne ___move_metasprite_hflip_loop
-___move_metasprite_hflip_end:
-    jmp .move_metasprite_epilogue
+    bcs 1$
+    dec *yPos+1
+1$:
+    jmp ___move_metasprite_loop_writePosY
 
-; uint8_t __move_metasprite_hvflip(uint8_t id, uint8_t x, uint8_t y)
-___move_metasprite_flipxy::
-___move_metasprite_hvflip::
-    jsr .move_metasprite_prologue
-___move_metasprite_hvflip_loop:
-    lda [*___current_metasprite],y      ; dy
+___move_metasprite_outsideY:
     iny
-    cmp #0x80
-    beq ___move_metasprite_hvflip_end
-    eor #0xFF
-    sec
-    adc *yPos
-    sta *yPos
-    sta _shadow_OAM+OAM_POS_Y,x
-    lda *xPos
-    sec
-    sbc [*___current_metasprite],y      ; dx
-    iny
-    sta *xPos
-    sta _shadow_OAM+OAM_POS_X,x
-    lda [*___current_metasprite],y      ; tile index
-    iny
+    lda [*___current_metasprite],y      ; dx
+    bmi ___move_metasprite_outsideY_dxNeg
     clc
-    adc *___current_base_tile
-    sta _shadow_OAM+OAM_TILE_INDEX,x
-    lda [*___current_metasprite],y      ; props
-    adc *___current_base_prop
-    eor #OAMF_YFLIP+OAMF_XFLIP
+    adc *xPos
+    sta *xPos
+    bcc ___move_metasprite_outsideX
+    inc *xPos+1
+___move_metasprite_outsideX:
     iny
-    sta _shadow_OAM+OAM_ATTRIBUTES,x
-    inx
-    inx
-    inx
-    inx
-    bne ___move_metasprite_hvflip_loop
-___move_metasprite_hvflip_end:
-    jmp .move_metasprite_epilogue
+    ; Skip tile index / props
+    iny
+    iny
+    lda #0xF0
+    sta _shadow_OAM+OAM_POS_Y,x
+    jmp ___move_metasprite_loop
+
+___move_metasprite_outsideY_dxNeg:
+    clc
+    adc *xPos
+    sta *xPos
+    bcs 1$
+    dec *xPos+1
+1$:
+    jmp ___move_metasprite_outsideX

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites_common.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites_common.s
@@ -1,0 +1,40 @@
+    .include    "global.s"
+
+    .title  "Metasprites"
+    .module Metasprites
+
+    .area   _HOME
+
+    .area   _INITIALIZED
+    ___render_shadow_OAM:: .ds     0x01
+
+    .area   _INITIALIZER
+    .db     #>_shadow_OAM
+
+.define id    ".tmp+1"
+
+.move_metasprite_prologue::
+    sta *id
+    asl
+    asl
+    tax
+    ; Make 8x16 mode bit fetch from second pattern table by setting bit0 of tile index
+    lda *_shadow_PPUCTRL
+    lsr
+    lsr
+    lsr
+    lsr
+    lsr
+    and #1
+    ora *___current_base_tile
+    sta *___current_base_tile
+    rts
+
+.move_metasprite_epilogue::
+    ; Return number of hardware sprites used
+    txa
+    lsr
+    lsr
+    sec
+    sbc *id
+    rts

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites_flipx.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites_flipx.s
@@ -1,0 +1,114 @@
+    .include    "global.s"
+
+    .title  "Metasprites"
+    .module Metasprites
+
+    .area	OSEG (PAG, OVR)
+    ___move_metasprite_vflip_PARM_2::
+    ___move_metasprite_flipx_PARM_2:: .ds 2
+    ___move_metasprite_vflip_PARM_3::
+    ___move_metasprite_flipx_PARM_3:: .ds 2
+
+    .area   _HOME
+
+.define xPos  "___move_metasprite_flipx_PARM_2"
+.define yPos  "___move_metasprite_flipx_PARM_3"
+
+; uint8_t __move_metasprite_flipx(uint8_t id, int16_t x, int16_t y)
+
+___move_metasprite_flipx::
+___move_metasprite_vflip::
+    jsr .move_metasprite_prologue
+___move_metasprite_flipx_loop:
+    lda [*___current_metasprite],y      ; dy
+    bmi ___move_metasprite_flipx_dyNeg
+    clc
+    adc *yPos
+    sta *yPos
+    bcc 1$
+    inc *yPos+1
+1$:
+___move_metasprite_flipx_loop_writePosY:
+    sta _shadow_OAM+OAM_POS_Y,x
+    lda *yPos+1
+    bne ___move_metasprite_flipx_outsideY
+    iny
+    lda [*___current_metasprite],y      ; dx
+    eor #0xFF
+    bmi ___move_metasprite_flipx_dxNeg
+    sec
+    adc *xPos
+    sta *xPos
+    bcc 2$
+    inc *xPos+1
+2$:
+___move_metasprite_flipx_loop_writePosX:
+    sta _shadow_OAM+OAM_POS_X,x
+    lda *xPos+1
+    bne ___move_metasprite_flipx_outsideX
+    iny
+    lda [*___current_metasprite],y      ; tile index
+    iny
+    clc
+    adc *___current_base_tile
+    sta _shadow_OAM+OAM_TILE_INDEX,x
+    lda [*___current_metasprite],y      ; props
+    eor #OAMF_XFLIP
+    adc *___current_base_prop
+    iny
+    sta _shadow_OAM+OAM_ATTRIBUTES,x
+    inx
+    inx
+    inx
+    inx
+    bne ___move_metasprite_flipx_loop
+___move_metasprite_flipx_end:
+    jmp .move_metasprite_epilogue
+
+___move_metasprite_flipx_dxNeg:
+    sec
+    adc *xPos
+    sta *xPos
+    bcs 1$
+    dec *xPos+1
+1$:
+    jmp ___move_metasprite_flipx_loop_writePosX
+
+___move_metasprite_flipx_dyNeg:
+    cmp #0x80
+    beq ___move_metasprite_flipx_end
+    clc
+    adc *yPos
+    sta *yPos
+    bcs 1$
+    dec *yPos+1
+1$:
+    jmp ___move_metasprite_flipx_loop_writePosY
+
+___move_metasprite_flipx_outsideY:
+    iny
+    lda [*___current_metasprite],y      ; dx
+    eor #0xFF
+    bmi ___move_metasprite_flipx_outsideY_dxNeg
+    sec
+    adc *xPos
+    sta *xPos
+    bcc ___move_metasprite_flipx_outsideX
+    inc *xPos+1
+___move_metasprite_flipx_outsideX:
+    iny
+    ; Skip tile index / props
+    iny
+    iny
+    lda #0xF0
+    sta _shadow_OAM+OAM_POS_Y,x
+    jmp ___move_metasprite_flipx_loop
+
+___move_metasprite_flipx_outsideY_dxNeg:
+    sec
+    adc *xPos
+    sta *xPos
+    bcs 1$
+    dec *xPos+1
+1$:
+    jmp ___move_metasprite_flipx_outsideX

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites_flipxy.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites_flipxy.s
@@ -1,0 +1,115 @@
+    .include    "global.s"
+
+    .title  "Metasprites"
+    .module Metasprites
+
+    .area	OSEG (PAG, OVR)
+    ___move_metasprite_hvflip_PARM_2::
+    ___move_metasprite_flipxy_PARM_2:: .ds 2
+    ___move_metasprite_hvflip_PARM_3::
+    ___move_metasprite_flipxy_PARM_3:: .ds 2
+
+    .area   _HOME
+
+.define xPos  "___move_metasprite_flipxy_PARM_2"
+.define yPos  "___move_metasprite_flipxy_PARM_3"
+
+; uint8_t __move_metasprite_flipxy(uint8_t id, int16_t x, int16_t y)
+
+___move_metasprite_flipxy::
+___move_metasprite_hvflip::
+    jsr .move_metasprite_prologue
+___move_metasprite_flipxy_loop:
+    lda [*___current_metasprite],y      ; dy
+    eor #0xFF
+    bpl ___move_metasprite_flipxy_dyNeg
+    sec
+    adc *yPos
+    sta *yPos
+    bcs 1$
+    dec *yPos+1
+1$:
+___move_metasprite_flipxy_loop_writePosY:
+    sta _shadow_OAM+OAM_POS_Y,x
+    lda *yPos+1
+    bne ___move_metasprite_flipxy_outsideY
+    iny
+    lda [*___current_metasprite],y      ; dx
+    eor #0xFF
+    bmi ___move_metasprite_flipxy_dxNeg
+    sec
+    adc *xPos
+    sta *xPos
+    bcc 2$
+    inc *xPos+1
+2$:
+___move_metasprite_flipxy_loop_writePosX:
+    sta _shadow_OAM+OAM_POS_X,x
+    lda *xPos+1
+    bne ___move_metasprite_flipxy_outsideX
+    iny
+    lda [*___current_metasprite],y      ; tile index
+    iny
+    clc
+    adc *___current_base_tile
+    sta _shadow_OAM+OAM_TILE_INDEX,x
+    lda [*___current_metasprite],y      ; props
+    eor #OAMF_YFLIP+OAMF_XFLIP
+    adc *___current_base_prop
+    iny
+    sta _shadow_OAM+OAM_ATTRIBUTES,x
+    inx
+    inx
+    inx
+    inx
+    bne ___move_metasprite_flipxy_loop
+___move_metasprite_flipxy_end:
+    jmp .move_metasprite_epilogue
+
+___move_metasprite_flipxy_dxNeg:
+    sec
+    adc *xPos
+    sta *xPos
+    bcs 1$
+    dec *xPos+1
+1$:
+    jmp ___move_metasprite_flipxy_loop_writePosX
+
+___move_metasprite_flipxy_dyNeg:
+    cmp #0x7F
+    beq ___move_metasprite_flipxy_end
+    sec
+    adc *yPos
+    sta *yPos
+    bcc 1$
+    inc *yPos+1
+1$:
+    jmp ___move_metasprite_flipxy_loop_writePosY
+
+___move_metasprite_flipxy_outsideY:
+    iny
+    lda [*___current_metasprite],y      ; dx
+    eor #0xFF
+    bmi ___move_metasprite_flipxy_outsideY_dxNeg
+    sec
+    adc *xPos
+    sta *xPos
+    bcc ___move_metasprite_flipxy_outsideX
+    inc *xPos+1
+___move_metasprite_flipxy_outsideX:
+    iny
+    ; Skip tile index / props
+    iny
+    iny
+    lda #0xF0
+    sta _shadow_OAM+OAM_POS_Y,x
+    jmp ___move_metasprite_flipxy_loop
+
+___move_metasprite_flipxy_outsideY_dxNeg:
+    sec
+    adc *xPos
+    sta *xPos
+    bcs 1$
+    dec *xPos+1
+1$:
+    jmp ___move_metasprite_flipxy_outsideX

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites_flipy.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites_flipy.s
@@ -1,0 +1,113 @@
+    .include    "global.s"
+
+    .title  "Metasprites"
+    .module Metasprites
+
+    .area	OSEG (PAG, OVR)
+    ___move_metasprite_hflip_PARM_2::
+    ___move_metasprite_flipy_PARM_2:: .ds 2
+    ___move_metasprite_hflip_PARM_3::
+    ___move_metasprite_flipy_PARM_3:: .ds 2
+
+    .area   _HOME
+
+.define xPos  "___move_metasprite_flipy_PARM_2"
+.define yPos  "___move_metasprite_flipy_PARM_3"
+
+; uint8_t __move_metasprite_flipy(uint8_t id, int16_t x, int16_t y)
+
+___move_metasprite_flipy::
+___move_metasprite_hflip::
+    jsr .move_metasprite_prologue
+___move_metasprite_flipy_loop:
+    lda [*___current_metasprite],y      ; dy
+    eor #0xFF
+    bpl ___move_metasprite_flipy_dyNeg
+    sec
+    adc *yPos
+    sta *yPos
+    bcs 1$
+    dec *yPos+1
+1$:
+___move_metasprite_flipy_loop_writePosY:
+    sta _shadow_OAM+OAM_POS_Y,x
+    lda *yPos+1
+    bne ___move_metasprite_flipy_outsideY
+    iny
+    lda [*___current_metasprite],y      ; dx
+    bmi ___move_metasprite_flipy_dxNeg
+    clc
+    adc *xPos
+    sta *xPos
+    bcc 2$
+    inc *xPos+1
+2$:
+___move_metasprite_flipy_loop_writePosX:
+    sta _shadow_OAM+OAM_POS_X,x
+    lda *xPos+1
+    bne ___move_metasprite_flipy_outsideX
+    iny
+    lda [*___current_metasprite],y      ; tile index
+    iny
+    clc
+    adc *___current_base_tile
+    sta _shadow_OAM+OAM_TILE_INDEX,x
+    lda [*___current_metasprite],y      ; props
+    eor #OAMF_YFLIP
+    adc *___current_base_prop
+    iny
+    sta _shadow_OAM+OAM_ATTRIBUTES,x
+    inx
+    inx
+    inx
+    inx
+    bne ___move_metasprite_flipy_loop
+___move_metasprite_flipy_end:
+    jmp .move_metasprite_epilogue
+
+___move_metasprite_flipy_dxNeg:
+    clc
+    adc *xPos
+    sta *xPos
+    bcs 1$
+    dec *xPos+1
+1$:
+    jmp ___move_metasprite_flipy_loop_writePosX
+
+___move_metasprite_flipy_dyNeg:
+    cmp #0x7F
+    beq ___move_metasprite_flipy_end
+    sec
+    adc *yPos
+    sta *yPos
+    bcc 1$
+    inc *yPos+1
+1$:
+    jmp ___move_metasprite_flipy_loop_writePosY
+
+___move_metasprite_flipy_outsideY:
+    iny
+    lda [*___current_metasprite],y      ; dx
+    bmi ___move_metasprite_flipy_outsideY_dxNeg
+    clc
+    adc *xPos
+    sta *xPos
+    bcc ___move_metasprite_flipy_outsideX
+    inc *xPos+1
+___move_metasprite_flipy_outsideX:
+    iny
+    ; Skip tile index / props
+    iny
+    iny
+    lda #0xF0
+    sta _shadow_OAM+OAM_POS_Y,x
+    jmp ___move_metasprite_flipy_loop
+
+___move_metasprite_flipy_outsideY_dxNeg:
+    clc
+    adc *xPos
+    sta *xPos
+    bcs 1$
+    dec *xPos+1
+1$:
+    jmp ___move_metasprite_flipy_outsideX


### PR DESCRIPTION
* Change x / y parameters of move_metasprite* function definitions from uint8 to int16
* Update move_metasprite* to do 16-bit math, and reject hardware sprites outside screen
* Move flip[x/y] move_metasprite* functions into separate files for independent linking
* Move .move_metasprite_prologue / _epilogue functions into new file metasprites_common.s