### PR TITLE
NES: Change nes target to use asm implementation of strcmp function

### DIFF
--- a/gbdk-lib/include/asm/mos6502/provides.h
+++ b/gbdk-lib/include/asm/mos6502/provides.h
@@ -1,4 +1,4 @@
 #define USE_C_MEMCPY	0
 #define USE_C_STRCPY	0
-#define USE_C_STRCMP	1
+#define USE_C_STRCMP	0
 


### PR DESCRIPTION
* Change USE_C_STRCMP in gbdk-lib/include/asm/mos6502/provides.h to 0