### PR TITLE
Examples: fix -p #514, some docs updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ endif
 # Turn on Latex -> PDF conversion to run run at end of regular docs build
 # (which includes latex output but deletes it at the end).
 #
-# The conversion process requires a Latex install. 
+# The conversion process requires a Latex install.
 # For Windows there are various Latex packages to choose from.
 # For Linux this appears to be the minimum:
 #   sudo apt install texlive-latex-base
@@ -393,7 +393,13 @@ ifneq (,$(wildcard $(BUILDDIR)/bin/))
 	echo \@anchor sdasz80-settings >> $(TOOLCHAIN_DOCS_FILE);
 	echo \# sdasz80 settings >> $(TOOLCHAIN_DOCS_FILE);
 	echo \`\`\` >> $(TOOLCHAIN_DOCS_FILE);
-	$(BUILDDIR)/bin/sdasgb -h >> $(TOOLCHAIN_DOCS_FILE) 2>&1 || true
+	$(BUILDDIR)/bin/sdasz80 -h >> $(TOOLCHAIN_DOCS_FILE) 2>&1 || true
+	echo \`\`\` >> $(TOOLCHAIN_DOCS_FILE);
+# sdas6500
+	echo \@anchor sdas6500-settings >> $(TOOLCHAIN_DOCS_FILE);
+	echo \# sdas6500 settings >> $(TOOLCHAIN_DOCS_FILE);
+	echo \`\`\` >> $(TOOLCHAIN_DOCS_FILE);
+	$(BUILDDIR)/bin/sdas6500 -h >> $(TOOLCHAIN_DOCS_FILE) 2>&1 || true
 	echo \`\`\` >> $(TOOLCHAIN_DOCS_FILE);
 # bankpack
 	echo \@anchor bankpack-settings >> $(TOOLCHAIN_DOCS_FILE);
@@ -410,6 +416,12 @@ ifneq (,$(wildcard $(BUILDDIR)/bin/))
 # sdldz80
 	echo \@anchor sdldz80-settings >> $(TOOLCHAIN_DOCS_FILE);
 	echo \# sdldz80 settings >> $(TOOLCHAIN_DOCS_FILE);
+	echo \`\`\` >> $(TOOLCHAIN_DOCS_FILE);
+	$(BUILDDIR)/bin/sdldgb >> $(TOOLCHAIN_DOCS_FILE) 2>&1 || true
+	echo \`\`\` >> $(TOOLCHAIN_DOCS_FILE);
+# sdld6808
+	echo \@anchor sdld6808-settings >> $(TOOLCHAIN_DOCS_FILE);
+	echo \# sdld6808 settings >> $(TOOLCHAIN_DOCS_FILE);
 	echo \`\`\` >> $(TOOLCHAIN_DOCS_FILE);
 	$(BUILDDIR)/bin/sdldgb >> $(TOOLCHAIN_DOCS_FILE) 2>&1 || true
 	echo \`\`\` >> $(TOOLCHAIN_DOCS_FILE);

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The sources in this repo are only needed if you want to re-compile GBDK-2020 you
 ## Current status
 - Updated CRT and library that suits better for game development
 - SDCC Versions
-  - Current GBDK-2020 versions require SDCC patches for z80 SMS/Game Gear support (only `sdldz80` in GBDK-2020 4.1.0). So SDCC nightlies/snapshot builds cannot be used if you want to target SMS/Game Gear. Instead use the [Patched SDCC Builds](https://github.com/gbdk-2020/gbdk-2020-sdcc/releases). 
+  - A [custom build of SDCC]([Patched SDCC Builds](https://github.com/gbdk-2020/gbdk-2020-sdcc/releases) with support for Sega GG/SMS and the Nintendo NES is used. See the [github workflow](https://github.com/gbdk-2020/gbdk-2020-sdcc/tree/main/.github/workflows) for details of how to patch and build SDCC.
   - The default calling convention changed in `SDCC 4.2`. This is supported starting with `GBDK-2020 4.1.0`. Older versions of GBDK should use SDCC builds #12539 or older (see per-version GBDK notes).
 - The compiler driver **lcc** supports the latest sdcc toolchain.
 

--- a/docs/pages/10_release_notes.md
+++ b/docs/pages/10_release_notes.md
@@ -8,6 +8,9 @@ https://github.com/gbdk-2020/gbdk-2020/releases
 
 ## GBDK-2020 4.2
   2023/x
+  - SDCC Compiler
+    - Updated to SDCC 14..TODO..
+    - ([Patched SDCC Builds](https://github.com/gbdk-2020/gbdk-2020-sdcc/releases) with support for Sega GG/SMS and the Nintendo NES are used. See the [github workflow](https://github.com/gbdk-2020/gbdk-2020-sdcc/tree/main/.github/workflows) for details
   - Library
     - Added: set_bkg_attributes(), set_bkg_submap_attributes()
     - The following new functions replace old ones. The old functions will continue to work for now, but migration to new versions is strongly encouraged.
@@ -24,7 +27,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - Increased sgb_transfer() maximum packet length to 7 x 16 bytes
       - Convert gb_decompress routines to the new calling convention
       - Convert rle_decompress routines to the new calling convention
-      - Removed legacy MBC register definitions `.MBC1_ROM_PAGE`  and `.MBC_ROM_PAGE`
+      - Removed legacy MBC register definitions `.MBC1_ROM_PAGE`  and `.MBC_ROM_PAGE`  
     - Refactored interrupts to use less space
   - Toolchain / Utilities
     - @ref lcc "lcc"
@@ -56,6 +59,8 @@ https://github.com/gbdk-2020/gbdk-2020/releases
 
 ## GBDK-2020 4.1.0
   2022/10
+  - Known Issues
+    - The `compile.bat` batch files for Windows use the an incalid `-p` option for `mkdir`
   - Building GBDK
     - The linux port of SDCC is custom built on Ubuntu 16.04 due to reduced GLIBC compatibility issues in more recent SDCC project builds.
     - Added Windows 32-Bit build

--- a/docs/pages/20_toolchain_settings.md
+++ b/docs/pages/20_toolchain_settings.md
@@ -43,7 +43,7 @@
 @anchor sdcc-settings
 # sdcc settings
 ```
