### PR TITLE
NES: Reduce use of zeropage

### DIFF
--- a/gbdk-lib/libc/asm/mos6502/rand.s
+++ b/gbdk-lib/libc/asm/mos6502/rand.s
@@ -13,6 +13,8 @@ ___rand_seed::
 
 .area _HOME
 
+.define .tmp "__TEMP"
+
 ;
 ; Returns an 8-bit / 16-bit rand value and updates the seed.
 ;

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -74,15 +74,14 @@ __crt0_spritePageValid:                 .ds 1
 __crt0_NMI_Done:                        .ds 1
 __crt0_NMI_insideNMI:                   .ds 1
 __crt0_ScrollHV:                        .ds 1
-__crt0_NMITEMP:                         .ds 4
 .mode::                                 .ds 1
-.tmp::                                  .ds 2
 _bkg_scroll_x::                         .ds 1
 _bkg_scroll_y::                         .ds 1
 _attribute_row_dirty::                  .ds 1
 _attribute_column_dirty::               .ds 1
 .crt0_forced_blanking::                 .ds 1
-.tempA::                                .ds 1
+
+.define __crt0_NMITEMP "___SDCC_m6502_ret4"
 
 .area _CODE
 
@@ -215,8 +214,8 @@ DoUpdateVRAM_valid_loop:
 ;                        = 8 * (6*NumTransfers + NumBytesTransferred + 7)
 ;
 ProcessDrawList:
-    ProcessDrawList_tempX  = __crt0_NMITEMP+2
-    ProcessDrawList_addr   = __crt0_NMITEMP+0
+    .define ProcessDrawList_tempX "__crt0_NMITEMP+2"
+    .define ProcessDrawList_addr  "__crt0_NMITEMP+0"
     lda #>ProcessDrawList_UnrolledCopyLoop  ; +2
     sta *ProcessDrawList_addr+1             ; +3
     tsx                                     ; +2

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -110,7 +110,7 @@
 
         ;; Global variables
         .globl  .mode
-        .globl  .tmp
+        .define .tmp "__TEMP"
 
         .globl _shadow_PPUCTRL, _shadow_PPUMASK
         .globl _bkg_scroll_x, _bkg_scroll_y

--- a/gbdk-lib/libc/targets/mos6502/nes/sdcc_bcall.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/sdcc_bcall.s
@@ -1,4 +1,7 @@
+.include "global.s"
 .include "mapper_macros.s"
+
+.define .tempA "(__TEMP+7)"
 
 ;
 ; Banked call support function.

--- a/gbdk-lib/libc/targets/mos6502/nes/set_bk_attributes.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_bk_attributes.s
@@ -14,7 +14,6 @@
     .attribute_y_odd:                       .ds 1
     .attribute_num_columns_odd:             .ds 1
     .attribute_num_rows_odd:                .ds 1
-    .row_dirty_mask:                        .ds 1
 
     .area   _HOME
 

--- a/gbdk-lib/libc/targets/mos6502/nes/vram_transfer_buffer.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/vram_transfer_buffer.s
@@ -47,7 +47,8 @@ __vram_transfer_buffer_valid::          .ds 1
 __vram_transfer_buffer_num_cycles_x8::  .ds 1
 __vram_transfer_buffer_pos_w::          .ds 1
 __vram_transfer_buffer_pos_old::        .ds 1
-__vram_transfer_buffer_temp::           .ds 1
+
+.define __vram_transfer_buffer_temp     "(__TEMP+6)"
 
 .area   _HOME
 

--- a/gbdk-support/lcc/targets.c
+++ b/gbdk-support/lcc/targets.c
@@ -38,7 +38,7 @@ arg_entry llist0_defaults_nes[] = {
     {.searchkey= "_CODE=",       .addflag= "-b",.addvalue= "_CODE=0xC000",       .found = false},
     {.searchkey= "VECTORS=",     .addflag= "-b",.addvalue= "VECTORS=0xFFFA",     .found = false},
     {.searchkey= "OSEG=",        .addflag= "-b",.addvalue= "OSEG=0x00",          .found = false},
-    {.searchkey= "_ZP=",         .addflag= "-b",.addvalue= "_ZP=0x30",           .found = false},
+    {.searchkey= "_ZP=",         .addflag= "-b",.addvalue= "_ZP=0x10",           .found = false},
 };
 
 // Port/Platform specific settings


### PR DESCRIPTION
* Remove unused byte row_dirty_mask from OSEG in set_bk_attributes.s
* Reduce size of OSEG segment from 48 to 16 bytes
* Reduce size of __crt0_NMITEMP from 4 to 3 bytes, and set it to start at ___SDCC_m6502_ret4 (no functions should have return values > 32bit)
* Redefine .tempA in sdcc_bcall.s to use SDCC temp location __TEMP+7
* Redefine  __vram_transfer_buffer_tempt to use SDCC location __TEMP+6
* Redefine .tmp to point at __TEMP (SDCC temporary zeropage usage)