### PR TITLE
Docs: 4.2

### DIFF
--- a/docs/pages/09_migrating_new_versions.md
+++ b/docs/pages/09_migrating_new_versions.md
@@ -6,7 +6,13 @@ This section contains information that may be useful to know or important when u
 
 ## Porting to GBDK-2020 4.2
   - GBDK now requires SDCC 4.3 or higher with GBDK-2020 patches for the the z80 linker
-  - wait_vbl_done() has been renamed to vsync(). The old name will continue to work for the time being, but migration to the new name is strongly encouraged.
+  - The following new functions replace old ones. The old functions will continue to work for now, but migration to new versions is strongly encouraged.
+    - vsync(): replaces wait_vbl_done()
+    - set_default_palette(): replaces cgb_compatibility()
+    - move_metasprite_flipy(): replaces move_metasprite_hflip()
+    - move_metasprite_flipx(): replaces move_metasprite_vflip()
+    - move_metasprite_flipxy(): replaces move_metasprite_hvflip()
+    - move_metasprite_ex(): replaces move_metasprite()
 
 ## Porting to GBDK-2020 4.1.1
   - No significant changes required

--- a/docs/pages/10_release_notes.md
+++ b/docs/pages/10_release_notes.md
@@ -9,10 +9,34 @@ https://github.com/gbdk-2020/gbdk-2020/releases
 ## GBDK-2020 4.2
   2023/x
   - Library
-    - wait_vbl_done() has been renamed to vsync(). The old name will continue to work for the time being, but migration to the new name is strongly encouraged.
     - Added: set_bkg_attributes(), set_bkg_submap_attributes()
