### PR TITLE
Png2asset: fix bit packed indexed images, -repair_indexed_pal feature

### DIFF
--- a/gbdk-support/png2asset/Makefile
+++ b/gbdk-support/png2asset/Makefile
@@ -41,7 +41,7 @@ endif
 TARGET = png2asset
 
 
-SRCS := lodepng.cpp png2asset.cpp rgb_to_nes_lut.cpp
+SRCS := lodepng.cpp png2asset.cpp rgb_to_nes_lut.cpp image_utils.cpp
 OBJS := $(SRCS:%.cpp=%.o)
 
 $(TARGET): $(OBJS)

--- a/gbdk-support/png2asset/image_utils.cpp
+++ b/gbdk-support/png2asset/image_utils.cpp
@@ -1,0 +1,62 @@
+
+// image_utils.cpp
+
+#include <vector>
+#include <stdio.h>
+#include "lodepng.h"
+#include "image_utils.h"
+
+using namespace std;
+
+static void image_unbitpack(vector<unsigned char> & src_image_data, vector<unsigned char> & unpacked_image_data, uint8_t bitdepth);
+
+
+// Un-bitpacks a source image into an 8-bit-per-pixel destination buffer
+// Acceptable range is 1-8 bits per pixel
+static void image_unbitpack(vector<unsigned char> & src_image_data, vector<unsigned char> & unpacked_image_data, uint8_t bitdepth) {
+
+    int pixels_per_byte = (8 / bitdepth);
+
+    // Loop through all pixels in source image buffer
+    for (vector<unsigned char>::iterator it_src = src_image_data.begin(); it_src != src_image_data.end(); it_src++) {
+
+        // Unpack grouped pixel data
+        unsigned char packed_bits = (unsigned char)*it_src;
+        for (int b = 0; b < pixels_per_byte; b++) {
+            unpacked_image_data.push_back(packed_bits >> (8 - bitdepth)); // Save extracted pixel bits
+            packed_bits <<= bitdepth;                                     // Shift out the extracted bits
+        }
+    }
+}
+
+
+// Converts indexed image with bit depths 1- 8 bpp to indexed 8 bits per pixel
+// Replaces incoming image buffer with unpacked image buffer if successful
+bool image_indexed_ensure_8bpp(vector<unsigned char> & src_image_data, int width, int height, int bitdepth, int colortype) {
+
+    vector<unsigned char> unpacked_image_data;
+
+    // For debug
+    // printf("colortype = %d, bitdepth = %d\n", colortype, bitdepth);
+
+    if (colortype != LCT_PALETTE) {
+        printf("png2asset: Error: keep_palette_order only works with indexed png images");
+        return false;
+    }
+    else if ((bitdepth < 1) || (bitdepth > 8)) {
+        printf("png2asset: Error: Indexed mode PNG requires between 1 - 8 bits per pixel (pngtype: %d, bits:%d)\n",
+                colortype, bitdepth);
+        return false;
+    }
+
+    image_unbitpack(src_image_data, unpacked_image_data, bitdepth);
+
+    // Replace source image pixel data with unpacked pixels
+    src_image_data.clear();
+    for (vector<unsigned char>::iterator it_unpacked = unpacked_image_data.begin(); it_unpacked != unpacked_image_data.end(); it_unpacked++)
+        src_image_data.push_back((unsigned char)*it_unpacked);
+
+    return true;
+}
+
+

--- a/gbdk-support/png2asset/image_utils.cpp
+++ b/gbdk-support/png2asset/image_utils.cpp
@@ -13,6 +13,12 @@ using namespace std;
 
 static void image_bitunpack(const vector<uint8_t> & src_image_data, vector<uint8_t> & unpacked_image_data, uint8_t bitdepth);
 
