### PR TITLE
NES: set_vram_byte / get_bkg_xy_addr fixes

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/set_tile.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_tile.s
@@ -1,12 +1,12 @@
     .include    "global.s"
 
     .area   OSEG (PAG, OVR)
-    _set_bkg_tile_xy_PARM_3::   .ds 1   ; (shared with _set_vram_byte_PARM_3)
+    _set_bkg_tile_xy_PARM_3::   .ds 1   ; (shared with _set_vram_byte_PARM_2)
     .bkg_tile_ppu_addr::        .ds 2
 
     .area   _HOME
 
-_set_bkg_tile_xy::
+_get_bkg_xy_addr::
     ; XA = (PPU_NT0) | (X << 5) | A
     ; (A = x_pos, X = y_pos)
     sta *.bkg_tile_ppu_addr
@@ -25,4 +25,8 @@ _set_bkg_tile_xy::
     ora #(PPU_NT0 >> 8)
     tax
     lda *.bkg_tile_ppu_addr
+    rts
+
+_set_bkg_tile_xy::
+    jsr _get_bkg_xy_addr
     jmp _set_vram_byte

--- a/gbdk-lib/libc/targets/mos6502/nes/vram_transfer_buffer.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/vram_transfer_buffer.s
@@ -40,7 +40,7 @@ VRAM_MAX_STRIPE_SIZE    = VRAM_HDR_SIZEOF + VRAM_MAX_BYTES
 .endm
 
 .area   OSEG (PAG, OVR)
-_set_vram_byte_PARM_3:: .ds 1
+_set_vram_byte_PARM_2:: .ds 1
     
 .area _ZP (PAG)
 __vram_transfer_buffer_valid::          .ds 1
@@ -197,7 +197,7 @@ _set_vram_byte::
     ; Direct write
     stx PPUADDR
     sta PPUADDR
-    ldy *_set_vram_byte_PARM_3
+    ldy *_set_vram_byte_PARM_2
     sty PPUDATA
     rts
 
@@ -278,7 +278,7 @@ _set_vram_byte::
     lda *ppu_addr
     sta __vram_transfer_buffer+VRAM_HDR_PPULO,y
     ; write data byte
-    lda *_set_vram_byte_PARM_3
+    lda *_set_vram_byte_PARM_2
     sta __vram_transfer_buffer+VRAM_HDR_SIZEOF,y
     ; Increase write pointer
     tya
@@ -320,7 +320,7 @@ _set_vram_byte::
 .ppu_stripe_append_1byte:
     ; Append 1 byte
     inc __vram_transfer_buffer+VRAM_HDR_LENGTH,x
-    lda *_set_vram_byte_PARM_3
+    lda *_set_vram_byte_PARM_2
     ldx *__vram_transfer_buffer_pos_w
     sta __vram_transfer_buffer,x
     inx


### PR DESCRIPTION
* Change incorrectly named function parameter _set_vram_byte_PARM_3 -> _set_vram_byte_PARM_2
* Add implementation for get_bkg_xy_addr, re-using existing set_bkg_tile_xy address calculation