+    - The following new functions replace old ones. The old functions will continue to work for now, but migration to new versions is strongly encouraged.
+      - vsync(): replaces wait_vbl_done()
+      - set_default_palette(): replaces cgb_compatibility()
+    - metasprites: added metasprite functions which can set base sprite property parameter (`__current_base_prop`) for GB/GBC and NES
+      - move_metasprite_flipy(): replaces move_metasprite_hflip()
+      - move_metasprite_flipx(): replaces move_metasprite_vflip()
+      - move_metasprite_flipxy(): replaces move_metasprite_hvflip()
+      - move_metasprite_ex(): (replaces move_metasprite()
+    - GB: faster vmemcpy(), set_data(), get_data()
+    - Refactored interrupts to use less space
+  - Toolchain / Utilities
+    - @ref lcc "lcc": fix for `--sdccbindir`
+    - @ref utility_png2asset "png2asset"
+      - Added `-repair_index_pal`: Tries to repair tile palettes for indexed color pngs (such as when RGB paint programs mix up indexed colors if the same color exists in multiple palettes). Implies `-keep_palette_order`.
+      - Fixed support for indexed color pngs with less than 8 bits color depth
+      - Fixed incorrect palettes when different colors have same luma value (use RGB values as less-significant bits)
+      - Changed to use cross-platform constants for metasprite properties (S_FLIPX, S_FLIPY and S_PAL)
+  - Examples
+     - Sound Test: Added MegaDuck support
+     - Wav Playback: Improved support on AGB/AGS hardware
+     - Metasprites: Added sub-palette switching for GBC and NES, software metasprite flipping for sms/gg
+     - Large Map: Added color for supported platforms
   - Docs:
-    - Expanded @ref megaduck_sound_register_value_changes "MegaDuck hardware documentation"
+    - Added @ref using_cgb_features "Using Game Boy Color Features"
+    - Added SDAS assembler manual (asmlnk_manual.txt)
+    - Updated @ref megaduck_sound_register_value_changes "MegaDuck hardware documentation"
+    - Added @ref banked_calling_convention "Banked Calling Convention"
 
 ## GBDK-2020 4.1.1
   2022/11
@@ -126,7 +150,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - Fixed CGB `...s_map_attributes` type definition in output
       - Fixed values for `num_palettes` in output
       - Fixed incorrect `TILE_COUNT` value when not `-using_structs`
-    - @ref lcc
+    - @ref lcc "lcc"
       - Changed @ref makebin flags to turn off Nintendo logo copy for GB/CGB (use version in crt instead)
       - Fixed lcc handling of makebin `-x*` arguments
   - Examples
@@ -182,7 +206,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - Added export as map: tileset + bg (`-map`)
       - Added option to use CGB BG Map attributes (`-use_map_attributes`)
       - Added option to group the exported info into structs (`-use_structs`)
-    - @ref lcc
+    - @ref lcc "lcc"
       - Use `-m` to select target port and platform: "-m[port]:[plat]" ports:`gbz80,z80` plats:`ap,gb,sms,gg`
       - Changed default output format when not specified from `.ihx` to `.gb` (or other active rom extension)
       - Changed lcc to always use the linkerfile `-lkout=` option when calling bankpack

--- a/gbdk-lib/include/gb/cgb.h
+++ b/gbdk-lib/include/gb/cgb.h
@@ -183,7 +183,7 @@ void cpu_fast(void);
  */
 void set_default_palette(void);
 
-/** This function has been replaced by set_default_palette(), which has identical behavior.
+/** Obsolete. This function has been replaced by set_default_palette(), which has identical behavior.
  */
 void cgb_compatibility(void);
 

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -758,7 +758,7 @@ void reset(void);
 */
 void vsync(void) PRESERVES_REGS(b, c, d, e, h, l);
 
-/** This function has been replaced by vsync(), which has identical behavior.
+/** Obsolete. This function has been replaced by vsync(), which has identical behavior.
 
 */
 void wait_vbl_done(void) PRESERVES_REGS(b, c, d, e, h, l);

--- a/gbdk-lib/include/gb/hardware.h
+++ b/gbdk-lib/include/gb/hardware.h
@@ -292,11 +292,11 @@ __REG LYC_REG;          /**< LY compare */
 #define rLYC LYC_REG
 __REG DMA_REG;          /**< DMA transfer */
 #define rDMA DMA_REG
-__REG BGP_REG;          /**< Background palette data @see OBP0_REG, OBP1_REG, DMG_PALETTE, DMG_BLACK, DMG_DARK_GRAY, DMG_LITE_GRAY, DMG_WHITE */
+__REG BGP_REG;          /**< Set and Read the Background palette. \n \n Example with the DMG_PALETTE() helper function and constants: \n BGP_REG = DMG_PALETTE(DMG_BLACK, DMG_DARK_GRAY, DMG_LITE_GRAY, DMG_WHITE); */
 #define rBGP BGP_REG
-__REG OBP0_REG;         /**< OBJ (Sprite) palette 0 data @see OBP1_REG, BGP_REG, DMG_PALETTE, DMG_BLACK, DMG_DARK_GRAY, DMG_LITE_GRAY, DMG_WHITE */
+__REG OBP0_REG;         /**< Set and Read the OBJ (Sprite) palette 0. \n \n The first color entry is always transparent.  \n \n Example with the DMG_PALETTE() helper function and constants: \n OBP0_REG = DMG_PALETTE(DMG_BLACK, DMG_DARK_GRAY, DMG_LITE_GRAY, DMG_WHITE); */
 #define rOBP0 OBP0_REG
-__REG OBP1_REG;         /**< OBJ (Sprite) palette 1 data @see OBP0_REG, BGP_REG, DMG_PALETTE, DMG_BLACK, DMG_DARK_GRAY, DMG_LITE_GRAY, DMG_WHITE */
+__REG OBP1_REG;         /**< Set and Read the OBJ (Sprite) palette 1. \n \n The first color entry is always transparent.  \n \n Example with the DMG_PALETTE() helper function and constants: \n OBP1_REG = DMG_PALETTE(DMG_BLACK, DMG_DARK_GRAY, DMG_LITE_GRAY, DMG_WHITE); */
 #define rOBP1 OBP1_REG
 __REG WY_REG;           /**< Window Y coordinate */
 #define rWY WY_REG

--- a/gbdk-lib/include/gb/metasprites.h
+++ b/gbdk-lib/include/gb/metasprites.h
@@ -122,6 +122,7 @@ void hide_sprites_range(UINT8 from, UINT8 to);
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags (can be used to set palette, etc)
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
@@ -147,7 +148,7 @@ inline uint8_t move_metasprite_ex(const metasprite_t * metasprite, uint8_t base_
     return __move_metasprite(base_sprite, (y << 8) | (uint8_t)x);
 }
 
-/** Obsolete
+/** Obsolete. This function has been replaced by move_metasprite_ex()
 */
 inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
     __current_metasprite = metasprite;
@@ -156,15 +157,16 @@ inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_til
     return __move_metasprite(base_sprite, (y << 8) | (uint8_t)x);
 }
 