-SDCC : z80/sm83/mos6502 TD- 4.2.14 #13911 (Linux)
+SDCC : z80/sm83/mos6502/mos65c02 TD- 4.2.14 #14088 (Linux)
 published under GNU General Public License (GPL)
 Usage : sdcc [options] filename
 Options :-
@@ -179,6 +179,11 @@ Special options for the mos6502 port:
       --model-small         8-bit address space for data
       --model-large         16-bit address space for data (default)
       --no-std-crt0         Do not link default crt0.rel
+
+Special options for the mos65c02 port:
+      --model-small         8-bit address space for data
+      --model-large         16-bit address space for data (default)
+      --no-std-crt0         Do not link default crt0.rel
 ```
 @anchor sdasgb-settings
 # sdasgb settings
@@ -229,7 +234,52 @@ Debugging:
 # sdasz80 settings
 ```
 
-sdas Assembler V02.00 + NoICE + SDCC mods  (GameBoy)
+sdas Assembler V02.00 + NoICE + SDCC mods  (Zilog Z80 / Hitachi HD64180 / ZX-Next / eZ80)
+
+
+Copyright (C) 2012  Alan R. Baldwin
+This program comes with ABSOLUTELY NO WARRANTY.
+
+Usage: [-Options] [-Option with arg] file
+Usage: [-Options] [-Option with arg] outfile file1 [file2 ...]
+  -h   or NO ARGUMENTS  Show this help list
+Input:
+  -I   Add the named directory to the include file
+       search path.  This option may be used more than once.
+       Directories are searched in the order given.
+Output:
+  -l   Create list   file/outfile[.lst]
+  -o   Create object file/outfile[.rel]
+  -s   Create symbol file/outfile[.sym]
+Listing:
+  -d   Decimal listing
+  -q   Octal   listing
+  -x   Hex     listing (default)
+  -b   Display .define substitutions in listing
+  -bb  and display without .define substitutions
+  -c   Disable instruction cycle count in listing
+  -f   Flag relocatable references by  `   in listing file
+  -ff  Flag relocatable references by mode in listing file
+  -p   Disable automatic listing pagination
+  -u   Disable .list/.nlist processing
+  -w   Wide listing format for symbol table
+Assembly:
+  -v   Enable out of range signed / unsigned errors
+Symbols:
+  -a   All user symbols made global
+  -g   Undefined symbols made global
+  -n   Don't resolve global assigned value symbols
+  -z   Disable case sensitivity for symbols
+Debugging:
+  -j   Enable NoICE Debug Symbols
+  -y   Enable SDCC  Debug Symbols
+
+```
+@anchor sdas6500-settings
+# sdas6500 settings
+```
+
+sdas Assembler V02.00 + NoICE + SDCC mods  (Rockwell 6502/6510/65C02)
 
 
 Copyright (C) 2012  Alan R. Baldwin
@@ -315,7 +365,7 @@ S ___bank_<const name> Def0000FF
 # sdldgb settings
 ```
 
