### PR TITLE
Add set_bkg_native_data / set_sprite_native_data functions to allow using native tile format with set_bkg_data / set_sprite_data functionality

### DIFF
--- a/gbdk-lib/examples/cross-platform/large_map/Makefile
+++ b/gbdk-lib/examples/cross-platform/large_map/Makefile
@@ -30,7 +30,7 @@ P2AFLAGS_pocket = -map -bpp 2 -max_palettes 4 -pack_mode gb -noflip
 P2AFLAGS_duck   = -map -bpp 2 -max_palettes 4 -pack_mode gb -noflip
 P2AFLAGS_sms    = -map -use_map_attributes -bpp 4 -max_palettes 2 -pack_mode sms
 P2AFLAGS_gg     = -map -use_map_attributes -bpp 4 -max_palettes 2 -pack_mode sms
-P2AFLAGS_nes    = -map -bpp 2 -max_palettes 4 -pack_mode gb -noflip -use_nes_attributes -b 0
+P2AFLAGS_nes    = -map -bpp 2 -max_palettes 4 -pack_mode nes -noflip -use_nes_attributes -b 0
 
 P2AFLAGS = $(P2AFLAGS_$(EXT))
 

--- a/gbdk-lib/examples/cross-platform/logo/res/NES/GBDK_2020_logo.png.meta
+++ b/gbdk-lib/examples/cross-platform/logo/res/NES/GBDK_2020_logo.png.meta
@@ -1,1 +1,1 @@
--map -use_nes_attributes -use_nes_colors -noflip -bpp 2 -max_palettes 4 -pack_mode gb
+-map -use_nes_attributes -use_nes_colors -noflip -bpp 2 -max_palettes 4 -pack_mode nes

--- a/gbdk-lib/examples/cross-platform/logo/src/main.c
+++ b/gbdk-lib/examples/cross-platform/logo/src/main.c
@@ -16,7 +16,7 @@ void main(void) {
     set_bkg_palette(0, GBDK_2020_logo_PALETTE_COUNT, GBDK_2020_logo_palettes);
 #endif
 
-    set_native_tile_data(0, GBDK_2020_logo_TILE_COUNT, GBDK_2020_logo_tiles);
+    set_bkg_native_data(0, GBDK_2020_logo_TILE_COUNT, GBDK_2020_logo_tiles);
     set_bkg_attributes((DEVICE_SCREEN_WIDTH - (GBDK_2020_logo_WIDTH >> 3)) >> 1,
                        (DEVICE_SCREEN_HEIGHT - (GBDK_2020_logo_HEIGHT >> 3)) >> 1,
                        GBDK_2020_logo_WIDTH >> 3,

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -2042,6 +2042,41 @@ inline void set_native_tile_data(uint16_t first_tile, uint8_t nb_tiles, const ui
     }
 }
 
+/** Sets VRAM Tile Pattern data for the Background / Window in the native format
+
+    @param first_tile  Index of the first tile to write
+    @param nb_tiles    Number of tiles to write
+    @param data        Pointer to source tile data
+
+    Writes __nb_tiles__ tiles to VRAM starting at __first_tile__, tile data
+    is sourced from __data__.
+
+    GBC only: @ref VBK_REG determines which bank of Background tile patterns are written to.
+    \li VBK_REG = @ref VBK_BANK_0 indicates the first bank
+    \li VBK_REG = @ref VBK_BANK_1 indicates the second
+
+    @see set_win_data, set_tile_data
+*/
+inline void set_bkg_native_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data) {
+    set_bkg_data(first_tile, nb_tiles, data);
+}
+
+/** Sets VRAM Tile Pattern data for Sprites in the native format
+
+    @param first_tile  Index of the first tile to write
+    @param nb_tiles    Number of tiles to write
+    @param data        Pointer to source tile data
+
+    Writes __nb_tiles__ tiles to VRAM starting at __first_tile__, tile data
+    is sourced from __data__.
+
+    GBC only: @ref VBK_REG determines which bank of Background tile patterns are written to.
+    \li VBK_REG = @ref VBK_BANK_0 indicates the first bank
+    \li VBK_REG = @ref VBK_BANK_1 indicates the second
+*/
+inline void set_sprite_native_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data) {
+    set_sprite_data(first_tile, nb_tiles, data);
+}
 
 /** Initializes the entire Window Tile Map with Tile Number __c__
     @param c   Tile number to fill with

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -1129,8 +1129,39 @@ void set_tiles(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t *vram_addr, c
 
     @see set_bkg_data, set_data
 */
