### PR TITLE
NES: Fix PPU register definitions

### DIFF
--- a/gbdk-lib/include/nes/hardware.h
+++ b/gbdk-lib/include/nes/hardware.h
@@ -7,19 +7,19 @@
 
 #include <types.h>
 
-#define __BYTES extern UBYTE
-#define __BYTE_REG extern volatile UBYTE
+#define __SHADOW_REG extern volatile uint8_t
+#define __REG(addr) volatile __at (addr) uint8_t
 
-#define PPUCTRL     ((uint8_t*)0x2000);
+__REG(0x2000) PPUCTRL;
 #define PPUCTRL_NMI         0b10000000
 #define PPUCTRL_SPR_8X8     0b00000000
 #define PPUCTRL_SPR_8X16    0b00100000
 #define PPUCTRL_BG_CHR      0b00010000
 #define PPUCTRL_SPR_CHR     0b00001000
 #define PPUCTRL_INC32       0b00000100
-extern volatile UBYTE shadow_PPUCTRL;
+__SHADOW_REG shadow_PPUCTRL;
 
-#define PPUMASK     ((uint8_t*)0x2001);
+__REG(0x2001) PPUMASK;
 #define PPUMASK_BLUE        0b10000000
 #define PPUMASK_RED         0b01000000
 #define PPUMASK_GREEN       0b00100000
@@ -28,15 +28,15 @@ extern volatile UBYTE shadow_PPUCTRL;
 #define PPUMASK_SHOW_SPR_LC 0b00000100
 #define PPUMASK_SHOW_BG_LC  0b00000010
 #define PPUMASK_MONOCHROME  0b00000001
-extern volatile UBYTE shadow_PPUMASK;
+__SHADOW_REG shadow_PPUMASK;
 
-#define PPUSTATUS   ((uint8_t*)0x2002);
-#define OAMADDR     ((uint8_t*)0x2003);
-#define OAMDATA     ((uint8_t*)0x2004);
-#define PPUSCROLL   ((uint8_t*)0x2005);
-#define PPUADDR     ((uint8_t*)0x2006);
-#define PPUDATA     ((uint8_t*)0x2007);
-#define OAMDMA      ((uint8_t*)0x4014);
+__REG(0x2002) PPUSTATUS;
+__REG(0x2003) OAMADDR;
+__REG(0x2004) OAMDATA;
+__REG(0x2005) PPUSCROLL;
+__REG(0x2006) PPUADDR;
+__REG(0x2007) PPUDATA;
+__REG(0x4014) OAMDMA;
 
 #define DEVICE_SCREEN_X_OFFSET 0
 #define DEVICE_SCREEN_Y_OFFSET 0
@@ -53,7 +53,7 @@ extern volatile UBYTE shadow_PPUMASK;
 #define DEVICE_SCREEN_PX_HEIGHT (DEVICE_SCREEN_HEIGHT * 8)
 
 // Scrolling coordinates (will be written to PPUSCROLL at end-of-vblank by NMI handler)
-extern volatile UBYTE bkg_scroll_x;
-extern volatile UBYTE bkg_scroll_y;
+__SHADOW_REG bkg_scroll_x;
+__SHADOW_REG bkg_scroll_y;
 
 #endif


### PR DESCRIPTION
* Change defines in hardware.h to use volatile __at(addr) for regs, and extern volatile for shadow regs