### PR TITLE
defaulting default props to zero

### DIFF
--- a/gbdk-support/png2asset/process_arguments.cpp
+++ b/gbdk-support/png2asset/process_arguments.cpp
@@ -45,6 +45,7 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
 
 	args->pack_mode = Tile::GB;
 	args->flip_tiles = true;
+	args->props_default = 0;
 	args->keep_duplicate_tiles = false;
 	args->include_palettes = true;
 	args->includedMapOrMetaspriteData = true;


### PR DESCRIPTION
when i printed the values of the default_props on windows i got crazy values. when i set the default to 0, my map was matching the map of the camera_sgb_border.c sent to me by @bbbbbr .