### PR TITLE
Makebin: Warn if RAM banks specified and file size of ROM is less than the 64K required to enable them with in emulators

### DIFF
--- a/docs/pages/05_banking_mbcs.md
+++ b/docs/pages/05_banking_mbcs.md
@@ -80,6 +80,9 @@ The MBC settings below are available when using the makebin `-Wl-yt<N>` switch.
 
 Source: Pandocs. Additional details available at [Pandocs](https://gbdev.io/pandocs/The_Cartridge_Header.html#0147---cartridge-type "Pandocs")
 
+For SMS/GG, the ROM file size must be at least 64K to enable mapper support for RAM banks in emulators.
+  - If the generated ROM is too small then `-yo 4` for makebin (or `-Wm-yo4` for LCC) can be used to set the size to 64K.
+
 
 ## MBC Type Chart
 ```

--- a/docs/pages/06b_supported_consoles.md
+++ b/docs/pages/06b_supported_consoles.md
@@ -190,6 +190,8 @@ GB/AP
   - VRAM and some other display data / registers should only be written to when the @ref STATF_B_BUSY bit of @ref STAT_REG is off. Most GBDK API calls manage this automatically.
 
 SMS/GG
+- The SMS/GG ROM file size must be at least 64K to enable mapper support for RAM banks in emulators.
+  - If the generated ROM is too small then `-yo 4` for makebin (or `-Wm-yo4` for LCC) can be used to set the size to 64K.
 - Display Controller (VDP)
   - Writing to the VDP should not be interrupted while an operation is already in progress (since that will interfere with the internal data pointer causing data to be written to the wrong location).
   - Recommended approach: Avoid writing to the VDP (tiles, map, scrolling, colors, etc) during an interrupt routine (ISR).

--- a/docs/pages/10_release_notes.md
+++ b/docs/pages/10_release_notes.md
@@ -43,6 +43,8 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - Fixed support for indexed color pngs with less than 8 bits color depth
       - Fixed incorrect palettes when different colors have same luma value (use RGB values as less-significant bits)
       - Changed to use cross-platform constants for metasprite properties (S_FLIPX, S_FLIPY and S_PAL)
+    - @ref makebin
+      - Warn if RAM banks specified and file size of ROM is less than the 64K required to enable them with in emulators
     - Added sdld6808 (for NES)
   - Examples
      - Fixed mkdir broken in some compile.bat files (remove unsupported -p flag during bat file conversion)


### PR DESCRIPTION
- Fix missing info that yoN and yaN are also used for SMS to actually set number of banks
- Notes in docs
(Requested by Calindro)