+static int pixel_get_palette_num(const PNGImage& image, int x, int y);
+static bool tile_palette_is_ok(const PNGImage& image, int x, int y, int tile_w, int tile_h);
+static int pixel_find_color_in_palette(const PNGImage& image, int x, int y, int pal_num, uint8_t * match_color_idx);
+static bool tile_palette_try_repair(PNGImage& image, int x, int y, int tile_w, int tile_h, int pal);
+static bool tile_palette_repair(PNGImage& image, int x, int y, int tile_w, int tile_h);
+
 
 // Un-bitpacks a source image into an 8-bit-per-pixel destination buffer
 // Acceptable range is 1-8 bits per pixel
@@ -90,7 +96,6 @@ static bool tile_palette_is_ok(const PNGImage& image, int x, int y, int tile_w, 
 
 
 // Finds a matching sub-palette RGB color for a pixel in a indexed 8bpp image
-// static int pixel_find_color_in_palette(const PNGImage& image, int x, int y, int pal_num) {
 static int pixel_find_color_in_palette(const PNGImage& image, int x, int y, int pal_num, uint8_t * match_color_idx) {
 
     // Get pixel palette index num, then get RGB value for it
@@ -115,41 +120,44 @@ static int pixel_find_color_in_palette(const PNGImage& image, int x, int y, int 
 }
 
 
-static bool tile_palette_repair(PNGImage& image, int x, int y, int tile_w, int tile_h) {
+// Tries to remap a tile to a new palette. Fails if any color in tile isn't in palette
+// Note: For any color that does match, tile color indexed gets remapped even if the rest
+//       of the match fails. That's ok because the new color is visually identical to previous.
+static bool tile_palette_try_repair(PNGImage& image, int x, int y, int tile_w, int tile_h, int pal_num) {
 
-    bool match_failed;
     uint8_t new_color;
 
-    // Loop through all sub-palettes
-    for (int pal = 0; pal < (int)image.total_color_count / (int)image.colors_per_pal; pal++) {
+    // For each pixel in the tile, try to find an exact color match in the palette
+    for (int tile_y = 0; tile_y < tile_h; tile_y++) {
+        for (int tile_x = 0; tile_x < tile_w; tile_x++) {
 
-        // For each pixel in the tile, try to find an exact color match in the palette
-        match_failed = false;
-// TODO: could this be a loop ... continue; instead?
-        for (int tile_y = 0; tile_y < tile_h; tile_y++) {
-            for (int tile_x = 0; tile_x < tile_w; tile_x++) {
-
-                // Update pixel if exact match was found
-                // TODO: count number of matches to use for optional "force best palette"
-                if (pixel_find_color_in_palette(image, x + tile_x, y + tile_y, pal, &new_color))
-                    image.data[((y + tile_y) * image.w) + x + tile_x] = new_color;
-                else
-                    match_failed = true;
-// TODO: make this skip out of loop sooner
-            }
-        }
-
-        // Quit as soon as a perfect palette match is found
-        if (!match_failed) {
-            printf("  + png2asset: Info: repaired tile at %d x %d to palette %d\n", x, y, pal);
-            return true;
+            // Update pixel if exact match was found
+            // Otherwise quit as soon as possible to reduce processing
+            if (pixel_find_color_in_palette(image, x + tile_x, y + tile_y, pal_num, &new_color))
+                image.data[((y + tile_y) * image.w) + x + tile_x] = new_color;
+            else
+                return false; // Failed, tile color not present in palette
         }
     }
 
+    // printf("  + png2asset: Info: repaired tile at %d x %d to palette make%d\n", x, y, pal_num);
+    return true; // Success, found a perfect match
+}
+
+
+// Checks all palettes to see if the tile's colors can be remapped to them.
+static bool tile_palette_repair(PNGImage& image, int x, int y, int tile_w, int tile_h) {
+
+    // Loop through all sub-palettes
+    for (int pal_num = 0; pal_num < (int)image.total_color_count / (int)image.colors_per_pal; pal_num++)
+        if (tile_palette_try_repair(image, x, y, tile_w, tile_h, pal_num))
+            return true; // Success
+
     printf("png2asset: Error: tile (%dx%d) at %d,%d - %d,%d uses unique colors from different palettes, "
            "cannot repair palette\n", x / tile_w, y / tile_h, x, y, x + tile_w - 1, y + tile_h - 1);
-    // If not exact palette match was found then signal failure
-    return false;
+
+    // If no exact palette match was found then signal failure
+    return false; // Failure
 }
 
 

--- a/gbdk-support/png2asset/image_utils.cpp
+++ b/gbdk-support/png2asset/image_utils.cpp
@@ -3,25 +3,27 @@
 
 #include <vector>
 #include <stdio.h>
+#include <stdint.h>
 #include "lodepng.h"
-#include "image_utils.h"
 
 using namespace std;
 
-static void image_unbitpack(vector<unsigned char> & src_image_data, vector<unsigned char> & unpacked_image_data, uint8_t bitdepth);
+#include "image_utils.h"
+
+static void image_bitunpack(const vector<uint8_t> & src_image_data, vector<uint8_t> & unpacked_image_data, uint8_t bitdepth);
 
 
 // Un-bitpacks a source image into an 8-bit-per-pixel destination buffer
 // Acceptable range is 1-8 bits per pixel
-static void image_unbitpack(vector<unsigned char> & src_image_data, vector<unsigned char> & unpacked_image_data, uint8_t bitdepth) {
+static void image_bitunpack(const vector<uint8_t> & src_image_data, vector<uint8_t> & unpacked_image_data, uint8_t bitdepth) {
 
     int pixels_per_byte = (8 / bitdepth);
 
     // Loop through all pixels in source image buffer
-    for (vector<unsigned char>::iterator it_src = src_image_data.begin(); it_src != src_image_data.end(); it_src++) {
+    for (const uint8_t & it_src: src_image_data) {
 
         // Unpack grouped pixel data
-        unsigned char packed_bits = (unsigned char)*it_src;
+        uint8_t packed_bits = it_src;
         for (int b = 0; b < pixels_per_byte; b++) {
             unpacked_image_data.push_back(packed_bits >> (8 - bitdepth)); // Save extracted pixel bits
             packed_bits <<= bitdepth;                                     // Shift out the extracted bits
@@ -32,12 +34,9 @@ static void image_unbitpack(vector<unsigned char> & src_image_data, vector<unsig
 
 // Converts indexed image with bit depths 1- 8 bpp to indexed 8 bits per pixel
 // Replaces incoming image buffer with unpacked image buffer if successful
-bool image_indexed_ensure_8bpp(vector<unsigned char> & src_image_data, int width, int height, int bitdepth, int colortype) {
+bool image_indexed_ensure_8bpp(vector<uint8_t> & src_image_data, int width, int height, int bitdepth, int colortype) {
 
-    vector<unsigned char> unpacked_image_data;
-
-    // For debug
-    // printf("colortype = %d, bitdepth = %d\n", colortype, bitdepth);
+    vector<uint8_t> unpacked_image_data;
 
     if (colortype != LCT_PALETTE) {
         printf("png2asset: Error: keep_palette_order only works with indexed png images");
@@ -49,14 +48,13 @@ bool image_indexed_ensure_8bpp(vector<unsigned char> & src_image_data, int width
         return false;
     }
 
-    image_unbitpack(src_image_data, unpacked_image_data, bitdepth);
+    image_bitunpack(src_image_data, unpacked_image_data, bitdepth);
 
     // Replace source image pixel data with unpacked pixels
     src_image_data.clear();
-    for (vector<unsigned char>::iterator it_unpacked = unpacked_image_data.begin(); it_unpacked != unpacked_image_data.end(); it_unpacked++)
-        src_image_data.push_back((unsigned char)*it_unpacked);
+    for (const uint8_t & it_unpacked: unpacked_image_data)
+        src_image_data.push_back(it_unpacked);
 
     return true;
 }
-
 

--- a/gbdk-support/png2asset/image_utils.cpp
+++ b/gbdk-support/png2asset/image_utils.cpp
@@ -8,6 +8,7 @@
 
 using namespace std;
 
+#include "png2asset.h"
 #include "image_utils.h"
 
 static void image_bitunpack(const vector<uint8_t> & src_image_data, vector<uint8_t> & unpacked_image_data, uint8_t bitdepth);
@@ -39,7 +40,8 @@ bool image_indexed_ensure_8bpp(vector<uint8_t> & src_image_data, int width, int 
     vector<uint8_t> unpacked_image_data;
 
     if (colortype != LCT_PALETTE) {
-        printf("png2asset: Error: keep_palette_order only works with indexed png images");
+        printf("png2asset: Error: keep_palette_order only works with indexed png images (pngtype: %d, bits:%d)\n",
+               colortype, bitdepth);
         return false;
     }
     else if ((bitdepth < 1) || (bitdepth > 8)) {
@@ -56,5 +58,133 @@ bool image_indexed_ensure_8bpp(vector<uint8_t> & src_image_data, int width, int 
         src_image_data.push_back(it_unpacked);
 
     return true;
+}
+
+
+
+
+// Returns the sub-palette number for a pixel in a indexed 8bpp image
+static int pixel_get_palette_num(const PNGImage& image, int x, int y) {
+
+    return image.data[(y * image.w) + x] / image.colors_per_pal;
+}
+
+
+// Verifies that a tile uses only colors within it's sub-palette in a indexed 8bpp image
+static bool tile_palette_is_ok(const PNGImage& image, int x, int y, int tile_w, int tile_h) {
+
+    // Get palette from first pixel in tile, use that as reference
+    int prev_palette_num = pixel_get_palette_num(image, x, y);
+
+    for (int tile_y = 0; tile_y < tile_h; tile_y++) {
+        for (int tile_x = 0; tile_x < tile_w; tile_x++) {
+
+            // If any pixels have a different palette than it's a failure
+            if (prev_palette_num != pixel_get_palette_num(image, x + tile_x, y + tile_y)) {
+                return false; // Return failure
+            }
+        }
+    }
+    return true; // Return success
+}
+
+
+// Finds a matching sub-palette RGB color for a pixel in a indexed 8bpp image
+// static int pixel_find_color_in_palette(const PNGImage& image, int x, int y, int pal_num) {
+static int pixel_find_color_in_palette(const PNGImage& image, int x, int y, int pal_num, uint8_t * match_color_idx) {
+
+    // Get pixel palette index num, then get RGB value for it
+    uint8_t pixel_pal_idx = image.data[(y * image.w) + x];
+    uint8_t * p_pixel_color = &image.palette[pixel_pal_idx * RGBA32_SZ];
+
+    // Loop through available palette colors to see if an exact match exists
+    uint8_t * p_pal_color = &image.palette[pal_num * (image.colors_per_pal * RGBA32_SZ)];
+    for (int c = 0; c < (int)image.colors_per_pal; c++, p_pal_color += RGBA32_SZ) {
+
+        // Check palette entry RGB match against pixel RGB
+        if ((p_pal_color[0] == p_pixel_color[0]) &&
+            (p_pal_color[1] == p_pixel_color[1]) &&
+            (p_pal_color[2] == p_pixel_color[2])) {
+
+            *match_color_idx = (pal_num * (int)image.colors_per_pal) + c;
+            return true; // Return success
+        }
+    }
+
+    return false; // Return failure
+}
+
+
+static bool tile_palette_repair(PNGImage& image, int x, int y, int tile_w, int tile_h) {
+
+    bool match_failed;
+    uint8_t new_color;
+
+    // Loop through all sub-palettes
+    for (int pal = 0; pal < (int)image.total_color_count / (int)image.colors_per_pal; pal++) {
+
+        // For each pixel in the tile, try to find an exact color match in the palette
+        match_failed = false;
+// TODO: could this be a loop ... continue; instead?
+        for (int tile_y = 0; tile_y < tile_h; tile_y++) {
+            for (int tile_x = 0; tile_x < tile_w; tile_x++) {
+
+                // Update pixel if exact match was found
+                // TODO: count number of matches to use for optional "force best palette"
+                if (pixel_find_color_in_palette(image, x + tile_x, y + tile_y, pal, &new_color))
+                    image.data[((y + tile_y) * image.w) + x + tile_x] = new_color;
+                else
+                    match_failed = true;
+// TODO: make this skip out of loop sooner
+            }
+        }
+
+        // Quit as soon as a perfect palette match is found
+        if (!match_failed) {
+            printf("  + png2asset: Info: repaired tile at %d x %d to palette %d\n", x, y, pal);
+            return true;
+        }
+    }
+
+    printf("png2asset: Error: tile (%dx%d) at %d,%d - %d,%d uses unique colors from different palettes, "
+           "cannot repair palette\n", x / tile_w, y / tile_h, x, y, x + tile_w - 1, y + tile_h - 1);
+    // If not exact palette match was found then signal failure
+    return false;
+}
+
+
+// Tries to repair indexed color sub-palette usage per attribute tile region
+// Must find a palette that contains all colors in tile, fails otherwise
+//
+// Image passed in must be: indexed 8bpp
+bool image_indexed_repair_tile_palettes(PNGImage & image, bool use_2x2_map_attributes) {
+
+    // TODO: Optional, but need to pass in vars
+    // if ((colortype != LCT_PALETTE) || (bitdepth != 8)) {
+    //     printf("png2asset: Error: repair_tile_palettes only works with indexed png images in 8 bits per pixel mode");
+    //     return false;
+    // }
+
+    int tile_w = image.tile_w;
+    int tile_h = image.tile_h;
+
+    if (use_2x2_map_attributes) {
+        tile_w *= 2;
+        tile_h *= 2;
+    }
+
+    for (int y = 0; y < (int)image.h; y += tile_h) {
+        for (int x = 0; x < (int)image.w; x += tile_w) {
+            // If tile has no palette errors leave it as is
+            // but if there are errors then try to repair it
+            if (!tile_palette_is_ok(image, x, y, tile_w, tile_h)) {
+                if (!tile_palette_repair(image, x, y, tile_w, tile_h)) {
+                    return false; // Return Failure
+                }
+            }
+        }
+    }
+
+    return true; // Return success
 }
 

--- a/gbdk-support/png2asset/image_utils.h
+++ b/gbdk-support/png2asset/image_utils.h
@@ -1,0 +1,7 @@
+// image_utils.h
+
+#include <vector>
+
+using namespace std;
+
+bool image_indexed_ensure_8bpp(vector <unsigned char> &data, int width, int height, int bitdepth, int colortype);

--- a/gbdk-support/png2asset/image_utils.h
+++ b/gbdk-support/png2asset/image_utils.h
@@ -6,5 +6,6 @@
 #include <vector>
 
 bool image_indexed_ensure_8bpp(vector <unsigned char> &data, int width, int height, int bitdepth, int colortype);
+bool image_indexed_repair_tile_palettes(PNGImage & image, bool use_2x2_map_attributes);
 
 #endif

--- a/gbdk-support/png2asset/image_utils.h
+++ b/gbdk-support/png2asset/image_utils.h
@@ -1,7 +1,10 @@
 // image_utils.h
 
+#ifndef _IMAGE_UTILS_H
+#define _IMAGE_UTILS_H
+
 #include <vector>
 
-using namespace std;
-
 bool image_indexed_ensure_8bpp(vector <unsigned char> &data, int width, int height, int bitdepth, int colortype);
+
+#endif

--- a/gbdk-support/png2asset/png2asset.h
+++ b/gbdk-support/png2asset/png2asset.h
@@ -1,6 +1,7 @@
 #ifndef _PNG2ASSET_H
 #define _PNG2ASSET_H
 
+#define RGBA32_SZ 4 // RGBA 8:8:8:8 is 4 bytes per pixel
 
 enum {
     SPR_NONE,
@@ -96,6 +97,12 @@ struct PNGImage
     // Default tile size
     int tile_w = 8;
     int tile_h = 16;
+
+    // TODO: embed these instead of deriving them many places in the code
+    // int attribute_w_factor = 1;
+    // int attribute_h_factor = 1;
+    // int get_attribute_tile_w() { tile_w * attribute_w_factor; }
+    // int get_attribute_tile_h() { tile_h * attribute_h_factor; }
 
     size_t colors_per_pal;  // Number of colors per palette (ex: CGB has 4 colors per palette x 8 palettes total)
     size_t total_color_count; // Total number of colors across all palettes (palette_count x colors_per_pal)

--- a/gbdk-support/png2asset/png2asset.h
+++ b/gbdk-support/png2asset/png2asset.h
@@ -1,0 +1,162 @@
+#ifndef _PNG2ASSET_H
+#define _PNG2ASSET_H
+
+
+enum {
+    SPR_NONE,
+    SPR_8x8,
+    SPR_8x16,
+    SPR_16x16_MSX
+};
+
+#define BIT(VALUE, INDEX) (1 & ((VALUE) >> (INDEX)))
+
+struct Tile
+{
+    vector< unsigned char > data;
+    unsigned char pal;
+
+    Tile(size_t size = 0) : data(size), pal(0) {}
+    bool operator==(const Tile& t) const
+    {
+        return data == t.data && pal == t.pal;
+    }
+
+    const Tile& operator=(const Tile& t)
+    {
+        data = t.data;
+        pal = t.pal;
+        return *this;
+    }
+
+    enum PackMode {
+        GB,
+        SGB,
+        SMS,
+        BPP1
+    };
+
+    vector< unsigned char > GetPackedData(PackMode pack_mode, int tile_w, int tile_h, int bpp) {
+        vector< unsigned char > ret((tile_w / 8) * tile_h * bpp, 0);
+        if(pack_mode == GB) {
+            for(int j = 0; j < tile_h; ++j) {
+                for(int i = 0; i < 8; ++ i) {
+                    unsigned char col = data[8 * j + i];
+                    ret[j * 2    ] |= BIT(col, 0) << (7 - i);
+                    ret[j * 2 + 1] |= BIT(col, 1) << (7 - i);
+                }
+            }
+        }
+        else if(pack_mode == SGB)
+        {
+            for(int j = 0; j < tile_h; ++j) {
+                for(int i = 0; i < 8; ++ i) {
+                    unsigned char col = data[8 * j + i];
+                    ret[j * 2    ] |= BIT(col, 0) << (7 - i);
+                    ret[j * 2 + 1] |= BIT(col, 1) << (7 - i);
+                    ret[(tile_h + j) * 2    ] |= BIT(col, 2) << (7 - i);
+                    ret[(tile_h + j) * 2 + 1] |= BIT(col, 3) << (7 - i);
+                }
+            }
+        }
+        else if(pack_mode == SMS)
+        {
+            for(int j = 0; j < tile_h; ++j) {
+                for(int i = 0; i < 8; ++ i) {
+                    unsigned char col = data[8 * j + i];
+                    ret[j * 4    ] |= BIT(col, 0) << (7 - i);
+                    ret[j * 4 + 1] |= BIT(col, 1) << (7 - i);
+                    ret[j * 4 + 2] |= BIT(col, 2) << (7 - i);
+                    ret[j * 4 + 3] |= BIT(col, 3) << (7 - i);
+                }
+            }
+        }
+        else if(pack_mode == BPP1)
+        {
+            // Packs 8 pixel wide rows in order set by ExtractTile**()
+            // Process all rows of pixels in the tile
+            for(int j = 0; j < ((tile_w / 8) * tile_h); j++) {
+                // Pack each row of 8 pixels into one byte
+                for(int i = 0; i < 8; i++) {
+                    unsigned char col = data[8 * j + i];
+                    ret[j] |= BIT(col, 0) << (7 - i);
+                }
+            }
+        }
+        return ret;
+    }
+};
+
+struct PNGImage
+{
+    vector< unsigned char > data; //data in indexed format
+    unsigned int w;
+    unsigned int h;
+
+    // Default tile size
+    int tile_w = 8;
+    int tile_h = 16;
+
+    size_t colors_per_pal;  // Number of colors per palette (ex: CGB has 4 colors per palette x 8 palettes total)
+    size_t total_color_count; // Total number of colors across all palettes (palette_count x colors_per_pal)
+    unsigned char* palette; //palette colors in RGBA (1 color == 4 bytes)
+
+private:
+    bool zero_palette = false;
+
+public:
+    unsigned char GetGBColor(int x, int y)
+    {
+        return data[w * y + x] % colors_per_pal;
+    }
+
+
+    // This needs separate tile_w and tile_h params since
+    // MSX tile extraction uses it to pull out the 4 sub-tiles
+    bool ExtractGBTile(int x, int y, int extract_tile_w, int extract_tile_h, Tile& tile, int buffer_offset)
+    {
+        // Set the palette to 0 when pals are not stored in tiles to allow tiles to be equal even when their palettes are different
+        tile.pal = zero_palette ? 0 : data[w * y + x] >> 2;
+
+        bool all_zero = true;
+        for(int j = 0; j < extract_tile_h; ++ j)
+        {
+            for(int i = 0; i < extract_tile_w; ++i)
+            {
+                unsigned char color_idx = GetGBColor(x + i, y + j);
+                tile.data[(j * extract_tile_w) + i + buffer_offset] = color_idx;
+                all_zero = all_zero && (color_idx == 0);
+            }
+        }
+        return !all_zero;
+    }
+
+    bool ExtractTile_MSX16x16(int x, int y, Tile& tile)
+    {
+        // MSX 16x16 sprite tiles are composed of four 8x8 tiles in this order UL, LL, UR, LR
+        bool UL_notempty, LL_notempty, UR_notempty, LR_notempty;
+
+        // Call these separately since otherwise some get optimized out during
+        // runtime if any single one before it returns false
+        UL_notempty = ExtractGBTile(x,     y,     8, 8, tile, 0);
+        LL_notempty = ExtractGBTile(x,     y + 8, 8, 8, tile, ((8 *8) * 1));
+        UR_notempty = ExtractGBTile(x + 8, y,     8, 8, tile, ((8 *8) * 2));
+        LR_notempty = ExtractGBTile(x + 8, y + 8, 8, 8, tile, ((8 *8) * 3));
+        return (UL_notempty || LL_notempty || UR_notempty || LR_notempty);
+    }
+
+    bool ExtractTile(int x, int y, Tile& tile, int sprite_mode, bool export_as_map, bool use_map_attributes)
+    {
+        // Set the palette to 0 when pals are not stored in tiles to allow tiles to be equal even when their palettes are different
+        zero_palette = !(export_as_map && !use_map_attributes);
+
+        if (sprite_mode == SPR_16x16_MSX)
+            return ExtractTile_MSX16x16(x, y, tile);
+        else
+            return ExtractGBTile(x, y, tile_w, tile_h, tile, 0); // No buffer offset for normal tile extraction
+    }
+// private:
+//     bool zero_palette = false;
+};
+
+#endif


### PR DESCRIPTION
**Fix bit packed indexed pngs bit with less than 8 bits**
- Turn off lodepng conversion when indexed bpp is less than 8
- lodepng was modifying the pixel palette color values when unpacking indexed color images with less than 8 bits per pixel
- Fix the issue by manually unpacking to the expected indexed 8bpp
 - See this earlier commit which tried to solve a related issue the easy way, which didn't end up working with lodepng https://github.com/gbdk-2020/gbdk-2020/commit/dbf093fdb1ee154714ef5e0812fbdadfd96ce589

**Repair Indexed Pal**
- Requires -keep_palette_order to be in use
- Tries to repair tile palettes for indexed color images
- Leaves tiles alone if they have no palette errors
- Errors out if it cannot find a palette which matches all colors in a tile

Might consider another mode where it can force the best palette on a tile even if it has colors not found in that palette