### PR TITLE
NES: Trim sprite modules

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites_common.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites_common.s
@@ -5,12 +5,6 @@
 
     .area   _HOME
 
-    .area   _INITIALIZED
-    ___render_shadow_OAM:: .ds     0x01
-
-    .area   _INITIALIZER
-    .db     #>_shadow_OAM
-
 .define id    ".tmp+1"
 
 .move_metasprite_prologue::

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites_hide_spr.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites_hide_spr.s
@@ -1,9 +1,15 @@
     .include    "global.s"
 
-    .title  "Metasprites"
-    .module Metasprites
+    .title  "Sprites"
+    .module Sprites
 
     .globl  ___render_shadow_OAM
+
+    .area   _INITIALIZED
+    ___render_shadow_OAM:: .ds     0x01
+
+    .area   _INITIALIZER
+    .db     #>_shadow_OAM
 
     .area   _HOME
 


### PR DESCRIPTION
* Move ___render_shadow_OAM from metasprites_common.s to metasprites_hide_spr.s
* Change module name of metasprites_hide_spr.s from "Metasprites" to "Sprites" to allow linking it separately