-/** Moves metasprite to the absolute position x and y, __flipped by X__
+/** Moves metasprite to the absolute position x and y, __flipped by X (horizontally)__
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags (can be used to set palette, etc)
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
-    Same as @ref move_metasprite(), but with the metasprite flipped by X.
+    Same as @ref move_metasprite(), but with the metasprite flipped by X (horizontally).
 
     Sets:
     \li __current_metasprite = metasprite;
@@ -186,7 +188,7 @@ inline uint8_t move_metasprite_flipx(const metasprite_t * metasprite, uint8_t ba
     return __move_metasprite_flipx(base_sprite, (y << 8) | (uint8_t)(x - 8u));
 }
 
-/** Obsolete
+/** Obsolete. This function has been replaced by move_metasprite_flipx()
 */
 inline uint8_t move_metasprite_vflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
     __current_metasprite = metasprite;
@@ -196,15 +198,16 @@ inline uint8_t move_metasprite_vflip(const metasprite_t * metasprite, uint8_t ba
 }
 
 
-/** Moves metasprite to the absolute position x and y, __flipped by Y__
+/** Moves metasprite to the absolute position x and y, __flipped by Y (vertically)__
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags (can be used to set palette, etc)
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
-    Same as @ref move_metasprite(), but with the metasprite flipped by Y.
+    Same as @ref move_metasprite(), but with the metasprite flipped by Y (vertically).
 
     Sets:
     \li __current_metasprite = metasprite;
@@ -226,7 +229,7 @@ inline uint8_t move_metasprite_flipy(const metasprite_t * metasprite, uint8_t ba
     return __move_metasprite_flipy(base_sprite, ((y - ((LCDC_REG & LCDCF_OBJ16) ? 16u : 8u)) << 8) | x);
 }
 
-/** Obsolete
+/** Obsolete. This function has been replaced by move_metasprite_flipy()
 */
 inline uint8_t move_metasprite_hflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
     __current_metasprite = metasprite;
@@ -235,15 +238,16 @@ inline uint8_t move_metasprite_hflip(const metasprite_t * metasprite, uint8_t ba
     return __move_metasprite_hflip(base_sprite, ((y - ((LCDC_REG & LCDCF_OBJ16) ? 16u : 8u)) << 8) | x);
 }
 
-/** Moves metasprite to the absolute position x and y, __flipped by X and Y__
+/** Moves metasprite to the absolute position x and y, __flipped by X and Y (horizontally and vertically)__
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags (can be used to set palette, etc)
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
-    Same as @ref move_metasprite(), but with the metasprite flipped by X and Y.
+    Same as @ref move_metasprite(), but with the metasprite flipped by X and Y (horizontally and vertically).
 
     Sets:
     \li __current_metasprite = metasprite;
@@ -265,7 +269,7 @@ inline uint8_t move_metasprite_flipxy(const metasprite_t * metasprite, uint8_t b
     return __move_metasprite_flipxy(base_sprite, ((y - ((LCDC_REG & LCDCF_OBJ16) ? 16u : 8u)) << 8) | (uint8_t)(x - 8));
 }
 
-/** Obsolete
+/** Obsolete. This function has been replaced by move_metasprite_flipxy()
 */
 inline uint8_t move_metasprite_hvflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
     __current_metasprite = metasprite;

