### PR TITLE
Add cross-platform test for exercising libc memcpy/memmove/memset functions in string.h

### DIFF
--- a/gbdk-lib/examples/cross-platform/libc_memcpy/Makefile
+++ b/gbdk-lib/examples/cross-platform/libc_memcpy/Makefile
@@ -1,0 +1,79 @@
+# If you move this project you can change the directory
+# to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/"
+GBDK_HOME = ../../../
+LCC = $(GBDK_HOME)bin/lcc
+
+# Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
+# They can also be built/cleaned individually: "make gg" and "make gg-clean"
+# Possible are: gb gbc pocket megaduck sms gg
+TARGETS=gb pocket megaduck sms gg nes
+
+# Configure platform specific LCC flags here:
+LCCFLAGS_gb      = -Wl-yt0x1B -autobank # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
+LCCFLAGS_pocket  = -Wl-yt0x1B -autobank # Usually the same as required for .gb
+LCCFLAGS_duck    = -Wl-yt0x1B -autobank # Usually the same as required for .gb
+LCCFLAGS_gbc     = -Wl-yt0x1B -Wm-yc -autobank # Same as .gb with: -Wm-yc (gb & gbc) or Wm-yC (gbc exclusive)
+LCCFLAGS_sms     = -autobank
+LCCFLAGS_gg      = -autobank
+LCCFLAGS_nes     = 
+
+LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
+
+LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
+# LCCFLAGS += -debug # Uncomment to enable debug output
+# LCCFLAGS += -v     # Uncomment for lcc verbose output
+
+# You can set the name of the ROM file here
+PROJECTNAME = libc_memcpy
+
+# EXT?=gb # Only sets extension to default (game boy .gb) if not populated
+SRCDIR      = src
+OBJDIR      = obj/$(EXT)
+RESDIR      = res
+BINDIR      = build/$(EXT)
+MKDIRS      = $(OBJDIR) $(BINDIR) # See bottom of Makefile for directory auto-creation
+
+BINS	    = $(OBJDIR)/$(PROJECTNAME).$(EXT)
+CSOURCES    = $(foreach dir,$(SRCDIR),$(notdir $(wildcard $(dir)/*.c))) $(foreach dir,$(RESDIR),$(notdir $(wildcard $(dir)/*.c)))
+ASMSOURCES  = $(foreach dir,$(SRCDIR),$(notdir $(wildcard $(dir)/*.s)))
+OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
+
+# Builds all targets sequentially
+all: $(TARGETS)
+
+# Compile .c files in "src/" to .o object files
+$(OBJDIR)/%.o:	$(SRCDIR)/%.c
+	$(LCC) $(CFLAGS) -c -o $@ $<
+
+# Compile .c files in "res/" to .o object files
+$(OBJDIR)/%.o:	$(RESDIR)/%.c
+	$(LCC) $(CFLAGS) -c -o $@ $<
+
+# Compile .s assembly files in "src/" to .o object files
+$(OBJDIR)/%.o:	$(SRCDIR)/%.s
+	$(LCC) $(CFLAGS) -c -o $@ $<
+
+# If needed, compile .c files in "src/" to .s assembly files
+# (not required if .c is compiled directly to .o)
+$(OBJDIR)/%.s:	$(SRCDIR)/%.c
+	$(LCC) $(CFLAGS) -S -o $@ $<
+
+# Link the compiled object files into a .gb ROM file
+$(BINS):	$(OBJS)
+	$(LCC) $(LCCFLAGS) $(CFLAGS) -o $(BINDIR)/$(PROJECTNAME).$(EXT) $(OBJS)
+
+clean:
+	@echo Cleaning
+	@for target in $(TARGETS); do \
+		$(MAKE) $$target-clean; \
+	done
+
+# Include available build targets
+include Makefile.targets
+
+
+# create necessary directories after Makefile is parsed but before build
+# info prevents the command from being pasted into the makefile
+ifneq ($(strip $(EXT)),)           # Only make the directories if EXT has been set by a target
+$(info $(shell mkdir -p $(MKDIRS)))
+endif

--- a/gbdk-lib/examples/cross-platform/libc_memcpy/Makefile.targets
+++ b/gbdk-lib/examples/cross-platform/libc_memcpy/Makefile.targets
@@ -1,0 +1,55 @@
+
+# Platform specific flags for compiling (only populate if they're both present)
+ifneq ($(strip $(PORT)),)
+ifneq ($(strip $(PLAT)),)
+CFLAGS += -m$(PORT):$(PLAT)
+endif
+endif
+
+# Called by the individual targets below to build a ROM
+build-target: $(BINS)
+
+clean-target:
+	rm -rf $(OBJDIR)
+	rm -rf $(BINDIR)
+
+gb-clean:
+	${MAKE} clean-target EXT=gb
+gb:
+	${MAKE} build-target PORT=sm83 PLAT=gb EXT=gb
+
+
+gbc-clean:
+	${MAKE} clean-target EXT=gbc
+gbc:
+	${MAKE} build-target PORT=sm83 PLAT=gb EXT=gbc
+
+
+pocket-clean:
+	${MAKE} clean-target EXT=pocket
+pocket:
+	${MAKE} build-target PORT=sm83 PLAT=ap EXT=pocket
+
+
+megaduck-clean:
+	${MAKE} clean-target EXT=duck
+megaduck:
+	${MAKE} build-target PORT=sm83 PLAT=duck EXT=duck
+
+
+sms-clean:
+	${MAKE} clean-target EXT=sms
+sms:
+	${MAKE} build-target PORT=z80 PLAT=sms EXT=sms
+
+
+gg-clean:
+	${MAKE} clean-target EXT=gg
+gg:
+	${MAKE} build-target PORT=z80 PLAT=gg EXT=gg
+
+
+nes-clean:
+	${MAKE} clean-target EXT=nes
+nes:
+	${MAKE} build-target PORT=mos6502 PLAT=nes EXT=nes

--- a/gbdk-lib/examples/cross-platform/libc_memcpy/src/libc_memcpy.c
+++ b/gbdk-lib/examples/cross-platform/libc_memcpy/src/libc_memcpy.c
@@ -1,0 +1,57 @@
+//
+// libc_memcpy.c
+// Simple test of memcpy/memset/memmove functions in C library string.h
+//
+
+#include <stdio.h>
+#include <string.h>
+
+#include <gbdk/platform.h>
+#include <gbdk/font.h>
+#include <gbdk/console.h>
+
+uint8_t memcpy_dst[300];
+const uint8_t memcpy_src[300];
+
+int benchmark_memcpy(int num, int size)
+{
+    int i;
+    uint16_t start_time = sys_time;
+    for(i = 0; i < num; i++)
+        memcpy(memcpy_dst, memcpy_src, size);
+    return (int)(sys_time - start_time);
+}
+
+void main(void)
+{
+    font_t ibm_font;
+
+    // init the font system to use IBM font
+    font_init();
+    ibm_font = font_load(font_ibm);
+    font_set(ibm_font);
+
+    // Test memcpy
+    {
+        char dst[4] = "dst";
+        const char* src = "src";
+        printf("memcpy(dst,src,2)\n-> %s\n", memcpy(dst, src, 2));
+    }
+    // Test memmove
+    {
+        char dst[4] = "dst";
+        const char* src = "src";
+        printf("memmove(dst,src,2)\n-> %s\n", memmove(dst, src, 2));
+    }
+    // Test memset
+    {
+        char dst[4] = "dst";
+        printf("memset(dst,x,2)\n-> %s\n", memset(dst, 'x', 2));
+    }
+    // Benchmark memcpy
+    printf("\nBenchmark memcpy:\n");
+    {
+        printf("800*memcpy(d,s,150)\n-> %d frames\n", benchmark_memcpy(800, 150));
+        printf("400*memcpy(d,s,300)\n-> %d frames\n", benchmark_memcpy(400, 300));
+    }
+}


### PR DESCRIPTION
* Make test execute memcpy, memmove and memset
* Make test do two benchmarks for memcpy with 150 and 300 bytes, to identify < 256-bytes length optimizations