### PR TITLE
Docs: doxygen: define NINTENDO when parsing headers. fixes EMU_profiler_message() not showing up in docs

### DIFF
--- a/docs/config/gbdk-2020-doxyfile
+++ b/docs/config/gbdk-2020-doxyfile
@@ -2172,7 +2172,10 @@ INCLUDE_FILE_PATTERNS  =
 # Define __PORT_sm83 fixes some functions that would get missed in
 # headers that are shared by multiple platforms. Use the Game Boy
 # versions by default
-PREDEFINED=__PORT_sm83 __TARGET_gb
+#
+# Define NINTENDO (meaning Game Boy) to ensure functions in some headers are enabled
+#
+PREDEFINED=__PORT_sm83 __TARGET_gb NINTENDO
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/pages/06_toolchain.md
+++ b/docs/pages/06_toolchain.md
@@ -317,6 +317,8 @@ An updated version of Glen Cook's Windows GUI "hicolour.exe" 1.2 conversion tool
 
 "Hi Color" on the Game Boy Color is a technique for displaying backgrounds with thousands of colors instead being limtied to 32 colors for the entire screen background. It achieves this by changing ~16 colors of the background palette per scanline. The main tradeoffs are that it uses much of the Game Boy's available cpu processing per frame and requires more ROM space. The tile patterns, map, attributes and per-scanline palettes are pre-calculated using the PC based conversion tool.
 
+For the current GBDK example ISR implementation there is a limit of 6 sprites per line before the hi-color timing breaks down and there start to be background artifacts.
+
 Example: `png2hicolorgb myimage.png --csource -o=my_output_filename`
 Example with higher quality (slower conversion): `png2hicolorgb myimage.png --csource -o=my_output_filename --type=3 -L=2 -R=2`
 

--- a/gbdk-lib/examples/gb/hicolor/Readme.md
+++ b/gbdk-lib/examples/gb/hicolor/Readme.md
@@ -5,6 +5,8 @@ PNG images placed in the res/hicolor folder will get automatically converted and
 
 To use them, include the automatically generated header file (based on the png filename) and then use the `hicolor_start()` and `hicolor_stop()` functions.
 
+For the current GBDK example ISR implementation there is a limit of 6 sprites per line before the hi-color timing breaks down and there start to be background artifacts.
+
 # Pallete ISR
 The new palette update ISR is contributed by Toxa
 https://github.com/untoxa

--- a/gbdk-lib/include/gbdk/emu_debug.h
+++ b/gbdk-lib/include/gbdk/emu_debug.h
@@ -124,6 +124,7 @@ __endasm
 #define EMU_TEXT(MSG) EMU_MESSAGE(MSG)
 #define BGB_TEXT(MSG) EMU_TEXT(MSG)
 
+#if defined(NINTENDO)
 /** Display preset debug information in the Emulator debug messages window.
 
     This function is equivalent to:
@@ -132,7 +133,6 @@ __endasm
     \endcode
 
 */
-#if defined(NINTENDO)
 void EMU_profiler_message(void);
 #define BGB_profiler_message EMU_profiler_message()
 #endif // NINTENDO


### PR DESCRIPTION
 - Also move comment for function inside platform ifdef
 - Also add sprite limit per scanline note for gb hi-color example