### PR TITLE
NES: Add support for set_bkg_tile_xy / set_vram_byte

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/font.s
+++ b/gbdk-lib/libc/targets/mos6502/font.s
@@ -284,9 +284,10 @@ set_char_no_encoding:
         txa
         clc
         adc font_current+sfont_handle_first_tile
-        ldx .curx
-        ldy .cury
-        jsr .writeNametableByte
+        sta _set_bkg_tile_xy_PARM_3
+        lda .curx
+        ldx .cury
+        jsr _set_bkg_tile_xy
         rts
 
 

--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -13,7 +13,7 @@ ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	metasprites_common.s \
 	metasprites_hide.s metasprites_hide_spr.s \
 	vram_transfer_buffer.s \
-	set_bk_ts.s set_tile_submap.s fill_rect_bk.s \
+	set_tile.s set_bk_ts.s set_tile_submap.s fill_rect_bk.s \
 	set_bk_attributes.s set_tile_submap_attributes.s flush_attributes.s \
 	nes_palettes.s \
 	pad.s pad_ex.s \

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -74,7 +74,6 @@ __crt0_spritePageValid:                 .ds 1
 __crt0_NMI_Done:                        .ds 1
 __crt0_NMI_insideNMI:                   .ds 1
 __crt0_ScrollHV:                        .ds 1
-__crt0_textPPUAddr::                    .ds 2
 __crt0_NMITEMP:                         .ds 4
 .mode::                                 .ds 1
 .tmp::                                  .ds 2
@@ -82,7 +81,6 @@ _bkg_scroll_x::                         .ds 1
 _bkg_scroll_y::                         .ds 1
 _attribute_row_dirty::                  .ds 1
 _attribute_column_dirty::               .ds 1
-.crt0_textStringBegin::                 .ds 1
 .crt0_forced_blanking::                 .ds 1
 .tempA::                                .ds 1
 
@@ -399,11 +397,6 @@ __crt0_RESET_bankSwitchValue:
     sta *__current_bank
     ; Set palette shadow
     jsr __crt0_setPalette
-    ; Initialize PPU address for printf output (start at 3rd row, 2nd column)
-    lda #<0x2041
-    sta *__crt0_textPPUAddr
-    lda #>0x2041
-    sta *(__crt0_textPPUAddr+1)
     lda #VRAM_DELAY_CYCLES_X8
     sta *__vram_transfer_buffer_num_cycles_x8
     lda #0

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -124,7 +124,6 @@
 
         .globl  .display_off, .display_on
         .globl  .wait_vbl_done
-        .globl  .writeNametableByte
 
         ;; Symbols defined at link time
         .globl _shadow_OAM, __vram_transfer_buffer

--- a/gbdk-lib/libc/targets/mos6502/nes/set_tile.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_tile.s
@@ -1,0 +1,28 @@
+    .include    "global.s"
+
+    .area   OSEG (PAG, OVR)
+    _set_bkg_tile_xy_PARM_3::   .ds 1   ; (shared with _set_vram_byte_PARM_3)
+    .bkg_tile_ppu_addr::        .ds 2
+
+    .area   _HOME
+
+_set_bkg_tile_xy::
+    ; XA = (PPU_NT0) | (X << 5) | A
+    ; (A = x_pos, X = y_pos)
+    sta *.bkg_tile_ppu_addr
+    txa
+    asl
+    asl
+    asl
+    asl
+    rol *.bkg_tile_ppu_addr+1
+    asl
+    ora *.bkg_tile_ppu_addr
+    sta *.bkg_tile_ppu_addr
+    lda *.bkg_tile_ppu_addr+1
+    rol
+    and #0x03
+    ora #(PPU_NT0 >> 8)
+    tax
+    lda *.bkg_tile_ppu_addr
+    jmp _set_vram_byte


### PR DESCRIPTION
* Remove old writeNametableByte implementation
* Add _set_vram_byte which replaces writeNametableByte, but can append to old stripe in both directions
* Rename: .crt0_textStringBegin -> __vram_transfer_buffer_pos_old
* Remove unused variable __crt0_textPPUAddr
* Add set_tile.s file with implementation for set_bkg_tile_xy, calling _set_vram_byte. Update Makefile.