-void set_tile_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data, uint8_t base) OLDCALL;
+inline void set_tile_data(uint16_t first_tile, uint8_t nb_tiles, const uint8_t *data) {
+    if (first_tile < 256) {
+        set_bkg_data(first_tile, nb_tiles, data);
+        if(first_tile + nb_tiles > 256)
+            set_sprite_data(first_tile - 256, nb_tiles, data);
+    } else {
+        set_sprite_data(first_tile - 256, nb_tiles, data);
+    }
+}
 
+/** Sets VRAM Tile Pattern data for the Background in the native format
+
+    @param first_tile  Index of the first tile to write
+    @param nb_tiles    Number of tiles to write
+    @param data        Pointer to source tile data
+
+    Writes __nb_tiles__ tiles to VRAM starting at __first_tile__, tile data
+    is sourced from __data__.
+
+    @see set_tile_data
+*/
+void set_bkg_native_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data);
+
+/** Sets VRAM Tile Pattern data for Sprites in the native format
+
+    @param first_tile  Index of the first tile to write
+    @param nb_tiles    Number of tiles to write
+    @param data        Pointer to source tile data
+
+    Writes __nb_tiles__ tiles to VRAM starting at __first_tile__, tile data
+    is sourced from __data__.
+*/
+void set_sprite_native_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data);
 
 /** Sets VRAM Tile Pattern data in the native format
 
@@ -1147,9 +1178,11 @@ void set_tile_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data, ui
  */
 inline void set_native_tile_data(uint16_t first_tile, uint8_t nb_tiles, const uint8_t *data) {
     if (first_tile < 256) {
-        set_bkg_data(first_tile, nb_tiles, data);
+        set_bkg_native_data(first_tile, nb_tiles, data);
+        if(first_tile + nb_tiles > 256)
+            set_sprite_native_data(first_tile - 256, nb_tiles, data);
     } else {
-        set_sprite_data(first_tile - 256, nb_tiles, data);
+        set_sprite_native_data(first_tile - 256, nb_tiles, data);
     }
 }
 

--- a/gbdk-lib/include/sms/sms.h
+++ b/gbdk-lib/include/sms/sms.h
@@ -528,8 +528,15 @@ void set_native_tile_data(uint16_t start, uint16_t ntiles, const void *src) Z88D
 inline void set_bkg_4bpp_data(uint16_t start, uint16_t ntiles, const void *src) {
     set_native_tile_data(start, ntiles, src);
 }
+inline void set_bkg_native_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data) {
+    set_bkg_4bpp_data(first_tile, nb_tiles, data);
+}
+
 inline void set_sprite_4bpp_data(uint16_t start, uint16_t ntiles, const void *src) {
     set_native_tile_data((uint8_t)(start) + 0x100u, ntiles, src);
+}
+inline void set_sprite_native_data(uint8_t first_tile, uint8_t nb_tiles, const uint8_t *data) {
+    set_sprite_4bpp_data(first_tile, nb_tiles, data);
 }
 
 #define COMPAT_PALETTE(C0,C1,C2,C3) (((uint16_t)(C3) << 12) | ((uint16_t)(C2) << 8) | ((uint16_t)(C1) << 4) | (uint16_t)(C0))

--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -8,7 +8,7 @@ PORT = mos6502
 CSRC = crlf.c
 
 ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
-	font.s font_color.s set_data.s set_1bit_data.s color.s mode.s \
+	font.s font_color.s set_data.s set_native_data.s set_1bit_data.s color.s mode.s \
 	metasprites.s metasprites_flipx.s metasprites_flipy.s metasprites_flipxy.s \
 	metasprites_common.s \
 	metasprites_hide.s metasprites_hide_spr.s \

--- a/gbdk-lib/libc/targets/mos6502/nes/set_data.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_data.s
@@ -1,39 +1,18 @@
+    .module SetData
     .include "global.s"
 
     .area	OSEG (PAG, OVR)
     _set_sprite_data_PARM_3::
-    _set_bkg_data_PARM_3::
-    _set_tile_data_PARM_3::     .ds 2
-    _set_tile_data_PARM_4::     .ds 1
+    _set_bkg_data_PARM_3::      .ds 2
+    .ppu_addr_lo:               .ds 1
+    .ppu_addr_hi:               .ds 1
     src:                        .ds 2
     tmpX:                       .ds 1
 
     .area   _HOME
 
-_set_tile_data::
-    sta *.tmp
-    lda *_set_tile_data_PARM_3
-    sta *src
-    lda *_set_tile_data_PARM_3+1
-    sta *src+1
-    ; *= 16
-    lda #0
-    asl *.tmp
-    rol
-    asl *.tmp
-    rol
-    asl *.tmp
-    rol
-    asl *.tmp
-    rol
-    clc
-    adc *_set_tile_data_PARM_4
-    sta PPUADDR
-    lda *.tmp
-    sta PPUADDR
-    jmp .copy_tiles_loop
 _set_bkg_data::