--- a/gbdk-lib/include/msx/metasprites.h
+++ b/gbdk-lib/include/msx/metasprites.h
@@ -1,13 +1,13 @@
 /** @file sms/metasprites.h
-    
+
     # Metasprite support
 
-    A metasprite is a larger sprite made up from a 
+    A metasprite is a larger sprite made up from a
     collection of smaller individual hardware sprites.
     Different frames of the same metasprites can share
     tile data.
 
-    The api supports metasprites in both 
+    The api supports metasprites in both
     @ref SPRITES_8x8 and @ref SPRITES_8x16 mode. If
     8x16 mode is used then the height of the metasprite
     must be a multiple of 16.
@@ -57,7 +57,7 @@ typedef struct metasprite_t {
     uint8_t props;
 } metasprite_t;
 
-#define metasprite_end -128 
+#define metasprite_end -128
 #define METASPR_ITEM(dy,dx,dt,a) {(dy),(dx),(dt),(a)}
 #define METASPR_TERM {metasprite_end}
 
@@ -73,46 +73,47 @@ static void __hide_metasprite(uint8_t id) Z88DK_FASTCALL PRESERVES_REGS(iyh, iyl
  * Hides all hardware sprites in range from <= X < to
  * @param from start OAM index
  * @param to finish OAM index
- */ 
+ */
 void hide_sprites_range(UINT8 from, UINT8 to) Z88DK_CALLEE PRESERVES_REGS(iyh, iyl);
 
 /** Moves metasprite to the absolute position x and y
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
-    @param base_sprite  Number of the first hardware sprite to be used by the metasprite    
+    @param base_prop    Base sprite property flags (unused on this platform)
+    @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
     Moves __metasprite__ to the absolute position __x__ and __y__
-    (with __no flip__ on the X or Y axis). Hardware sprites are 
-    allocated starting from __base_sprite__, using tiles 
+    (with __no flip__ on the X or Y axis). Hardware sprites are
+    allocated starting from __base_sprite__, using tiles
     starting from __base_tile__.
 
     Sets:
-    \li __current_metasprite = metasprite; 
+    \li __current_metasprite = metasprite;
     \li __current_base_tile = base_tile;
 
     @return Number of hardware sprites used to draw this metasprite
  */
 inline uint8_t move_metasprite_ex(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, uint8_t x, uint8_t y) {
     base_prop;
-    __current_metasprite = metasprite; 
+    __current_metasprite = metasprite;
     __current_base_tile = base_tile;
-    return __move_metasprite(base_sprite, x, y); 
+    return __move_metasprite(base_sprite, x, y);
 }
 
 /** Obsolete
 */
 inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
-    __current_metasprite = metasprite; 
+    __current_metasprite = metasprite;
     __current_base_tile = base_tile;
-    return __move_metasprite(base_sprite, x, y); 
+    return __move_metasprite(base_sprite, x, y);
 }
 
 
 /** Hides a metasprite from the screen
- 
+
     @param metasprite    Pointer to first struct of the desired metasprite frame
     @param base_sprite   Number of hardware sprite to start with
 
@@ -121,7 +122,7 @@ inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_til
 
  **/
 inline void hide_metasprite(const metasprite_t * metasprite, uint8_t base_sprite) {
-    __current_metasprite = metasprite; 
+    __current_metasprite = metasprite;
     __hide_metasprite(base_sprite);
 }
 

