### PR TITLE
Z80 jumps optimization for rle/gb decompressors

### DIFF
--- a/gbdk-lib/libc/targets/z80/gb_decompress.s
+++ b/gbdk-lib/libc/targets/z80/gb_decompress.s
@@ -20,9 +20,9 @@ _gb_decompress::
         ld      a, (hl) ; load command
         inc     hl
         or      a
-        jr      z, 9$   ; exit, if last byte
+        jr      z, 7$   ; exit, if last byte
         bit     7, a
-        jr      nz, 5$  ; string functions
+        jp      nz, 5$  ; string functions
         bit     6, a
         jr      nz, 3$
         ; RLE byte
@@ -35,8 +35,8 @@ _gb_decompress::
         ld      (de), a
         inc     de
         dec     b
-        jr      nz, 2$
-        jr      1$      ; next command
+        jp      nz, 2$
+        jp      1$      ; next command
 3$:                     ; RLE word
         and     #63
         inc     a
@@ -51,12 +51,12 @@ _gb_decompress::
         ld      (hl), b
         inc     hl
         dec     a
-        jr      nz, 4$
+        jp      nz, 4$
         ex      de, hl
-        jr      1$      ; next command
+        jp      1$      ; next command
 5$:
         bit     6, a
-        jr      nz, 7$
+        jr      nz, 6$
         ; string repeat
         and     #63
         inc     a
@@ -73,15 +73,15 @@ _gb_decompress::
         pop     hl
         inc     hl
         inc     hl
-        jr      1$      ; next command
-7$:                     ; string copy
+        jp      1$      ; next command
+6$:                     ; string copy
         and     #63
         inc     a
         ld      c, a
         ld      b, #0
         ldir
-        jr      1$      ; next command
-9$:
+        jp      1$      ; next command
+7$:
         pop     hl
         ex      de, hl
         or      a       ; clear carry flag

--- a/gbdk-lib/libc/targets/z80/rle_decompress.s
+++ b/gbdk-lib/libc/targets/z80/rle_decompress.s
@@ -44,14 +44,14 @@ _rle_decompress::
 
         ld a, (rle_current)
         bit 7, c
-        jr nz, 10$
-        jr 11$
+        jr nz, 7$
+        jp 8$
 1$:
         ;; Fetch the run
         ld c, (hl)
         inc hl
+
         ;; Negative means a run
-8$:
         bit 7, c
         jr z, 2$
         ;; Expanding a run
@@ -63,10 +63,10 @@ _rle_decompress::
 
         dec b
         jr z, 6$
-10$:
+7$:
         inc c
-        jr NZ, 3$
-        jr 1$
+        jp NZ, 3$
+        jp 1$
 2$:
         ;; Zero means end of a block
         inc c
@@ -79,10 +79,10 @@ _rle_decompress::
 
         dec b
         jr z, 6$
-11$:
+8$:
         dec c
-        jr NZ, 5$
-        jr 1$
+        jp NZ, 5$
+        jp 1$
 4$:
         ;; save state and exit
         ld hl, #0


### PR DESCRIPTION
on Z80 in some cases `jp` would be faster than `jr`
this change optimize decompression for speed

observerd improvments:

RLE (cycles without/with)
1177/1149 (2.37%) - `rle_decompress(data, MAP_DATA_HEIGHT);` from rle_map example (also depends on data up to 3%)

GB (cycles without/with)
162358/160190 (1.34%) - `gb_decompress(monalisa_tiles_comp, buffer)` from gbdecompress example 



