### PR TITLE
Update 01_getting_started.md for macOS users

### DIFF
--- a/docs/pages/01_getting_started.md
+++ b/docs/pages/01_getting_started.md
@@ -31,12 +31,14 @@ Navigate to the example projects folder (`"examples/gb/"` under your GBDK-2020 i
 
 This should build all of the examples sequentially. You can also navigate into an individual example project's folder and build it by typing `make`.
 
-If you get a security warning about unsigned binaries on macOS, you will need to unquarrantine the files in the bin folder. You can do this by running:
+@anchor macos_unsigned_security_workaround
+### macOS security warnings
+If you get a security warning about unsigned binaries on macOS, you will need to unquarrantine the files in the bin folder. This can be fixed using the following steps.
 
-```bash
-cd $GBDKDIR
-xattr -d com.apple.quarantine bin/*
-```
+Open a terminal and navigate to the gbdk bin folder (`"bin/"` under your GBDK-2020 install folder). Then type:
+
+    xattr -d com.apple.quarantine *
+
 
 
 # 3. Use a Template

--- a/docs/pages/01_getting_started.md
+++ b/docs/pages/01_getting_started.md
@@ -24,12 +24,19 @@ or
 This should build the example project. You can also navigate into other example project folders and build in the same way.
 
 
-## Linux / MacOS / Windows with Make installed:
+## Linux / macOS / Windows with Make installed:
 Navigate to the example projects folder (`"examples/gb/"` under your GBDK-2020 install folder) and open a command line. Then type:
 
     make
 
 This should build all of the examples sequentially. You can also navigate into an individual example project's folder and build it by typing `make`.
+
+If you get a security warning about unsigned binaries on macOS, you will need to unquarrantine the files in the bin folder. You can do this by running:
+
+```bash
+cd $GBDKDIR
+xattr -d com.apple.quarantine bin/*
+```
 
 
 # 3. Use a Template


### PR DESCRIPTION
Add instructions how to un-quarantine unsigned binaries for macOS users. Also fixed `MacOS` -> `macOS` to match Apple styling / branding. 