### PR TITLE
NES: Remove need for dummy GB mbc parameter for banking when using NES target

### DIFF
--- a/gbdk-lib/examples/cross-platform/banks/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks/Makefile
@@ -17,7 +17,7 @@ LCCFLAGS_duck    = -Wl-yt0x1B # Usually the same as required for .gb
 LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
 LCCFLAGS_sms     =
 LCCFLAGS_gg      =
-LCCFLAGS_nes     = -Wl-yt0x1B
+LCCFLAGS_nes     =
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 

--- a/gbdk-lib/examples/cross-platform/banks_autobank/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_autobank/Makefile
@@ -15,7 +15,7 @@ LCCFLAGS_duck    = -Wl-yt0x1B # Usually the same as required for .gb
 LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
 LCCFLAGS_sms     =
 LCCFLAGS_gg      =
-LCCFLAGS_nes     = -Wl-yt0x1B
+LCCFLAGS_nes     =
 LCCFLAGS_msxdos  =
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags

--- a/gbdk-lib/examples/cross-platform/banks_farptr/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_farptr/Makefile
@@ -15,7 +15,7 @@ LCCFLAGS_duck    = -Wl-yt0x1B # Usually the same as required for .gb
 LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
 LCCFLAGS_sms     =
 LCCFLAGS_gg      =
-LCCFLAGS_nes     = -Wl-yt0x1B
+LCCFLAGS_nes     =
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 

--- a/gbdk-lib/examples/cross-platform/banks_nonintrinsic/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_nonintrinsic/Makefile
@@ -15,7 +15,7 @@ LCCFLAGS_duck    = -Wl-yt0x1B # Usually the same as required for .gb
 LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
 LCCFLAGS_sms     =
 LCCFLAGS_gg      =
-LCCFLAGS_nes     = -Wl-yt0x1B
+LCCFLAGS_nes     =
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 

--- a/gbdk-lib/examples/cross-platform/large_map/Makefile
+++ b/gbdk-lib/examples/cross-platform/large_map/Makefile
@@ -16,7 +16,7 @@ LCCFLAGS_duck    = -Wl-yt0x1B -autobank # Usually the same as required for .gb
 LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc -autobank # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
 LCCFLAGS_sms     =
 LCCFLAGS_gg      =
-LCCFLAGS_nes     = -Wl-yt0x1B -autobank
+LCCFLAGS_nes     = -autobank
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 

--- a/gbdk-lib/examples/cross-platform/scroller/Makefile
+++ b/gbdk-lib/examples/cross-platform/scroller/Makefile
@@ -15,7 +15,7 @@ LCCFLAGS_duck    = -Wl-yt0x1B # Usually the same as required for .gb
 LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
 LCCFLAGS_sms     =
 LCCFLAGS_gg      =
-LCCFLAGS_nes     = -Wl-yt0x1B
+LCCFLAGS_nes     =
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
 

