### PR TITLE
NES: Fix support for 4-player controllers using fourscore

### DIFF
--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -75,14 +75,14 @@ void set_sprite_palette_entry(uint8_t palette, uint8_t entry, palette_color_t rg
 
     @see joypad
  */
-#define J_UP         0x10U
-#define J_DOWN       0x20U
-#define J_LEFT       0x40U
-#define J_RIGHT      0x80U
-#define J_A          0x01U
-#define J_B          0x02U
-#define J_SELECT     0x04U
-#define J_START      0x08U
+#define J_UP         0x08U
+#define J_DOWN       0x04U
+#define J_LEFT       0x02U
+#define J_RIGHT      0x01U
+#define J_A          0x80U
+#define J_B          0x40U
+#define J_SELECT     0x20U
+#define J_START      0x10U
 
 /** Screen modes.
     Normally used by internal functions only.

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -4,14 +4,14 @@
         VRAM_DELAY_CYCLES_X8  = 167
 
         ;;  Keypad
-        .UP             = 0x10
-        .DOWN           = 0x20
-        .LEFT           = 0x40
-        .RIGHT          = 0x80
-        .A              = 0x01
-        .B              = 0x02
-        .SELECT         = 0x04
-        .START          = 0x08
+        .UP             = 0x08
+        .DOWN           = 0x04
+        .LEFT           = 0x02
+        .RIGHT          = 0x01
+        .A              = 0x80
+        .B              = 0x40
+        .SELECT         = 0x20
+        .START          = 0x10
 
         ;;  Screen dimensions (in tiles)
         .DEVICE_SCREEN_WIDTH            = 32

--- a/gbdk-lib/libc/targets/mos6502/nes/pad.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/pad.s
@@ -2,20 +2,43 @@
 
     .area   _HOME
 
-_read_joypad::
-    ; Strobe to latch joypad data
+_strobe_joypads::
     lda #1
     sta JOY1
     lda #0
     sta JOY1
+    rts
+
+_read_joypad::
+    ; Strobe to latch joypad data
+    jsr _strobe_joypads
+_read_joypad_no_strobe::
     ;
-    ldy #8
-_read_joypad_loop:
     lda JOY1,x
     lsr
-    ror *.tmp+1
-    dey
-    bne _read_joypad_loop
+    rol *.tmp+1
+    lda JOY1,x
+    lsr
+    rol *.tmp+1
+    lda JOY1,x
+    lsr
+    rol *.tmp+1
+    lda JOY1,x
+    lsr
+    rol *.tmp+1
+    lda JOY1,x
+    lsr
+    rol *.tmp+1
+    lda JOY1,x
+    lsr
+    rol *.tmp+1
+    lda JOY1,x
+    lsr
+    rol *.tmp+1
+    lda JOY1,x
+    lsr
+    rol *.tmp+1
+    ;
     lda *.tmp+1
     rts
 


### PR DESCRIPTION
* Reverse order of bits in joypad byte and bitmasks for buttons, to conform to more common order in nesdev
* Bump MAX_JOYPADS definition in joypad_ex.s from 2 to 4
* Add label read_joypad_no_strobe, to avoid repeated strobing when reading multiple controllers
* Update joypad_ex function to call read_joypad_no_strobe repeatedly for as many controllers as initialized in joypads_t struct
* Unroll joypad reading loop for less cycles and no clobbering of Y register