### PR TITLE
NES: Re-enable peephole optimization for nes target

### DIFF
--- a/gbdk-support/lcc/targets.c
+++ b/gbdk-support/lcc/targets.c
@@ -159,7 +159,7 @@ CLASS classes[] = {
       .rom_extension=  EXT_NES,
       .cpp          = "%cpp% %cppdefault% $1 $2 $3",
       .include      = "%includedefault%",
-      .com          = "%com% %comdefault% -Wa%asdefault% --no-peep $1 %comflag% $2 -o $3",
+      .com          = "%com% %comdefault% -Wa%asdefault% $1 %comflag% $2 -o $3",
       .as           = "%as_6500% %asdefault% $1 $3 $2",
       .bankpack     = "%bankpack% -plat=nes -mapper=30 $1 $2",
       .ld           = "%ld_6808% -a nes -n -i -j $1 %libs_include% $3 %crt0dir% $2",


### PR DESCRIPTION
* Remove --no-peep parameter in gbdk-support/lcc/targets.c