### PR TITLE
NES: Fix recent regression caused by improper initialization of jmp_to_VBL_isr / jmp_to_LCD_isr

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/color.s
+++ b/gbdk-lib/libc/targets/mos6502/color.s
@@ -3,7 +3,7 @@
         .title  "Colors"
         .module colors
 
-        .area   _INITIALIZED
+        .area   _DATA
 
 __current_1bpp_colors::
 .fg_colour::
@@ -11,7 +11,6 @@ __current_1bpp_colors::
 .bg_colour::
         .ds     1
 
-        .area   _INITIALIZER
-
+        .area   _XINIT
         .db     0x03    ; .fg_colour
         .db     0x00    ; .bg_color

--- a/gbdk-lib/libc/targets/mos6502/font.s
+++ b/gbdk-lib/libc/targets/mos6502/font.s
@@ -43,17 +43,17 @@
 
         .globl  _set_bkg_1bpp_data, _set_bkg_data
 
-        .area   _INITIALIZED
+        .area   _DATA
 .curx::                         ; Cursor position
         .ds     0x01
 .cury::
         .ds     0x01
 
-        .area   _INITIALIZER
+        .area   _XINIT
         .db     0x00            ; .curx
         .db     0x00            ; .cury
 
-        .area   _DATA
+        .area   _BSS
         ; The current font
 font_handle_base:
 font_current::

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -328,7 +328,7 @@ __crt0_setPalette:
     lda #0x30
     sta __crt0_paletteShadow
     ; set all background / sprite sub-palettes to 10, 00, 1D
-    ldx #0x1F
+    ldx #0x18
 1$:
     lda #0x1D
     sta __crt0_paletteShadow,x
@@ -339,8 +339,7 @@ __crt0_setPalette:
     lda #0x10
     sta __crt0_paletteShadow,x
     dex
-    dex
-    bpl 1$
+    bne 1$
     rts
 
 __crt0_waitPPU:
@@ -415,6 +414,7 @@ __crt0_RESET_bankSwitchValue:
     stx OAMADDR
     lda #>_shadow_OAM
     sta OAMDMA
+
     ; Perform initialization of DATA area
     lda #<s__XINIT
     sta ___memcpy_PARM_2
@@ -427,6 +427,7 @@ __crt0_RESET_bankSwitchValue:
     lda #<s__DATA
     ldx #>s__DATA
     jsr ___memcpy
+
     ; Set bank to first
     lda #0x00
     sta *__current_bank

--- a/gbdk-lib/libc/targets/mos6502/nes/lcd.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/lcd.s
@@ -5,11 +5,11 @@
 .area _ZP (PAG)
 __lcd_scanline::    .ds 1
 
-.area _DATA
+.area   _DATA
 .jmp_to_VBL_isr::   .ds 3
 .jmp_to_LCD_isr::   .ds 3
 
-.area _XINIT
+.area   _XINIT
 ; .jmp_to_VBL_isr
 rts
 nop

--- a/gbdk-lib/libc/targets/mos6502/nes/metasprites_hide_spr.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/metasprites_hide_spr.s
@@ -5,10 +5,10 @@
 
     .globl  ___render_shadow_OAM
 
-    .area   _INITIALIZED
+    .area   _DATA
     ___render_shadow_OAM:: .ds     0x01
 
-    .area   _INITIALIZER
+    .area   _XINIT
     .db     #>_shadow_OAM
 
     .area   _HOME


### PR DESCRIPTION
* Update source files to use _XINIT / _DATA instead of _INITIALIZER / _INITIALIZED
* Fix bug with __crt0_setPalette causing overwriting of initialized segment