### PR TITLE
png2asset: fix -source_tileset

### DIFF
--- a/gbdk-support/png2asset/Makefile
+++ b/gbdk-support/png2asset/Makefile
@@ -5,7 +5,7 @@
 # LFLAGS = -s -static
 
 CXX = $(TOOLSPREFIX)g++
-CXXFLAGS = -Os -Wall -g
+CXXFLAGS = -Os -Wall -g # -Wextra -pedantic
 LFLAGS = -g
 
 ifeq ($(OS),Windows_NT)

--- a/gbdk-support/png2asset/export.cpp
+++ b/gbdk-support/png2asset/export.cpp
@@ -122,7 +122,8 @@ bool export_h_file( PNG2AssetData* assetData) {
         fprintf(file, "\n");
 
         // If we are not using a source tileset, or if we have extra palettes defined
-        if(assetData->args->include_palettes && (assetData->image.total_color_count - assetData->args->source_total_color_count > 0 || assetData->args->source_tilesets.size()==0)) {
+        if (assetData->args->include_palettes &&
+            ((assetData->image.total_color_count - assetData->args->source_total_color_count > 0) || (assetData->args->source_tilesets.size()==0)) ) {
             fprintf(file, "extern const palette_color_t %s_palettes[%d];\n", assetData->args->data_name.c_str(), (unsigned int)assetData->image.total_color_count - (unsigned int)assetData->args->source_total_color_count);
         }
         if(assetData->args->includeTileData) {
@@ -189,7 +190,8 @@ bool export_c_file( PNG2AssetData* assetData) {
     fprintf(file, "BANKREF(%s)\n\n", assetData->args->data_name.c_str());
 
     // Are we not using a source tileset, or do we have extra colors
-    if(assetData->args->include_palettes && (assetData->image.total_color_count - assetData->args->source_total_color_count > 0 || !assetData->args->source_tilesets.size() == 0)) {
+    if (assetData->args->include_palettes &&
+        ((assetData->image.total_color_count - assetData->args->source_total_color_count > 0) || (!assetData->args->source_tilesets.size() == 0)) ) {
 
         // Subtract however many palettes we had in the source tileset
         fprintf(file, "const palette_color_t %s_palettes[%d] = {\n", assetData->args->data_name.c_str(), (unsigned int)assetData->image.total_color_count - (unsigned int)assetData->args->source_total_color_count);

--- a/gbdk-support/png2asset/image_utils.cpp
+++ b/gbdk-support/png2asset/image_utils.cpp
@@ -41,7 +41,7 @@ static void image_bitunpack(const vector<uint8_t> & src_image_data, vector<uint8
 
 // Converts indexed image with bit depths 1- 8 bpp to indexed 8 bits per pixel
 // Replaces incoming image buffer with unpacked image buffer if successful
-bool image_indexed_ensure_8bpp(vector<uint8_t> & src_image_data, int width, int height, int bitdepth, int colortype) {
+bool image_indexed_ensure_8bpp(vector<uint8_t> & src_image_data, int bitdepth, int colortype) {
 
     vector<uint8_t> unpacked_image_data;
 

--- a/gbdk-support/png2asset/image_utils.h
+++ b/gbdk-support/png2asset/image_utils.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-bool image_indexed_ensure_8bpp(vector <unsigned char> &data, int width, int height, int bitdepth, int colortype);
+bool image_indexed_ensure_8bpp(vector <unsigned char> &data, int bitdepth, int colortype);
 bool image_indexed_repair_tile_palettes(PNGImage & image, bool use_2x2_map_attributes);
 
 #endif

--- a/gbdk-support/png2asset/main.cpp
+++ b/gbdk-support/png2asset/main.cpp
@@ -39,17 +39,20 @@ int main(int argc, char* argv[])
         return errorCode;
     }
 
+    // The png2AssetInstance tile and palette data is retained after
+    // processing source tilesets and so is shared with the main image
     PNG2AssetData png2AssetInstance;
 
     // If we have a source tileset
-    if(arguments.source_tilesets.size() > 0) {
+    if (arguments.source_tilesets.size() > 0) {
 
         vector<string>::iterator sourceTilesetFileNameIter = arguments.source_tilesets.begin();
 
         // Iterate through each source tileset and execute
         while (sourceTilesetFileNameIter < arguments.source_tilesets.end()) {
 
-            // Run with our source tileset filename
+            // Run with current source tileset filename
+            arguments.processing_mode = MODE_SOURCE_TILESET;
             errorCode = png2AssetInstance.Execute(&arguments, *sourceTilesetFileNameIter);
 
             // Return the error code if the function returns non-zero
@@ -61,12 +64,22 @@ int main(int argc, char* argv[])
         }
 
         // Save these values for later usage on the main execution
-        arguments.source_tileset_size = (unsigned int)png2AssetInstance.tiles.size();
+        arguments.source_tileset_size      = (unsigned int)png2AssetInstance.tiles.size();
         arguments.source_total_color_count = png2AssetInstance.image.total_color_count;
+
+        // Clearing map and attributes isn't needed here since adding them is blocked for source tileset data
+        // (pre-refactor png2asset used map.clear() and map_attributes.clear() )
+
+        arguments.has_source_tilesets = true;
+        printf("Got %d tiles from the source tileset.\n", (unsigned int)arguments.source_tileset_size);
+        printf("Got %d palettes from the source tileset.\n", (unsigned int)(arguments.source_total_color_count / png2AssetInstance.image.colors_per_pal));        
     }
+
+
 
     // Run the primary input file
     // Return the error code if the function returns non-zero
+    arguments.processing_mode = MODE_MAIN_IMAGE;
     if((errorCode = png2AssetInstance.Execute(&arguments, arguments.input_filename)) != 0) {
         return errorCode;
     }

--- a/gbdk-support/png2asset/main.cpp
+++ b/gbdk-support/png2asset/main.cpp
@@ -44,20 +44,20 @@ int main(int argc, char* argv[])
     // If we have a source tileset
     if(arguments.source_tilesets.size() > 0) {
 
-        vector<string>::iterator sourceTilesetsIterator = arguments.source_tilesets.begin();
+        vector<string>::iterator sourceTilesetFileNameIter = arguments.source_tilesets.begin();
 
         // Iterate through each source tileset and execute
-        while (sourceTilesetsIterator < arguments.source_tilesets.end()) {
+        while (sourceTilesetFileNameIter < arguments.source_tilesets.end()) {
 
             // Run with our source tileset filename
-            errorCode = png2AssetInstance.Execute(&arguments, *sourceTilesetsIterator);
+            errorCode = png2AssetInstance.Execute(&arguments, *sourceTilesetFileNameIter);
 
             // Return the error code if the function returns non-zero
             if(errorCode != 0) {
                 return errorCode;
             }
 
-            sourceTilesetsIterator++;
+            sourceTilesetFileNameIter++;
         }
 
         // Save these values for later usage on the main execution

--- a/gbdk-support/png2asset/map_attributes.cpp
+++ b/gbdk-support/png2asset/map_attributes.cpp
@@ -26,7 +26,7 @@ unsigned char GetMapAttribute(size_t x, size_t y,PNG2AssetData* assetData)
         return 0;
 }
 
-void ReduceMapAttributes2x2(const vector< SetPal >& palettes,PNG2AssetData* assetData)
+void ReduceMapAttributes2x2(PNG2AssetData* assetData)
 {
     size_t w = (assetData->args->map_attributes_size.width + 1) / 2;
     size_t h = (assetData->args->map_attributes_size.height + 1) / 2;
@@ -113,7 +113,7 @@ void HandleMapAttributes(PNG2AssetData* assetData) {
     if(assetData->args->use_2x2_map_attributes)
     {
         // NES attribute map dimensions are half-resolution 
-        ReduceMapAttributes2x2(assetData->palettes, assetData);
+        ReduceMapAttributes2x2(assetData);
     }
     // Optionally align and pack map attributes into NES PPU format
     if(assetData->args->pack_map_attributes)

--- a/gbdk-support/png2asset/map_attributes.h
+++ b/gbdk-support/png2asset/map_attributes.h
@@ -4,7 +4,7 @@
 #include "cmp_int_color.h"
 using namespace std;
 unsigned char GetMapAttribute(size_t x, size_t y);
-void ReduceMapAttributes2x2(const vector< SetPal >& palettes);
+void ReduceMapAttributes2x2(PNG2AssetData* assetData);
 void AlignMapAttributes(PNG2AssetData* assetData);
 void PackMapAttributes(PNG2AssetData* assetData);
 void HandleMapAttributes( PNG2AssetData* assetData);

--- a/gbdk-support/png2asset/png2asset.h
+++ b/gbdk-support/png2asset/png2asset.h
@@ -28,7 +28,6 @@ public:
     vector< MetaSprite > sprites;
     vector< unsigned char > map;
     vector< unsigned char > map_attributes;
-    PNGImage source_tileset_image;
     PNGImage image;
 
 };

--- a/gbdk-support/png2asset/png_image.h
+++ b/gbdk-support/png2asset/png_image.h
@@ -12,6 +12,12 @@ enum {
     SPR_16x16_MSX
 };
 
+// processing_mode states
+enum {
+    MODE_MAIN_IMAGE,
+    MODE_SOURCE_TILESET
+};
+
 struct PNGImage
 {
     vector< unsigned char > data; //data in indexed format
@@ -30,7 +36,8 @@ struct PNGImage
 
     size_t colors_per_pal;  // Number of colors per palette (ex: CGB has 4 colors per palette x 8 palettes total)
     size_t total_color_count; // Total number of colors across all palettes (palette_count x colors_per_pal)
-    unsigned char* palette; //palette colors in RGBA (1 color == 4 bytes)
+    unsigned char * palette = NULL; //palette colors in RGBA (1 color == 4 bytes)
+    unsigned char * source_tileset_palette = NULL;  // Mostly used for ensuring source tileset and primary image palettes match sufficiently
 
 private:
     bool zero_palette = false;

--- a/gbdk-support/png2asset/process_arguments.cpp
+++ b/gbdk-support/png2asset/process_arguments.cpp
@@ -32,41 +32,48 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
     //default values for some params
     args->spriteSize.width = 0;
     args->spriteSize.height = 0;
+    args->map_attributes_size.width = 0;
+    args->map_attributes_size.height = 0;
+    args->map_attributes_packed_size.width = 0;
+    args->map_attributes_packed_size.height = 0;
+
     args->pivot.x = 0xFFFFFF;
     args->pivot.y = 0xFFFFFF;
     args->pivot.width = 0xFFFFFF;
     args->pivot.height = 0xFFFFFF;
-    args->bank = -1;
+
+
+    args->max_palettes = 8;
+
     args->keep_palette_order = false;
     args->repair_indexed_pal = false;
     args->output_binary = false;
     args->output_transposed = false;
-    args->max_palettes = 8;
-
-    args->pack_mode = Tile::GB;
-    args->map_entry_size_bytes = 1;
-    args->flip_tiles = true;
-    args->props_default = 0;
-    args->keep_duplicate_tiles = false;
-    args->include_palettes = true;
-    args->includedMapOrMetaspriteData = true;
-    args->includeTileData = true;
-    args->use_structs = false;
     args->export_as_map = false;
     args->use_map_attributes = false;
     args->use_2x2_map_attributes = false;
     args->pack_map_attributes = false;
     args->convert_rgb_to_nes = false;
-    args->map_attributes_size.width = 0;
-    args->map_attributes_size.height = 0;
-    args->map_attributes_packed_size.width = 0;
-    args->map_attributes_packed_size.height = 0;
-    args->sprite_mode = SPR_8x16;
-    args->source_tileset_size = 0;
-    args->source_total_color_count = 0;
+    args->includeTileData = true;
+    args->includedMapOrMetaspriteData = true;
+    args->keep_duplicate_tiles = false;
+    args->include_palettes = true;
+    args->use_structs = false;
+    args->flip_tiles = true;
 
+    // args->errorCode;
+    args->bank = -1;
+    args->sprite_mode = SPR_8x16;
     args->bpp = 2;
+    args->props_default = 0;
+
     args->tile_origin = 0; // Default to no tile index offset
+    // args->extra_tile_count;
+    args->source_total_color_count = 0;
+    args->source_tileset_size = 0;
+
+    args->pack_mode = Tile::GB;
+    args->map_entry_size_bytes = 1;
 
 
     if(argc < 2)

--- a/gbdk-support/png2asset/process_arguments.cpp
+++ b/gbdk-support/png2asset/process_arguments.cpp
@@ -71,6 +71,8 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
     // args->extra_tile_count;
     args->source_total_color_count = 0;
     args->source_tileset_size = 0;
+    args->has_source_tilesets = false;
+    args->processing_mode = MODE_MAIN_IMAGE;
 
     args->pack_mode = Tile::GB;
     args->map_entry_size_bytes = 1;

--- a/gbdk-support/png2asset/process_arguments.h
+++ b/gbdk-support/png2asset/process_arguments.h
@@ -59,6 +59,8 @@ struct PNG2AssetArguments {
     size_t extra_tile_count;
     size_t source_total_color_count;  // Total number of colors (palette_count x colors_per_palette)
     unsigned int source_tileset_size;
+    bool has_source_tilesets;
+    int processing_mode;  // Whether the current image being processed is a source tileset is (MODE_SOURCE_TILESET) or the main image (MODE_MAIN_IMAGE)
 
     Tile::PackMode pack_mode;
     int map_entry_size_bytes;


### PR DESCRIPTION
- Add processing_mode for gating behavior for only source tilesets or main image
- Don't push map and metasprite index entries for source tileset images entries
- Remove unused source_tileset_image
- Fix failing to load main image after source tileset in indexed mode by clearing image data beforehand (loading quietly failed otherwise)
- Fix comparison of source tileset palette with main image palette
- Fix mis-matched palette export criteria between C header and C source file
- Re-add minimal logging to terminal of source tileset info found
- Improve source tileset conditional readbility with has_source_tilesets flag
- Remove some unused function parameters
- Re-sort default param init to match header declaration. No value changes.