-sdld Linker V03.00 + NoICE + sdld
+sdld Linker V03.00/V05.40 + sdld
 
 Usage: [-Options] [-Option with arg] file
 Usage: [-Options] [-Option with arg] outfile file1 [file2 ...]
@@ -331,6 +381,7 @@ Libraries:
 Relocation:
   -b   area base address = expression
   -g   global symbol = expression
+  -a   (platform) Select platform specific virtual address translation
 Map format:
   -m   Map output generated as (out)file[.map]
   -w   Wide listing format for map file
@@ -354,7 +405,7 @@ End:
 # sdldz80 settings
 ```
 
-sdld Linker V03.00 + NoICE + sdld
+sdld Linker V03.00/V05.40 + sdld
 
 Usage: [-Options] [-Option with arg] file
 Usage: [-Options] [-Option with arg] outfile file1 [file2 ...]
@@ -370,6 +421,47 @@ Libraries:
 Relocation:
   -b   area base address = expression
   -g   global symbol = expression
+  -a   (platform) Select platform specific virtual address translation
+Map format:
+  -m   Map output generated as (out)file[.map]
+  -w   Wide listing format for map file
+  -x   Hexadecimal (default)
+  -d   Decimal
+  -q   Octal
+Output:
+  -i   Intel Hex as (out)file[.ihx]
+  -s   Motorola S Record as (out)file[.s19]
+  -j   NoICE Debug output as (out)file[.noi]
+  -y   SDCDB Debug output as (out)file[.cdb]
+List:
+  -u   Update listing file(s) with link data as file(s)[.rst]
+Case Sensitivity:
+  -z   Disable Case Sensitivity for Symbols
+End:
+  -e   or null line terminates input
+
+```
+@anchor sdld6808-settings
+# sdld6808 settings
+```
+
+sdld Linker V03.00/V05.40 + sdld
+
+Usage: [-Options] [-Option with arg] file
+Usage: [-Options] [-Option with arg] outfile file1 [file2 ...]
+Startup:
+  -p   Echo commands to stdout (default)
+  -n   No echo of commands to stdout
+Alternates to Command Line Input:
+  -c                   ASlink >> prompt input
+  -f   file[.lk]       Command File input
+Libraries:
+  -k   Library path specification, one per -k
+  -l   Library file specification, one per -l
+Relocation:
+  -b   area base address = expression
+  -g   global symbol = expression
+  -a   (platform) Select platform specific virtual address translation
 Map format:
   -m   Map output generated as (out)file[.map]
   -w   Wide listing format for map file

--- a/gbdk-lib/examples/ap/bcd/Makefile
+++ b/gbdk-lib/examples/ap/bcd/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/colorbar/Makefile
+++ b/gbdk-lib/examples/ap/colorbar/Makefile
@@ -8,7 +8,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/ap/comm/Makefile
+++ b/gbdk-lib/examples/ap/comm/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/crash/Makefile
+++ b/gbdk-lib/examples/ap/crash/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/dscan/Makefile
+++ b/gbdk-lib/examples/ap/dscan/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/ap/emu_debug/Makefile
+++ b/gbdk-lib/examples/ap/emu_debug/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/filltest/Makefile
+++ b/gbdk-lib/examples/ap/filltest/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/galaxy/Makefile
+++ b/gbdk-lib/examples/ap/galaxy/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/gb-dtmf/Makefile
+++ b/gbdk-lib/examples/ap/gb-dtmf/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 %.s:	%.c
 	$(CC) -S -o $@ $<

--- a/gbdk-lib/examples/ap/gbdecompress/Makefile
+++ b/gbdk-lib/examples/ap/gbdecompress/Makefile
@@ -22,7 +22,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link all source files in a single call to LCC
 $(BINS): $(CSOURCES) $(ASMSOURCES)

--- a/gbdk-lib/examples/ap/irq/Makefile
+++ b/gbdk-lib/examples/ap/irq/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/large_map/Makefile
+++ b/gbdk-lib/examples/ap/large_map/Makefile
@@ -5,7 +5,7 @@ all:
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 clean:
 	rm -f *.o *.lst *.map *.pocket *.ihx *.sym *.cdb *.adb *.asm

--- a/gbdk-lib/examples/ap/lcd_isr_wobble/Makefile
+++ b/gbdk-lib/examples/ap/lcd_isr_wobble/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/linkerfile/Makefile
+++ b/gbdk-lib/examples/ap/linkerfile/Makefile
@@ -30,7 +30,7 @@ all:	prepare $(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/ap/paint/Makefile
+++ b/gbdk-lib/examples/ap/paint/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/ram_function/Makefile
+++ b/gbdk-lib/examples/ap/ram_function/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/ap/rand/Makefile
+++ b/gbdk-lib/examples/ap/rand/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/rpn/Makefile
+++ b/gbdk-lib/examples/ap/rpn/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/scroller/Makefile
+++ b/gbdk-lib/examples/ap/scroller/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/sgb_border/Makefile
+++ b/gbdk-lib/examples/ap/sgb_border/Makefile
@@ -5,7 +5,7 @@ all:
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 clean:
 	rm -f *.o *.lst *.map *.pocket *.ihx *.sym *.cdb *.adb *.asm

--- a/gbdk-lib/examples/ap/sgb_multiplayer/Makefile
+++ b/gbdk-lib/examples/ap/sgb_multiplayer/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/sound/Makefile
+++ b/gbdk-lib/examples/ap/sound/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.c

--- a/gbdk-lib/examples/ap/space/Makefile
+++ b/gbdk-lib/examples/ap/space/Makefile
@@ -7,7 +7,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.pocket:	%.s

--- a/gbdk-lib/examples/ap/template_minimal/Makefile
+++ b/gbdk-lib/examples/ap/template_minimal/Makefile
@@ -22,7 +22,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link all source files in a single call to LCC
 $(BINS):	$(CSOURCES) $(ASMSOURCES)

--- a/gbdk-lib/examples/ap/template_subfolders/Makefile
+++ b/gbdk-lib/examples/ap/template_subfolders/Makefile
@@ -29,7 +29,7 @@ all:	prepare $(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/gb/apa_image/Makefile
+++ b/gbdk-lib/examples/gb/apa_image/Makefile
@@ -45,7 +45,7 @@ all: $(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Use png2asset to convert the png into C formatted metasprite data
 # -keep_duplicate_tiles   : Don't remove duplicate tiles

--- a/gbdk-lib/examples/gb/banks/Makefile
+++ b/gbdk-lib/examples/gb/banks/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/gb/bcd/Makefile
+++ b/gbdk-lib/examples/gb/bcd/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/colorbar/Makefile
+++ b/gbdk-lib/examples/gb/colorbar/Makefile
@@ -8,7 +8,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/gb/comm/Makefile
+++ b/gbdk-lib/examples/gb/comm/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/crash/Makefile
+++ b/gbdk-lib/examples/gb/crash/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/dscan/Makefile
+++ b/gbdk-lib/examples/gb/dscan/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/gb/filltest/Makefile
+++ b/gbdk-lib/examples/gb/filltest/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/galaxy/Makefile
+++ b/gbdk-lib/examples/gb/galaxy/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/gb-dtmf/Makefile
+++ b/gbdk-lib/examples/gb/gb-dtmf/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 %.s:	%.c
 	$(CC) -S -o $@ $<

--- a/gbdk-lib/examples/gb/gbdecompress/Makefile
+++ b/gbdk-lib/examples/gb/gbdecompress/Makefile
@@ -22,7 +22,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link all source files in a single call to LCC
 $(BINS): $(CSOURCES) $(ASMSOURCES)

--- a/gbdk-lib/examples/gb/incbin/Makefile
+++ b/gbdk-lib/examples/gb/incbin/Makefile
@@ -28,7 +28,7 @@ all:	prepare $(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/gb/irq/Makefile
+++ b/gbdk-lib/examples/gb/irq/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/isr_vector/Makefile
+++ b/gbdk-lib/examples/gb/isr_vector/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/large_map/Makefile
+++ b/gbdk-lib/examples/gb/large_map/Makefile
@@ -5,7 +5,7 @@ all:
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 clean:
 	rm -f *.o *.lst *.map *.gb *.ihx *.sym *.cdb *.adb *.asm

--- a/gbdk-lib/examples/gb/lcd_isr_wobble/Makefile
+++ b/gbdk-lib/examples/gb/lcd_isr_wobble/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/linkerfile/Makefile
+++ b/gbdk-lib/examples/gb/linkerfile/Makefile
@@ -29,7 +29,7 @@ all:	prepare $(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/gb/paint/Makefile
+++ b/gbdk-lib/examples/gb/paint/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/ram_function/Makefile
+++ b/gbdk-lib/examples/gb/ram_function/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 %.o:	%.c
 	$(CC) -c -o $@ $<

--- a/gbdk-lib/examples/gb/rand/Makefile
+++ b/gbdk-lib/examples/gb/rand/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/rpn/Makefile
+++ b/gbdk-lib/examples/gb/rpn/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/scroller/Makefile
+++ b/gbdk-lib/examples/gb/scroller/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/sgb_border/Makefile
+++ b/gbdk-lib/examples/gb/sgb_border/Makefile
@@ -7,7 +7,7 @@ all:
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 clean:
 	rm -f *.o *.lst *.map *.gb *.ihx *.sym *.cdb *.adb *.asm

--- a/gbdk-lib/examples/gb/sgb_multiplayer/Makefile
+++ b/gbdk-lib/examples/gb/sgb_multiplayer/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/sgb_pong/Makefile
+++ b/gbdk-lib/examples/gb/sgb_pong/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/sgb_sfx/Makefile
+++ b/gbdk-lib/examples/gb/sgb_sfx/Makefile
@@ -5,7 +5,7 @@ all:
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 clean:
 	rm -f *.o *.lst *.map *.gb *.ihx *.sym *.cdb *.adb *.asm

--- a/gbdk-lib/examples/gb/simple_physics/Makefile
+++ b/gbdk-lib/examples/gb/simple_physics/Makefile
@@ -6,7 +6,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/sound/Makefile
+++ b/gbdk-lib/examples/gb/sound/Makefile
@@ -7,7 +7,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.c

--- a/gbdk-lib/examples/gb/space/Makefile
+++ b/gbdk-lib/examples/gb/space/Makefile
@@ -7,7 +7,7 @@ all:	$(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 %.gb:	%.s

--- a/gbdk-lib/examples/gb/template_subfolders/Makefile
+++ b/gbdk-lib/examples/gb/template_subfolders/Makefile
@@ -28,7 +28,7 @@ all:	prepare $(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/gb/wav_sample/Makefile
+++ b/gbdk-lib/examples/gb/wav_sample/Makefile
@@ -29,7 +29,7 @@ all:	prepare $(BINS)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/gg/smoke/Makefile
+++ b/gbdk-lib/examples/gg/smoke/Makefile
@@ -11,7 +11,7 @@ OBJS = $(CSRC:%.c=%.o) $(ASRC:%.s=%.o)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 

--- a/gbdk-lib/examples/msxdos/hello/Makefile
+++ b/gbdk-lib/examples/msxdos/hello/Makefile
@@ -11,7 +11,7 @@ OBJS = $(CSRC:%.c=%.o) $(ASRC:%.s=%.o)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 

--- a/gbdk-lib/examples/msxdos/smoke/Makefile
+++ b/gbdk-lib/examples/msxdos/smoke/Makefile
@@ -11,7 +11,7 @@ OBJS = $(CSRC:%.c=%.o) $(ASRC:%.s=%.o)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 

--- a/gbdk-lib/examples/msxdos/test/Makefile
+++ b/gbdk-lib/examples/msxdos/test/Makefile
@@ -11,7 +11,7 @@ OBJS = $(CSRC:%.c=%.o) $(ASRC:%.s=%.o)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 

--- a/gbdk-lib/examples/nes/smoke/Makefile
+++ b/gbdk-lib/examples/nes/smoke/Makefile
@@ -11,7 +11,7 @@ OBJS = $(CSRC:%.c=%.o) $(ASRC:%.s=%.o)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 

--- a/gbdk-lib/examples/sms/smoke/Makefile
+++ b/gbdk-lib/examples/sms/smoke/Makefile
@@ -11,7 +11,7 @@ OBJS = $(CSRC:%.c=%.o) $(ASRC:%.s=%.o)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 

--- a/gbdk-lib/examples/sms/test/Makefile
+++ b/gbdk-lib/examples/sms/test/Makefile
@@ -11,7 +11,7 @@ OBJS = $(CSRC:%.c=%.o) $(ASRC:%.s=%.o)
 
 compile.bat: Makefile
 	@echo "REM Automatically generated from Makefile" > compile.bat
-	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
 
 # Compile and link single file in one pass
 


### PR DESCRIPTION
Docs: update link to gbdk-sdcc building
Example: Strip -p arg from mkdir in generated compile.bat files
Docs: toolchain settings: SDCC 4.3 + NES updates
- Add sdas6500, sdld6808
- Regenerate output