### PR TITLE
Docs: 4.2.0 updates + update undefs for platform header files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ __Supported Consoles:__ [(see docs)](https://gbdk-2020.github.io/gbdk-2020/docs/
 - Analogue Pocket
 - Sega Master System & Game Gear
 - Mega Duck / Cougar Boy
+- NES
 
 Expirimental consoles (not yet fully functional)
   - MSXDOS
-  - NES
 
 
 ## Current Release

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,3 +1,38 @@
+gbdk-4.2.0
+    - Library fixes/improvements
+      - Added: set_bkg_attributes(), set_bkg_submap_attributes(), set_bkg_attribute_xy()
+      - Some functions renamed (old names will work for now)
+        - vsync(): replaces wait_vbl_done()
+        - set_default_palette(): replaces cgb_compatibility()
+        - move_metasprite_flipy(): replaces move_metasprite_hflip()
+        - move_metasprite_flipx(): replaces move_metasprite_vflip()
+        - move_metasprite_flipxy(): replaces move_metasprite_hvflip()
+        - move_metasprite_ex(): (replaces move_metasprite()
+      - metasprites: added metasprite functions which can set base sprite property parameter
+    - NES
+      - Added support for much of the GBDK API
+      - Banking support (library and sdcc toolchain)
+      - Added set_bkg_attributes_nes16x16(), set_bkg_submap_attributes_nes16x16(), set_bkg_attribute_xy_nes16x16()
+    - Game Boy
+      - Faster vmemcpy(), set_data(), get_data()
+      - Fixed hide_sprites_range(39u, 40u) overflow shadow OAM
+      - Removed legacy MBC register definitions `.MBC1_ROM_PAGE` and `.MBC_ROM_PAGE`
+      - Workaround for possible HALT bug in Crash Handler
+    - Refactored interrupts to use less space
+    - lcc "lcc"
+      - Fixed `--sdccbindir`
+    - utility_png2asset "png2asset"
+      - Added `-repair_index_pal`: Tries to repair tile palettes
+      - Added `-no_palettes`: Do not export palette data
+      - Fixed support for indexed color pngs with less than 8 bits color depth
+      - Fixed incorrect palettes when different colors have same luma value
+    - Added sdld6808 (for NES)
+    - Examples
+      - Wav Playback: Improved support on AGB/AGS hardware
+      - Large Map: Added color for supported platforms
+      - Added GB-Type example
+    - Updated documentation
+
 gbdk-4.1.1
     - Library fixes/improvements
       - Fixed RGB() and RGB8() macros
@@ -305,3 +340,107 @@ gbdk-2.92:
     work.
     * Fixed minor bug with 104$: labels in as.
     * Up to 167d/s...
+
+...
+
+gbdk-2.15:
+MLH
+    Fixed memset() for when the length is zero
+    Optimised memset() - now 75% faster (see examples/tests/test-memset.c)
+    Did the same thing to memcpy()
+    Re-wrote the malloc() routines
+    Added support for native (ie assembly) malloc() replacements
+    Few changes to .mul16, .asl16 etc (Sam Nova)
+
+...
+
+gbdk-2.0b11:
+    Changes in GBDK 2.0b11 (DOS binary only) - 24 Nov 97
+    • Fixed another bug in code generation, that could happen when performing logical operations on 1-byte variables.
+
+gbdk-2.0b10:
+    Changes in GBDK 2.0b10 (DOS binary only) - 6 Nov 97
+    • Fixed a nasty bug in code generation, that could happen when performing arithmetic operations on 1-byte variables.
+    • Changed the name of same files of the gb-dtmf example so that it compiles on DOS.
+
+gbdk-2.0b9:
+    Changes in GBDK 2.0b9 (DOS binary only)
+    • Several bug fixes in the compiler and in the libraries.
+
+gbdk-2.0b8:
+    Changes in GBDK 2.0b8 (DOS binary only)
+    • Limited all file names to 8 characters to solve problems on DOS.
+    • Added communication routines that enable to send data through the link port of the GameBoy. Unfortunately, these routines do not always work; so use them with care until the next GBDK release.
+    • Added the comm.c example which illustrates how to use communication routines.
+    • It is possible to specify the name of the program (to be written in the image header) at link time using the -Wl-yn="XXX" flag (where X is the name of the program, which can contain up to 16 characters in quotes, including spaces; on Unix, depending on your shell, you must add backslashes before quotes and spaces like in -Wl-yn=\"My\ Game\").
+    • Several bug fixes in the compiler.
+
+gbdk-2.0b7:
+    Changes in GBDK 2.0b7 (DOS binary only)
+    • GBDK now uses a pre-release of lcc 4.1 (DOS binary only), that fixes a couple of problems in code generation.
+    • A couple of important points have been documented in the GBDK Programming Guidelines and Known Problems sections.
+    • Several improvements and optimizations to the code generator.
+
+gbdk-2.0b6:
+    Changes in GBDK 2.0b6
+    • Added a peephole optimizer (with few rules at the moment).
+    • Changed the name of the hardware registers to match the "official" names.
+    • Added support for copying complete functions to RAM or HIRAM (memcpy() and hiramcpy() functions). The compiler now automatically generates two symbol for the start and the end of each function, named start_X and end_X (where X is the name of the function). This enables to calculate the length of a function when copying it to RAM.
+    • Added the ram_fn.c example which illustrates how to copy functions to RAM and HIRAM.
+    • Added support for installing IRQ handlers.
+    • Added the irq.c example which illustrates how to install IRQ handlers.
+    • Added RAM banks support (switch_ram_bank() function). The switch_bank() function
+    has been renamed to switch_rom_bank(). The banks.c example has been updated. The flags for generating multiple bank images have been modified.
+    • It is possible to set the sprite ram location at link time using the -Wl-g.OAM=# flag (where # is the address of the sprite ram). The sprite ram address must begin at an address multiple of 0x100, and is 0xA0 bytes long.
+
+gbdk-2.0b5:
+    Changes in GBDK 2.0b5
+    • New documentation (not finished yet).
+    • Fixed a bug that could generate wrong code in switch statements.
+    • Fixed a bug in int comparison.
+    • Added a DTMF program written by Osamu Ohashi.
+    • Added a game (Deep Scan) written by a friend of Osamu.
+    • Modified the delay() function so that it takes a long parameter. It can be used to wait between 1 and 65536 milliseconds (0 = 65536). The pause() function has been removed.
+
+gbdk-2.0b4:
+    Changes in GBDK 2.0b4
+    • Fixed a bug that could generate wrong code when using hexadecimal constants.
+    • A new example (galaxy.c) has been added. It is the C version of the space.s
+    example. sprite.c has been removed.
+    • Most of the libraries have been split into small modules for reducing final code size.
+
+gbdk-2.0b3:
+    Changes in GBDK 2.0b3
+    • GBDK can generate multiple-banks images, i.e. images greater than 32kB (see the banks example).
+    • It is possible to set the stack pointer at link time using the -Wl-g.STACK=# flag (where # is the address of the stack pointer).
+    • Several functions (e.g. show_bkg()) have been changed into macros (e.g. SHOW_BKG).
+    • The delay() function waits exactly 1 millisecond, and the pause() waits 256 milliseconds.
+    • Linking with the standard libraries is no more required. The lib/gb.lib (lib\gb.lib on DOS) text file contains a list of modules in which to look for undefined symbols. The linker will parse this file, and link your code with the required modules only. The stdio library has been split in several object files, and only necessary modules will be added to your code, thus reducing its size.
+    • The GBDK distribution can be located anywhere in your system if you use the -Wo-lccdir=GBDK-DIR flag when invoking lcc.
+    • Bug fixes.
+
+gbdk-2.0b2:
+    Changes in GBDK 2.0b2
+    • Lots of bug fixes.
+    • GBDK has to be in the \GBDK-2.0 directory on DOS machines.
+
+gbdk-2.0b1:
+    Changes in GBDK 2.0b1
+    • The code generator has been completely rewritten with the new version of lcc. It produces much smaller and more efficient code. The size of the code is generally between 20 and 50% smaller. A number of small optimizations are still to be done.
+    • The size of basic types has been changed:
+        ◦ An int is 8 bits.
+        ◦ A long is 16 bits.
+        This change was required for the code generator to produce better code,
+        because the Z80 is actually an 8-bit processor.
+        • The linker generates the complement checksum correctly now.
+        • The libraries and example programs have been modified for the new code generator.
+
+gbdk-1.1:
+    Changes in GBDK 1.1
+    • Removed Xloadimage from the GBDK distribution. It is now available as a
+    separate archive.
+    • A compiled DOS version is now available (cross-compiled on my Sun
+    Workstation!).
+    • The libraries and the example programs have been improved.
+    • The make script has been improved. Compiling on UNIX should be easier.
+    • Many bugfixes.

--- a/docs/pages/06b_supported_consoles.md
+++ b/docs/pages/06b_supported_consoles.md
@@ -353,8 +353,7 @@ Bit-depth specific API calls:
 - 2bpp: @ref set_2bpp_palette, @ref set_bkg_2bpp_data, @ref set_sprite_2bpp_data
 
 Platform specific API calls:
-- set_bkg_attributes_nes16x16(), set_bkg_submap_attributes_nes16x16()
-- set_bkg_attribute_xy_nes16x16()
+- set_bkg_attributes_nes16x16(), set_bkg_submap_attributes_nes16x16(), set_bkg_attribute_xy_nes16x16()
 
 
 #### Game Boy Color map attributes on the NES

--- a/docs/pages/10_release_notes.md
+++ b/docs/pages/10_release_notes.md
@@ -13,6 +13,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
   - Known Issues
     - SDCC may fail on Windows when @ref windows_sdcc_non_c_drive_path_spaces "run from folder names with spaces on non-C drives".
   - Library
+    - Added `NORETURN` definition (for `_Noreturn`)
     - Added: set_bkg_attributes(), set_bkg_submap_attributes(), set_bkg_attribute_xy()
     - The following new functions replace old ones. The old functions will continue to work for now, but migration to new versions is strongly encouraged.
       - vsync(): replaces wait_vbl_done()
@@ -23,7 +24,9 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - move_metasprite_flipxy(): replaces move_metasprite_hvflip()
       - move_metasprite_ex(): (replaces move_metasprite()
     - NES
+      - Added support for much of the GBDK API
       - Banking support (library and sdcc toolchain)
+      - Added set_bkg_attributes_nes16x16(), set_bkg_submap_attributes_nes16x16(), set_bkg_attribute_xy_nes16x16()
     - Game Boy
       - Minor crt0 optimizations
       - Faster vmemcpy(), set_data(), get_data()
@@ -40,6 +43,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - Removed the unused `-DINT_16_BITS` from the default SDCC compiler and preprocessor arguments
       - Improved improved Game Gear header compatibility (change header region code from 4 to 6)
     - @ref utility_png2asset "png2asset"
+      - Added `-o` as a more standard version of the `-c` argument
       - Added `-repair_index_pal`: Tries to repair tile palettes for indexed color pngs (such as when RGB paint programs mix up indexed colors if the same color exists in multiple palettes). Implies `-keep_palette_order`
       - Added `-no_palettes`: Do not export palette data
       - Fixed support for indexed color pngs with less than 8 bits color depth

--- a/docs/pages/20_toolchain_settings.md
+++ b/docs/pages/20_toolchain_settings.md
@@ -43,7 +43,7 @@
 @anchor sdcc-settings
 # sdcc settings
 ```
-SDCC : z80/sm83/mos6502/mos65c02 TD- 4.2.14 #14088 (Linux)
+SDCC : z80/sm83/mos6502/mos65c02 TD- 4.3.2 #14228 (Linux)
 published under GNU General Public License (GPL)
 Usage : sdcc [options] filename
 Options :-
@@ -102,24 +102,25 @@ Code generation options:
       --dataseg             <name> use this name for the data segment
 
 Optimization options:
+      --opt-code-speed      Optimize for code speed rather than size
+      --opt-code-size       Optimize for code size rather than speed
+      --max-allocs-per-node  Maximum number of register assignments considered at each node of the tree decomposition
+      --no-reg-params       On some ports, disable passing some parameters in registers
+      --nostdlibcall        Disable optimization of calls to standard library
       --nooverlay           Disable overlaying leaf function auto variables
       --nogcse              Disable the GCSE optimisation
+      --nolospre            Disable lospre
+      --nogenconstprop      Disable generalized constant propagation
       --nolabelopt          Disable label optimisation
       --noinvariant         Disable optimisation of invariants
       --noinduction         Disable loop variable induction
       --noloopreverse       Disable the loop reverse optimisation
       --no-peep             Disable the peephole assembly file optimisation
-      --no-reg-params       On some ports, disable passing some parameters in registers
       --peep-asm            Enable peephole optimization on inline assembly
       --peep-return         Enable peephole optimization for return instructions
       --no-peep-return      Disable peephole optimization for return instructions
       --peep-file           <file> use this extra peephole file
-      --opt-code-speed      Optimize for code speed rather than size
-      --opt-code-size       Optimize for code size rather than speed
-      --max-allocs-per-node  Maximum number of register assignments considered at each node of the tree decomposition
-      --nolospre            Disable lospre
       --allow-unsafe-read   Allow optimizations to read any memory location anytime
-      --nostdlibcall        Disable optimization of calls to standard library
 
 Internal debugging options:
       --dump-ast            Dump front-end AST before generating i-code
@@ -507,9 +508,11 @@ Options:
   -N             generate Famicom/NES format binary file
   -o bytes       skip amount of bytes in binary file
 SMS format options (applicable only with -S option):
-  -xo n          rom size (0xa-0x2) (default: 0xc)
+  -xo n          header rom size (0xa-0x2) (default: 0xc)
   -xj n          set region code (3-7) (default: 4)
   -xv n          version number (0-15) (default: 0)
+  -yo n          number of rom banks (default: 2) (autosize: A)
+  -ya n          number of ram banks (default: 0)
 GameBoy format options (applicable only with -Z option):
   -yo n          number of rom banks (default: 2) (autosize: A)
   -ya n          number of ram banks (default: 0)
@@ -560,7 +563,8 @@ The rle compression is Amiga IFF style
 # png2asset settings
 ```
 usage: png2asset    <file>.png [options]
--c                  ouput file (default: <png file>.c)
+-o                  ouput file (default: <png file>.c)
+-c                  deprecated, same as -o
 -sw <width>         metasprites width size (default: png width)
 -sh <height>        metasprites height size (default: png height)
 -sp <props>         change default for sprite OAM property bytes (in hex) (default: 0x00)
@@ -571,7 +575,7 @@ usage: png2asset    <file>.png [options]
 -spr8x8             use SPRITES_8x8
 -spr8x16            use SPRITES_8x16 (this is the default)
 -spr16x16msx        use SPRITES_16x16
--b <bank>           bank (default 0)
+-b <bank>           bank (default: fixed bank)
 -keep_palette_order use png palette
 -repair_indexed_pal try to repair indexed tile palettes (implies "-keep_palette_order")
 -noflip             disable tile flip
@@ -583,7 +587,7 @@ usage: png2asset    <file>.png [options]
 -bpp                bits per pixel: 1, 2, 4 (default: 2)
 -max_palettes       max number of palettes allowed (default: 8)
                     (note: max colors = max_palettes x num colors per palette)
--pack_mode          gb, sgb, sms, 1bpp (default: gb)
+-pack_mode          gb, nes, sgb, sms, 1bpp (default: gb)
 -tile_origin        tile index offset for maps (default: 0)
 -tiles_only         export tile data only
 -maps_only          export map tilemap only

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -956,7 +956,7 @@ inline void set_1bpp_colors(uint8_t fgcolor, uint8_t bgcolor) {
 
     @note Sprite Tiles 128-255 share the same memory region as Background Tiles 128-255.
 
-    GBC only: @ref VBK_REG determines which bank of Background tile patterns are written to.
+    GBC only: @ref VBK_REG determines which bank of tile patterns are written to.
     \li VBK_REG = @ref VBK_BANK_0 indicates the first bank
     \li VBK_REG = @ref VBK_BANK_1 indicates the second
 
@@ -1672,7 +1672,7 @@ inline void scroll_win(int8_t x, int8_t y) {
 
     @note Sprite Tiles 128-255 share the same memory region as Background Tiles 128-255.
 
-    GBC only: @ref VBK_REG determines which bank of Background tile patterns are written to.
+    GBC only: @ref VBK_REG determines which bank of tile patterns are written to.
     \li VBK_REG = @ref VBK_BANK_0 indicates the first bank
     \li VBK_REG = @ref VBK_BANK_1 indicates the second
 */
@@ -1905,7 +1905,7 @@ inline void hide_sprite(uint8_t nb) {
 
     Copies __len__ bytes from a buffer at __data__ to VRAM starting at __vram_addr__.
 
-    GBC only: @ref VBK_REG determines which bank of Background tile patterns are written to.
+    GBC only: @ref VBK_REG determines which bank of tile patterns are written to.
     \li VBK_REG = @ref VBK_BANK_0 indicates the first bank
     \li VBK_REG = @ref VBK_BANK_1 indicates the second
 
@@ -1929,7 +1929,7 @@ void set_data(uint8_t *vram_addr, const uint8_t *data, uint16_t len);
 
     Copies __len__ bytes from VRAM starting at __vram_addr__ into a buffer at __data__.
 
-    GBC only: @ref VBK_REG determines which bank of Background tile patterns are written to.
+    GBC only: @ref VBK_REG determines which bank of tile patterns are written to.
     \li VBK_REG = @ref VBK_BANK_0 indicates the first bank
     \li VBK_REG = @ref VBK_BANK_1 indicates the second
 
@@ -1945,7 +1945,7 @@ void get_data(uint8_t *data, uint8_t *vram_addr, uint16_t len);
 
     Copies __len__ bytes from or to VRAM starting at __sour__ into a buffer or to VRAM at __dest__.
 
-    GBC only: @ref VBK_REG determines which bank of Background tile patterns are written to.
+    GBC only: @ref VBK_REG determines which bank of tile patterns are written to.
     \li VBK_REG = @ref VBK_BANK_0 indicates the first bank
     \li VBK_REG = @ref VBK_BANK_1 indicates the second
 */
@@ -2051,7 +2051,7 @@ inline void set_native_tile_data(uint16_t first_tile, uint8_t nb_tiles, const ui
     Writes __nb_tiles__ tiles to VRAM starting at __first_tile__, tile data
     is sourced from __data__.
 
-    GBC only: @ref VBK_REG determines which bank of Background tile patterns are written to.
+    GBC only: @ref VBK_REG determines which bank of tile patterns are written to.
     \li VBK_REG = @ref VBK_BANK_0 indicates the first bank
     \li VBK_REG = @ref VBK_BANK_1 indicates the second
 
@@ -2070,7 +2070,7 @@ inline void set_bkg_native_data(uint8_t first_tile, uint8_t nb_tiles, const uint
     Writes __nb_tiles__ tiles to VRAM starting at __first_tile__, tile data
     is sourced from __data__.
 
-    GBC only: @ref VBK_REG determines which bank of Background tile patterns are written to.
+    GBC only: @ref VBK_REG determines which bank of tile patterns are written to.
     \li VBK_REG = @ref VBK_BANK_0 indicates the first bank
     \li VBK_REG = @ref VBK_BANK_1 indicates the second
 */

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -9,10 +9,21 @@
 #include <gbdk/version.h>
 #include <gb/hardware.h>
 
+// Here NINTENDO means Game Boy & related clones
 #define NINTENDO
+
 #ifdef SEGA
 #undef SEGA
 #endif
+
+#ifdef NINTENDO_NES
+#undef NINTENDO_NES
+#endif
+
+#ifdef MSX
+#undef MSX
+#endif
+
 #if defined(__TARGET_ap)
 #define ANALOGUEPOCKET
 #elif defined(__TARGET_gb)

--- a/gbdk-lib/include/msx/msx.h
+++ b/gbdk-lib/include/msx/msx.h
@@ -10,12 +10,20 @@
 #include <msx/hardware.h>
 
 #define MSX
+
+// Here NINTENDO means Game Boy & related clones
 #ifdef NINTENDO
 #undef NINTENDO
 #endif
+
+#ifdef NINTENDO_NES
+#undef NINTENDO_NES
+#endif
+
 #ifdef SEGA
 #undef SEGA
 #endif
+
 #if defined(__TARGET_msxdos)
 #define MSXDOS
 #endif

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -905,7 +905,7 @@ inline void scroll_bkg(int8_t x, int8_t y) {
 
     Note: Sprite Tiles 128-255 share the same memory region as Background Tiles 128-255.
 
-    GBC only: @ref VBK_REG determines which bank of Background tile patterns are written to.
+    GBC only: @ref VBK_REG determines which bank of tile patterns are written to.
     \li VBK_REG=0 indicates the first bank
     \li VBK_REG=1 indicates the second
 */

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -11,9 +11,20 @@
 #include <nes/rgb_to_nes_macro.h>
 
 #define NINTENDO_NES
+
+// Here NINTENDO means Game Boy & related clones
+#ifdef NINTENDO
+#undef NINTENDO
+#endif
+
 #ifdef SEGA
 #undef SEGA
 #endif
+
+#ifdef MSX
+#undef MSX
+#endif
+
 
 #define RGB(r,g,b)        RGB_TO_NES(((r) | ((g) << 2) | ((b) << 4)))
 #define RGB8(r,g,b)       RGB_TO_NES((((r) >> 6) | (((g) >> 6) << 2) | (((b) >> 6) << 4)))

--- a/gbdk-lib/include/sms/sms.h
+++ b/gbdk-lib/include/sms/sms.h
@@ -10,9 +10,20 @@
 #include <sms/hardware.h>
 
 #define SEGA
+
+// Here NINTENDO means Game Boy & related clones
 #ifdef NINTENDO
 #undef NINTENDO
 #endif
+
+#ifdef NINTENDO_NES
+#undef NINTENDO_NES
+#endif
+
+#ifdef MSX
+#undef MSX
+#endif
+
 #if defined(__TARGET_sms)
 #define MASTERSYSTEM
 #elif defined(__TARGET_gg)


### PR DESCRIPTION
- Docs: some rough NES info in supported consoles pages
- More release notes
- Updated toolchain settings (via make docstools)
- Update console un-defines for platform header files
- Docs: 4.2 text file chaneglog
- Bonus: changelogs for some ancient versions