### PR TITLE
Remove nonexistant __nonbanked directive for sdcc mos6502 target

### DIFF
--- a/gbdk-lib/include/asm/mos6502/types.h
+++ b/gbdk-lib/include/asm/mos6502/types.h
@@ -11,7 +11,7 @@
 
 #ifdef __SDCC
 
-#define NONBANKED			__nonbanked
+#define NONBANKED           /* __nonbanked */ /** < __nonbanked directive does not exist in sdcc for target mos6502 */
 #define BANKED				__banked
 #define REENTRANT			__reentrant /**< Needed for mos6502 target when functions take too many parameters. */
 #define NO_OVERLAY_LOCALS	__no_overlay_locals /**< Optimization for mos6502 target, indicating locals won't conflict with compiler's overlay segment */


### PR DESCRIPTION
The `NONBANKED` macro causes a build error when present after a function prototype, because the most recent `sdcc` version does not have this compiler directive for the `mos6502` target.

**Build Command** (from Makefile)**:**
```bash
/bin/sdcc -I../include -D__PORT_mos6502 -D__TARGET_mos6502 -mmos6502 --max-allocs-per-node 50000 --fsigned-char -c -o ../build/mos6502/atoi.o atoi.c
```

**Build Error** (without fix)**:**
```bash
atoi.c:10: syntax error: token -> '__nonbanked' ; column 35
```