-    sta *.tmp
+    sta *.ppu_addr_lo
     lda *_set_bkg_data_PARM_3
     sta *src
     lda *_set_bkg_data_PARM_3+1
@@ -43,7 +22,7 @@ _set_bkg_data::
     lsr
     jmp .copy_tiles
 _set_sprite_data::
-    sta *.tmp
+    sta *.ppu_addr_lo
     lda *_set_sprite_data_PARM_3
     sta *src
     lda *_set_sprite_data_PARM_3+1
@@ -55,19 +34,19 @@ _set_sprite_data::
     lsr
     lsr
     ; *= 16
-    asl *.tmp
+    asl *.ppu_addr_lo
     rol
-    asl *.tmp
+    asl *.ppu_addr_lo
     rol
-    asl *.tmp
+    asl *.ppu_addr_lo
     rol
-    asl *.tmp
+    asl *.ppu_addr_lo
     rol
     bit *.crt0_forced_blanking
     bpl .copy_tiles_indirect
     ; Direct write
     sta PPUADDR
-    lda *.tmp
+    lda *.ppu_addr_lo
     sta PPUADDR
 .copy_tiles_loop:
     ; plane0 - 8 even bytes
@@ -89,12 +68,12 @@ _set_sprite_data::
     rts
 
 .copy_tiles_indirect:
-    sta *.tmp+1
+    sta *.ppu_addr_hi
 .copy_tiles_indirect_loop:
     stx *tmpX
     ;
-    ldx *.tmp+1
-    lda *.tmp
+    ldx *.ppu_addr_hi
+    lda *.ppu_addr_lo
     jsr .ppu_stripe_begin_horizontal
     ;
     ldx *__vram_transfer_buffer_pos_w
@@ -112,13 +91,13 @@ _set_sprite_data::
     adc #0
     sta *src+1
     ; tmp += 16
-    lda *.tmp
+    lda *.ppu_addr_lo
     clc
     adc #16
-    sta *.tmp
-    lda *.tmp+1
+    sta *.ppu_addr_lo
+    lda *.ppu_addr_hi
     adc #0
-    sta *.tmp+1
+    sta *.ppu_addr_hi
     ;
     ldx *tmpX
     dex

--- a/gbdk-lib/libc/targets/mos6502/nes/set_native_data.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_native_data.s
@@ -1,0 +1,119 @@
+    .module SetNativeData
+
+    .include "global.s"
+
+    .area	OSEG (PAG, OVR)
+    _set_sprite_native_data_PARM_3::
+    _set_bkg_native_data_PARM_3::       .ds 2
+    .ppu_addr_lo:                       .ds 1
+    .ppu_addr_hi:                       .ds 1
+    src:                                .ds 2
+    tmpX:                               .ds 1
+
+    .area   _HOME
+
+_set_bkg_native_data::
+    sta *.ppu_addr_lo
+    lda *_set_bkg_data_PARM_3
+    sta *src
+    lda *_set_bkg_data_PARM_3+1
+    sta *src+1
+    lda *_shadow_PPUCTRL
+    and #PPUCTRL_BG_CHR
+    lsr
+    jmp .copy_tiles
+_set_sprite_native_data::
+    sta *.ppu_addr_lo
+    lda *_set_sprite_data_PARM_3
+    sta *src
+    lda *_set_sprite_data_PARM_3+1
+    sta *src+1
+    lda *_shadow_PPUCTRL
+    and #PPUCTRL_SPR_CHR
+.copy_tiles:
+    lsr
+    lsr
+    lsr
+    ; *= 16
+    asl *.ppu_addr_lo
+    rol
+    asl *.ppu_addr_lo
+    rol
+    asl *.ppu_addr_lo
+    rol
+    asl *.ppu_addr_lo
+    rol
+    bit *.crt0_forced_blanking
+    bpl .copy_tiles_indirect
+    ; Direct write
+    sta PPUADDR
+    lda *.ppu_addr_lo
+    sta PPUADDR
+.copy_tiles_loop:
+    ldy #0
+1$:
+    lda [*src],y
+    sta PPUDATA
+    iny
+    cpy #16
+    bne 1$
+    ; src += 16
+    lda *src
+    clc
+    adc #16
+    sta *src
+    lda *src+1
+    adc #0
+    sta *src+1
+    dex
+    bne .copy_tiles_loop
+    rts
+
+.copy_tiles_indirect:
+    sta *.ppu_addr_hi
+.copy_tiles_indirect_loop:
+    stx *tmpX
+    ;
+    ldx *.ppu_addr_hi
+    lda *.ppu_addr_lo
+    jsr .ppu_stripe_begin_horizontal
+    ;
+    jsr .copy_tiles_indirect_2planes
+    jsr .ppu_stripe_end
+    ; src += 16
+    lda *src
+    clc
+    adc #16
+    sta *src
+    lda *src+1
+    adc #0
+    sta *src+1
+    ; tmp += 16
+    lda *.ppu_addr_lo
+    clc
+    adc #16
+    sta *.ppu_addr_lo
+    lda *.ppu_addr_hi
+    adc #0
+    sta *.ppu_addr_hi
+    ;
+    ldx *tmpX
+    dex
+    bne .copy_tiles_indirect_loop
+    rts
+
+.copy_tiles_indirect_2planes:
+    lda *__vram_transfer_buffer_pos_w
+    clc
+    adc #16
+    sta *__vram_transfer_buffer_pos_w
+    tax
+    dex
+    ldy #15
+1$:
+    lda [*src],y
+    sta __vram_transfer_buffer,x
+    dex
+    dey
+    bpl 1$
+    rts

