### PR TITLE
Png2asset: -bin mode: fix sgb export, honor -maps_only, -tiles_only

### DIFF
--- a/gbdk-support/png2asset/export.cpp
+++ b/gbdk-support/png2asset/export.cpp
@@ -335,6 +335,8 @@ bool export_c_file( PNG2AssetData* assetData) {
 			//Export map
 			fprintf(file, "\n");
 			fprintf(file, "const unsigned char %s_map[%d] = {\n", assetData->args->data_name.c_str(), (unsigned int)(assetData->map.size()));
+			// TODO: These hardwired "/ 8" should be using " / assetData->image.tile_w" and "_h"
+			// TODO: Should also be converted to using args.map_entry_size_bytes
 			size_t line_size = assetData->map.size() / (assetData->image.h / 8);
 			if(assetData->args->output_transposed) {
 
@@ -442,7 +444,9 @@ bool export_map_binary( PNG2AssetData* assetData) {
 
 
 	// Open our file for writing attributes if specified
-	if(assetData->args->use_map_attributes)mapAttributesBinaryfile.open(assetData->args->output_filename_attributes_bin, std::ios_base::binary);
+	if (assetData->args->use_map_attributes && assetData->map_attributes.size()) {
+		mapAttributesBinaryfile.open(assetData->args->output_filename_attributes_bin, std::ios_base::binary);
+	}
 
 	int columns = assetData->image.w >> 3;
 	int rows = assetData->image.h >> 3;
@@ -450,34 +454,37 @@ bool export_map_binary( PNG2AssetData* assetData) {
 	// If we want the values to be column-by-column
 	if(assetData->args->output_transposed) {
 
+		int map_entry_size = assetData->args->map_entry_size_bytes;
 		// Swap the column/row for loops
 		for(int column = 0; column < columns; column++) {
 			for(int row = 0; row < rows; ++row) {
 
-				int tile = column + row * columns;
-
-				const char mapChars[] = { (const char)assetData->map[tile] };
+				int tile = (column + row * columns) * map_entry_size;
 
 				// Write map items column-by-column
-				mapBinaryFile.write(mapChars, 1);
-				if(assetData->args->use_map_attributes) {
-					const char mapAttributeChars[] = { (const char)assetData->map_attributes[tile] };
-					mapAttributesBinaryfile.write(mapAttributeChars, 1);
+				mapBinaryFile.write( (const char *) &(assetData->map[tile]), map_entry_size);
+
+				if (assetData->args->use_map_attributes && assetData->map_attributes.size()) {
+				   mapAttributesBinaryfile.write( (const char*) &(assetData->map_attributes[tile]), map_entry_size);
 				}
 			}
 		}
 	}
 	else {
-
 		// Write the arrays as-is, row-by-row
-		mapBinaryFile.write((const char*)(&assetData->map[0]), rows * columns);
-		if(assetData->args->use_map_attributes)mapAttributesBinaryfile.write((const char*)(&assetData->map_attributes[0]), rows * columns);
+		mapBinaryFile.write((const char*)(&assetData->map[0]), assetData->map.size());
+
+		if (assetData->args->use_map_attributes && assetData->map_attributes.size()) {
+			mapAttributesBinaryfile.write((const char*)(&assetData->map_attributes[0]), assetData->map_attributes.size());
+		}
 	}
 
 	// Finalize the files
 	mapBinaryFile.close();
 	tilesBinaryFile.close();
-	if(assetData->args->use_map_attributes)mapAttributesBinaryfile.close();
+	if (assetData->args->use_map_attributes && assetData->map_attributes.size()) {
+		mapAttributesBinaryfile.close();
+	}
 
 	return true; // success
 }

--- a/gbdk-support/png2asset/main.cpp
+++ b/gbdk-support/png2asset/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
 
 	PNG2AssetData png2AssetInstance;
 
-	// If we have a source tilest
+	// If we have a source tileset
 	if(arguments.source_tilesets.size() > 0) {
 
 		vector<string>::iterator sourceTilesetsIterator = arguments.source_tilesets.begin();
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
 		// Iterate through each source tileset and execute
         while (sourceTilesetsIterator < arguments.source_tilesets.end()) {
 
-			// Run with our source tileset filename 
+			// Run with our source tileset filename
 			errorCode = png2AssetInstance.Execute(&arguments, *sourceTilesetsIterator);
 
 			// Return the error code if the function returns non-zero

--- a/gbdk-support/png2asset/process_arguments.cpp
+++ b/gbdk-support/png2asset/process_arguments.cpp
@@ -44,6 +44,7 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
 	args->max_palettes = 8;
 
 	args->pack_mode = Tile::GB;
+    args->map_entry_size_bytes = 1;
 	args->flip_tiles = true;
 	args->props_default = 0;
 	args->keep_duplicate_tiles = false;
@@ -220,8 +221,16 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
 			std::string pack_mode_str = argv[++i];
 			if(pack_mode_str == "gb")  args->pack_mode = Tile::GB;
 			else if(pack_mode_str == "nes") args->pack_mode = Tile::NES;
-			else if(pack_mode_str == "sgb") args->pack_mode = Tile::SGB;
-			else if(pack_mode_str == "sms") args->pack_mode = Tile::SMS;
+			else if(pack_mode_str == "sgb") {
+                args->pack_mode = Tile::SGB;
+                 // SGB attributes are packed in map data, so 2 bytes per map tile
+                args->map_entry_size_bytes = 2;
+            }
+			else if(pack_mode_str == "sms") {
+                args->pack_mode = Tile::SMS;
+                 // SMS attributes are packed in map data, so 2 bytes per map tile
+                args->map_entry_size_bytes = 2;
+            }
 			else if(pack_mode_str == "1bpp") args->pack_mode = Tile::BPP1;
 			else
 			{

--- a/gbdk-support/png2asset/process_arguments.h
+++ b/gbdk-support/png2asset/process_arguments.h
@@ -61,6 +61,7 @@ struct PNG2AssetArguments {
 	unsigned int source_tileset_size;
 
 	Tile::PackMode pack_mode;
+    int map_entry_size_bytes;
 
 };
 


### PR DESCRIPTION
png2asset: fix segfault and wrong data size on -bin export for SGB (and likely SMS)
- Make sure there is attrib data before trying to bin export it
- SGB and SMS pack attribute data into maps, so can't assume maps are 1 byte per tile in -bin mode. Added args.map_entry_size_bytes for determining size to use

png2asset: -bin mode: fix -tiles_only and -maps_only
- Make -bin export mode honor request to skip map or tile data export