--- a/gbdk-support/bankpack/bankpack.c
+++ b/gbdk-support/bankpack/bankpack.c
@@ -95,6 +95,8 @@ static int handle_args(int argc, char * argv[]) {
                 files_set_out_path(argv[i] + 6);
             } else if (strstr(argv[i], "-mbc=") == argv[i]) {
                 option_set_mbc(atoi(argv[i] + 5));
+            } else if (strstr(argv[i], "-mapper=") == argv[i]) {
+                option_set_nes_mapper(atoi(argv[i] + 8));
             } else if (strstr(argv[i], "-yt") == argv[i]) {
                 option_mbc_by_rom_byte_149(strtol(argv[i] + 3, NULL, 0));
             } else if (strstr(argv[i], "-v") == argv[i]) {

--- a/gbdk-support/bankpack/common.h
+++ b/gbdk-support/bankpack/common.h
@@ -15,6 +15,16 @@ enum {
     MBC_TYPE_DEFAULT =  MBC_TYPE_NONE
 };
 
+enum {
+    NES_MAPPER_TYPE_NONE = 0,
+    NES_MAPPER_TYPE_UXROM = 2,
+    NES_MAPPER_TYPE_MAPPER30 = 30,
+
+    NES_MAPPER_TYPE_MIN = NES_MAPPER_TYPE_NONE,
+    NES_MAPPER_TYPE_MAX = NES_MAPPER_TYPE_MAPPER30,
+    NES_MAPPER_TYPE_DEFAULT = NES_MAPPER_TYPE_MAPPER30
+};
+
 #define MAX_FILE_STR 2048
 
 #define BANK_NUM_UNASSIGNED   0xFFFFU
@@ -32,6 +42,9 @@ enum {
 #define BANK_NUM_ROM_MAX_MBC2  15
 #define BANK_NUM_ROM_MAX_MBC3  127
 #define BANK_NUM_ROM_MAX_MBC5  255 // 511 // TODO: support full MBC5 address range (currently 8 bit only)
+
+#define BANK_NUM_ROM_MAX_UXROM     127  // Oversize UNROM supports up to 4MB, but iNES 1.0 only supports up to 2MB. Historical UxROM boards only supported 256kB at most
+#define BANK_NUM_ROM_MAX_MAPPER30  31   // Mapper30 only supports up to 512kB due to other register bits being used for CHR-RAM / 1-screen mirroring control.
 
 #define STRINGIFY(x) #x
 #define TOSTR(x) STRINGIFY(x)

--- a/gbdk-support/bankpack/options.c
+++ b/gbdk-support/bankpack/options.c
@@ -245,7 +245,30 @@ void option_set_mbc(int mbc_type) {
         bank_limit_rom_max = mbc_bank_limit_rom_max;
 }
 
+// Set NES mapper type directly
+void option_set_nes_mapper(int mapper_type) {
 
+    uint16_t mapper_bank_limit_rom_max;
+
+    switch (mapper_type) {
+    case NES_MAPPER_TYPE_NONE:
+        option_mbc_type = NES_MAPPER_TYPE_NONE;
+        break;
+    case NES_MAPPER_TYPE_UXROM:
+        option_mbc_type = mapper_type;
+        mapper_bank_limit_rom_max = BANK_NUM_ROM_MAX_UXROM;
+        break;
+    case NES_MAPPER_TYPE_MAPPER30:
+        option_mbc_type = mapper_type;
+        mapper_bank_limit_rom_max = BANK_NUM_ROM_MAX_MAPPER30;
+        break;
+    default:
+        printf("BankPack: Warning: unrecognized NES mapper option -mapper%d!\n", mapper_type);
+        break;
+    }
+    if (mapper_bank_limit_rom_max < bank_limit_rom_max)
+        bank_limit_rom_max = mapper_bank_limit_rom_max;
+}
 
 // From makebin
 //  Byte

--- a/gbdk-support/bankpack/options.h
+++ b/gbdk-support/bankpack/options.h
@@ -38,6 +38,8 @@ int  option_get_mbc_type(void);
 void option_set_mbc(int);
 void option_mbc_by_rom_byte_149(int);
 
+void option_set_nes_mapper(int mapper_type);
+
 uint32_t option_banks_calc_cart_size(void);
 
 bool option_banks_set_min(uint16_t bank_num);

--- a/gbdk-support/lcc/targets.c
+++ b/gbdk-support/lcc/targets.c
@@ -161,7 +161,7 @@ CLASS classes[] = {
       .include      = "%includedefault%",
       .com          = "%com% %comdefault% -Wa%asdefault% --no-peep $1 %comflag% $2 -o $3",
       .as           = "%as_6500% %asdefault% $1 $3 $2",
-      .bankpack     = "%bankpack% -plat=nes $1 $2",
+      .bankpack     = "%bankpack% -plat=nes -mapper=30 $1 $2",
       .ld           = "%ld_6808% -a nes -n -i -j $1 %libs_include% $3 %crt0dir% $2",
       .ihxcheck     = "%ihxcheck% $2 $1",
       .mkbin        = "%mkbin% -N -yo A -yS $2 $3",


### PR DESCRIPTION
* Update bankpack to have a new command-line parameter -mapper to supply mapper info for NES target (copy-n-paste of -mbc parameter implementation)
* Update gbdk-support/lcc/targets.c to call bankpack for NES target with -mapper=30 (still hard-coding Mapper30 as the mapper for now)
* Update examples/cross-platform to not supply nonsense "-Wl-yt0x1B" parameter for nes build