### PR TITLE
NES: Fix recent regression caused by improper initialization of jmp_to_VBL_isr / jmp_to_LCD_isr and palette

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -328,7 +328,7 @@ __crt0_setPalette:
     lda #0x30
     sta __crt0_paletteShadow
     ; set all background / sprite sub-palettes to 10, 00, 1D
-    ldx #0x1F
+    ldx #0x18
 1$:
     lda #0x1D
     sta __crt0_paletteShadow,x
@@ -339,8 +339,7 @@ __crt0_setPalette:
     lda #0x10
     sta __crt0_paletteShadow,x
     dex
-    dex
-    bpl 1$
+    bne 1$
     rts
 
 __crt0_waitPPU:
@@ -426,6 +425,18 @@ __crt0_RESET_bankSwitchValue:
     sta ___memcpy_PARM_3+1
     lda #<s__DATA
     ldx #>s__DATA
+    jsr ___memcpy
+    ; Perform initialization of INITIALIZED area
+    lda #<s__INITIALIZER
+    sta ___memcpy_PARM_2
+    lda #>s__INITIALIZER
+    sta ___memcpy_PARM_2+1
+    lda #<l__INITIALIZER
+    sta ___memcpy_PARM_3
+    lda #>l__INITIALIZER
+    sta ___memcpy_PARM_3+1
+    lda #<s__INITIALIZED
+    ldx #>s__INITIALIZED
     jsr ___memcpy
     ; Set bank to first
     lda #0x00

--- a/gbdk-lib/libc/targets/mos6502/nes/lcd.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/lcd.s
@@ -5,11 +5,11 @@
 .area _ZP (PAG)
 __lcd_scanline::    .ds 1
 
-.area _DATA
+.area _INITIALIZED
 .jmp_to_VBL_isr::   .ds 3
 .jmp_to_LCD_isr::   .ds 3
 
-.area _XINIT
+.area _INITIALIZER
 ; .jmp_to_VBL_isr
 rts
 nop


### PR DESCRIPTION
* Initialize both _INITIALIZER -> _INITIALIZED and _XINIT -> _DATA segments, for maximum compatibility
* Update lcd.s to use these segments
* Fix bug __crt0_setPalette causing overwriting of initialized segment