--- a/gbdk-support/png2asset/png2asset.cpp
+++ b/gbdk-support/png2asset/png2asset.cpp
@@ -696,7 +696,7 @@ int main(int argc, char* argv[])
 		printf("-bpp                bits per pixel: 1, 2, 4 (default: 2)\n");
 		printf("-max_palettes       max number of palettes allowed (default: 8)\n");
 		printf("                    (note: max colors = max_palettes x num colors per palette)\n");
-		printf("-pack_mode          gb, sgb, sms, 1bpp (default: gb)\n");
+		printf("-pack_mode          gb, nes, sgb, sms, 1bpp (default: gb)\n");
 		printf("-tile_origin        tile index offset for maps (default: 0)\n");
 
 		printf("-tiles_only         export tile data only\n");
@@ -824,12 +824,13 @@ int main(int argc, char* argv[])
 		{
 			std::string pack_mode_str = argv[++ i];
 			if     (pack_mode_str == "gb")  pack_mode = Tile::GB;
+			else if (pack_mode_str == "nes")  pack_mode = Tile::NES;
 			else if(pack_mode_str == "sgb") pack_mode = Tile::SGB;
 			else if(pack_mode_str == "sms") pack_mode = Tile::SMS;
 			else if(pack_mode_str == "1bpp") pack_mode = Tile::BPP1;
 			else
 			{
-				printf("-pack_mode must be one of gb, sgb, sms, 1bpp\n");
+				printf("-pack_mode must be one of gb, nes, sgb, sms, 1bpp\n");
 				return 1;
 			}
 		}

--- a/gbdk-support/png2asset/png2asset.h
+++ b/gbdk-support/png2asset/png2asset.h
@@ -32,6 +32,7 @@ struct Tile
 
     enum PackMode {
         GB,
+        NES,
         SGB,
         SMS,
         BPP1
@@ -45,6 +46,15 @@ struct Tile
                     unsigned char col = data[8 * j + i];
                     ret[j * 2    ] |= BIT(col, 0) << (7 - i);
                     ret[j * 2 + 1] |= BIT(col, 1) << (7 - i);
+                }
+            }
+        }
+        if (pack_mode == NES) {
+            for (int j = 0; j < tile_h; ++j) {
+                for (int i = 0; i < 8; ++i) {
+                    unsigned char col = data[8 * j + i];
+                    ret[j] |= BIT(col, 0) << (7 - i);
+                    ret[j+8] |= BIT(col, 1) << (7 - i);
                 }
             }
         }


### PR DESCRIPTION
* Update gbdk-lib/include/gb/gb.h to forward set_bkg_native_data / set_sprite_native_data to set_bkg_data / set_sprite_data functions
* Update gbdk-lib/include/sms/sms.h to forward set_bkg_native_data / set_sprite_data to set_bkg_4bpp_data / set_sprite_4bpp_data
* Add implementation for set_bkg_native_data / set_sprite_native_data in gbdk-lib/libc/targets/mos6502/nes/set_native_data.s
* Update gbdk-lib/include/nes/nes.h to include function declarations for set_bkg_native_data / set_sprite_native_data
* Update gbdk-lib/inlcude/nes/nes.h to implement set_native_tile_data in terms of set_bkg_native_data / set_sprite_native_data
* Update gbdk-lib/inlcude/nes/nes.h to implement set_tile_data in terms of set_bkg_data / set_sprite_data
* Remove old (/broken for indirect mode) code for set_tile_data / set_native_tile_data from set_data.s / set_native_data.s
* Update png2asset to include NES among the supported PackModes
* Update examples/cross-platform/logo .meta file to specify NES PackFormat for NES build
* Update examples/cross-platform/large_map Makefile to specify NES PackFormat for NES build