### PR TITLE
Fix gbdk-lib-install-ports target dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ gbdk-lib-install: gbdk-lib-install-platforms
 gbdk-lib-install-prepare:
 	@rm -rf $(BUILDDIR)/lib
 
-gbdk-lib-install-ports:
+gbdk-lib-install-ports: gbdk-lib-build
 	@for port in $(PORTS); do \
 		echo Installing lib for port: $$port; \
 		mkdir -p $(BUILDDIR)/lib/$$port/; \


### PR DESCRIPTION
The gbdk-lib-install-ports has an unwritten dependency on the gbdk-lib-build target. the gbdk-lib-install-ports target fails if built before the gbdk-lib-build target. In a non-parallelized build, these two targets are built in the right order and the build works fine. In a parallelized build, a race condition causes the targets to build in the wrong order.