### PR TITLE
Bugfix: skip keep_duplicate_tiles logic when using a source_tileset

### DIFF
--- a/gbdk-support/png2asset/png2asset.cpp
+++ b/gbdk-support/png2asset/png2asset.cpp
@@ -184,7 +184,7 @@ void GetMetaSprite(int _x, int _y, int _w, int _h, int pivot_x, int pivot_y)
 				unsigned char props;
 				unsigned char pal_idx = image.data[y * image.w + x] >> 2; //We can pick the palette from the first pixel of this tile
 
-				if(keep_duplicate_tiles)
+				if((!use_source_tileset) && keep_duplicate_tiles)
 				{
 					tiles.push_back(tile);
 					idx = tiles.size() - 1;
@@ -233,7 +233,7 @@ void GetMap()
 			size_t idx;
 			unsigned char props;
 
-			if(keep_duplicate_tiles)
+			if((!use_source_tileset) && keep_duplicate_tiles)
 			{
 				tiles.push_back(tile);
 				idx = tiles.size() - 1;


### PR DESCRIPTION
This fixes a bug in the interaction between two features: when both source_tileset and keep_duplicate_tiles are used, the resulting generated map is just a list of steadily increasing numbers.

To reproduce:

* Create tileset.png and map1.png
* Call png2asset as follows: `png2asset -keep_duplicate_tiles -map -source_tileset tileset.png map1.png -c map1.c`

The resulting map will look as follows, regardless of the tile & map content:

```
const unsigned char map1_map[...] = {
	0x00,0x01,0x02,0x03,0x04,0x05,0x06,... (etc)
};
```

... because the keep_duplicate_tiles logic is applied to both the source tileset PNG *and* the map PNG, when it should only be applied to the former.