--- a/gbdk-lib/include/msx/msx.h
+++ b/gbdk-lib/include/msx/msx.h
@@ -214,7 +214,7 @@ inline void scroll_bkg(int8_t x, int8_t y) {
 */
 void vsync(void) PRESERVES_REGS(b, c, d, e, h, l, iyh, iyl);
 
-/** This function has been replaced by vsync(), which has identical behavior.
+/** Obsolete. This function has been replaced by vsync(), which has identical behavior.
 */
 void wait_vbl_done(void) PRESERVES_REGS(b, c, d, e, h, l, iyh, iyl);
 

--- a/gbdk-lib/include/nes/metasprites.h
+++ b/gbdk-lib/include/nes/metasprites.h
@@ -111,6 +111,7 @@ void hide_sprites_range(UINT8 from, UINT8 to) OLDCALL;
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
@@ -137,7 +138,7 @@ inline uint8_t move_metasprite_ex(const metasprite_t * metasprite, uint8_t base_
     return __move_metasprite(base_sprite, x, y);
 }
 
-/** Obsolete
+/** Obsolete. Replaced by move_metasprite_ex()
 */
 inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, int16_t x, int16_t y) {
     __current_metasprite = metasprite;
@@ -146,15 +147,16 @@ inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_til
     return __move_metasprite(base_sprite, x, y);
 }
 
