### PR TITLE
NES bugfix: Actually apply _map_tile_offset for set_bkg_based_tiles

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/set_bk_ts.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_bk_ts.s
@@ -8,6 +8,7 @@
     .ypos:                      .ds 1
     .num_rows:                  .ds 1
     .src_tiles:                 .ds 2
+    __map_tile_offset:          .ds 1
 
     .area   _HOME
 
@@ -54,6 +55,8 @@ _set_bkg_tiles_horizontalStripes:
     ldy #0
 2$:
     lda [*.src_tiles],y
+    clc
+    adc *__map_tile_offset
     iny
     jsr .ppu_stripe_write_byte
     dex
@@ -108,6 +111,8 @@ _set_bkg_tiles_verticalStripes::
     ldx *.height
 2$:
     lda [*.src_tiles],y
+    clc
+    adc *__map_tile_offset
     jsr .ppu_stripe_write_byte
     ; .src_tiles += width
     lda *.width


### PR DESCRIPTION
* Add __map_tile_offset to OSEG in libc/targets/mos6502/nes/set_bk_ts.s
* Add __map_tile_offset to fetched tile in libc/targets/mos6502/nes/set_bk_ts.s