-/** Moves metasprite to the absolute position x and y, __flipped by X__
+/** Moves metasprite to the absolute position x and y, __flipped by X (horizontally)__
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
-    Same as @ref move_metasprite(), but with the metasprite flipped by X.
+    Same as @ref move_metasprite(), but with the metasprite flipped by X (horizontally).
 
     Sets:
     \li __current_metasprite = metasprite;
@@ -175,7 +177,7 @@ inline uint8_t move_metasprite_flipx(const metasprite_t * metasprite, uint8_t ba
     return __move_metasprite_flipx(base_sprite, x - 8, y);
 }
 
-/** Obsolete
+/** Obsolete. Replaced by move_metasprite_flipx()
 */
 inline uint8_t move_metasprite_vflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, int16_t x, int16_t y) {
     __current_metasprite = metasprite;
@@ -185,15 +187,16 @@ inline uint8_t move_metasprite_vflip(const metasprite_t * metasprite, uint8_t ba
 }
 
 
-/** Moves metasprite to the absolute position x and y, __flipped by Y__
+/** Moves metasprite to the absolute position x and y, __flipped by Y (vertically)__
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
-    Same as @ref move_metasprite(), but with the metasprite flipped by Y.
+    Same as @ref move_metasprite(), but with the metasprite flipped by Y (vertically).
 
     Sets:
     \li __current_metasprite = metasprite;
@@ -214,7 +217,7 @@ inline uint8_t move_metasprite_flipy(const metasprite_t * metasprite, uint8_t ba
     return __move_metasprite_flipy(base_sprite, x, y - ((shadow_PPUCTRL & PPUCTRL_SPR_8X16) ? 16 : 8) );
 }
 
-/** Obsolete
+/** Obsolete. Replaced by move_metasprite_flipy()
 */
 inline uint8_t move_metasprite_hflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, int16_t x, int16_t y) {
     __current_metasprite = metasprite;
@@ -223,15 +226,16 @@ inline uint8_t move_metasprite_hflip(const metasprite_t * metasprite, uint8_t ba
     return __move_metasprite_hflip(base_sprite, x, y - ((shadow_PPUCTRL & PPUCTRL_SPR_8X16) ? 16 : 8) );
 }
 
-/** Moves metasprite to the absolute position x and y, __flipped by X and Y__
+/** Moves metasprite to the absolute position x and y, __flipped by X and Y (horizontally and vertically)__
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
-    Same as @ref move_metasprite(), but with the metasprite flipped by X and Y.
+    Same as @ref move_metasprite(), but with the metasprite flipped by X and Y (horizontally and vertically).
 
     Sets:
     \li __current_metasprite = metasprite;
@@ -252,7 +256,7 @@ inline uint8_t move_metasprite_flipxy(const metasprite_t * metasprite, uint8_t b
     return __move_metasprite_flipxy(base_sprite, x - 8, y - ((shadow_PPUCTRL & PPUCTRL_SPR_8X16) ? 16 : 8));
 }
 
-/** Obsolete
+/** Obsolete. Replaced by move_metasprite_flipxy()
 */
 inline uint8_t move_metasprite_hvflip(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, int16_t x, int16_t y) {
     __current_metasprite = metasprite;

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -337,7 +337,7 @@ inline void disable_interrupts(void) {
 */
 void vsync(void);
 
-/** This function has been replaced by vsync(), which has identical behavior.
+/** Obsolete. This function has been replaced by vsync(), which has identical behavior.
 */
 void wait_vbl_done(void);
 
@@ -489,11 +489,11 @@ void set_bkg_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *ti
 
 /** Sets a rectangular region of Background Tile Map Attributes.
 
-    @param x      X Start position in Background Map tile coordinates. Range 0 - 15
-    @param y      Y Start position in Background Map tile coordinates. Range 0 - 14
-    @param w      Width of area to set in tiles. Range 1 - 16
-    @param h      Height of area to set in tiles. Range 1 - 15
-    @param tiles  Pointer to source tile map attribute data
+    @param x          X Start position in Background Map tile coordinates. Range 0 - 15
+    @param y          Y Start position in Background Map tile coordinates. Range 0 - 14
+    @param w          Width of area to set in tiles. Range 1 - 16
+    @param h          Height of area to set in tiles. Range 1 - 15
+    @param attributes Pointer to source tile map attribute data
 
     Entries are copied from map at __tiles__ to the Background Tile Map starting at
     __x__, __y__ writing across for __w__ tiles and down for __h__ tiles.

--- a/gbdk-lib/include/sms/metasprites.h
+++ b/gbdk-lib/include/sms/metasprites.h
@@ -1,13 +1,13 @@
 /** @file sms/metasprites.h
-    
+
     # Metasprite support
 
-    A metasprite is a larger sprite made up from a 
+    A metasprite is a larger sprite made up from a
     collection of smaller individual hardware sprites.
     Different frames of the same metasprites can share
     tile data.
 
-    The api supports metasprites in both 
+    The api supports metasprites in both
     @ref SPRITES_8x8 and @ref SPRITES_8x16 mode. If
     8x16 mode is used then the height of the metasprite
     must be a multiple of 16.
@@ -55,7 +55,7 @@ typedef struct metasprite_t {
     uint8_t dtile;
 } metasprite_t;
 
-#define metasprite_end -128 
+#define metasprite_end -128
 #define METASPR_ITEM(dy,dx,dt,a) {(dy),(dx),(dt)}
 #define METASPR_TERM {metasprite_end}
 
@@ -74,52 +74,54 @@ static void __hide_metasprite(uint8_t id) Z88DK_FASTCALL PRESERVES_REGS(iyh, iyl
  * Hides all hardware sprites in range from <= X < to
  * @param from start OAM index
  * @param to finish OAM index
- */ 
+ */
 void hide_sprites_range(UINT8 from, UINT8 to) Z88DK_CALLEE PRESERVES_REGS(iyh, iyl);
 
 /** Moves metasprite to the absolute position x and y
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
-    @param base_sprite  Number of the first hardware sprite to be used by the metasprite    
+    @param base_prop    Base sprite property flags (unused on this platform)
+    @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
     Moves __metasprite__ to the absolute position __x__ and __y__
-    (with __no flip__ on the X or Y axis). Hardware sprites are 
-    allocated starting from __base_sprite__, using tiles 
+    (with __no flip__ on the X or Y axis). Hardware sprites are
+    allocated starting from __base_sprite__, using tiles
     starting from __base_tile__.
 
     Sets:
-    \li __current_metasprite = metasprite; 
+    \li __current_metasprite = metasprite;
     \li __current_base_tile = base_tile;
 
     @return Number of hardware sprites used to draw this metasprite
 */
 inline uint8_t move_metasprite_ex(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_prop, uint8_t base_sprite, uint8_t x, uint8_t y) {
     base_prop;
-    __current_metasprite = metasprite; 
+    __current_metasprite = metasprite;
     __current_base_tile = base_tile;
-    return __move_metasprite(base_sprite, x, y); 
+    return __move_metasprite(base_sprite, x, y);
 }
 
-/** Obsolete
+/** Obsolete. This function has been replaced by move_metasprite_ex()
 */
 inline uint8_t move_metasprite(const metasprite_t * metasprite, uint8_t base_tile, uint8_t base_sprite, uint8_t x, uint8_t y) {
-    __current_metasprite = metasprite; 
+    __current_metasprite = metasprite;
     __current_base_tile = base_tile;
-    return __move_metasprite(base_sprite, x, y); 
+    return __move_metasprite(base_sprite, x, y);
 }
 
-/** Moves metasprite to the absolute position x and y, __flipped by X__
+/** Moves metasprite to the absolute position x and y, __flipped by X (horizontally)__
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags (unused on this platform)
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
-    Same as @ref move_metasprite(), but with the metasprite flipped by X.
+    Same as @ref move_metasprite(), but with the metasprite flipped by X (horizontally).
 
     Sets:
     \li __current_metasprite = metasprite;
@@ -139,15 +141,16 @@ inline uint8_t move_metasprite_flipx(const metasprite_t * metasprite, uint8_t ba
     return __move_metasprite_flipx(base_sprite, x - 8, y);
 }
 
-/** Moves metasprite to the absolute position x and y, __flipped by Y__
+/** Moves metasprite to the absolute position x and y, __flipped by Y (vertically)__
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags (unused on this platform)
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
-    Same as @ref move_metasprite(), but with the metasprite flipped by Y.
+    Same as @ref move_metasprite(), but with the metasprite flipped by Y (vertically).
 
     Sets:
     \li __current_metasprite = metasprite;
@@ -167,15 +170,16 @@ inline uint8_t move_metasprite_flipy(const metasprite_t * metasprite, uint8_t ba
     return __move_metasprite_flipy(base_sprite, x, y - ((__READ_VDP_REG(VDP_R1) & R1_SPR_8X16) ? 16 : 8) );
 }
 
-/** Moves metasprite to the absolute position x and y, __flipped by X and Y__
+/** Moves metasprite to the absolute position x and y, __flipped by X and Y (horizontally and vertically)__
 
     @param metasprite   Pointer to the first struct of the metasprite (for the desired frame)
     @param base_tile    Number of the first tile where the metasprite's tiles start
+    @param base_prop    Base sprite property flags (unused on this platform)
     @param base_sprite  Number of the first hardware sprite to be used by the metasprite
     @param x            Absolute x coordinate of the sprite
     @param y            Absolute y coordinate of the sprite
 
-    Same as @ref move_metasprite(), but with the metasprite flipped by X and Y.
+    Same as @ref move_metasprite(), but with the metasprite flipped by X and Y (horizontally and vertically).
 
     Sets:
     \li __current_metasprite = metasprite;
@@ -196,7 +200,7 @@ inline uint8_t move_metasprite_flipxy(const metasprite_t * metasprite, uint8_t b
 }
 
 /** Hides a metasprite from the screen
- 
+
     @param metasprite    Pointer to first struct of the desired metasprite frame
     @param base_sprite   Number of hardware sprite to start with
 
@@ -205,7 +209,7 @@ inline uint8_t move_metasprite_flipxy(const metasprite_t * metasprite, uint8_t b
 
  **/
 inline void hide_metasprite(const metasprite_t * metasprite, uint8_t base_sprite) {
-    __current_metasprite = metasprite; 
+    __current_metasprite = metasprite;
     __hide_metasprite(base_sprite);
 }
 

--- a/gbdk-lib/include/sms/sms.h
+++ b/gbdk-lib/include/sms/sms.h
@@ -218,7 +218,7 @@ inline void scroll_bkg(int8_t x, int8_t y) {
 */
 void vsync(void) PRESERVES_REGS(b, c, d, e, h, l, iyh, iyl);
 
-/** This function has been replaced by vsync(), which has identical behavior.
+/** Obsolete. This function has been replaced by vsync(), which has identical behavior.
 */
 void wait_vbl_done(void) PRESERVES_REGS(b, c, d, e, h, l, iyh, iyl);
 


### PR DESCRIPTION
- More details for for new metasprite functions
- More details for BGP/OBP0/OBP1
- Remove some trailing spaces in metasprite headers
- Re-add Obsolete keyword to pre-deprecated functions
- Entries for release notes, migration notes