### PR TITLE
Example: large map: support changing the initial camera position

### DIFF
--- a/gbdk-lib/examples/cross-platform/large_map/Makefile
+++ b/gbdk-lib/examples/cross-platform/large_map/Makefile
@@ -37,7 +37,7 @@ P2AFLAGS = $(P2AFLAGS_$(EXT))
 # You can set the name of the ROM file here
 PROJECTNAME = large-map
 
-CFLAGS = -Wf-MMD
+CFLAGS = -Wf-MMD -Wf-Wp-MP # Header file dependency output (-MMD) for Makefile use + per-header Phoney rules (-MP)
 
 # EXT?=gb # Only sets extension to default (game boy .gb) if not populated
 SRCDIR      = src
@@ -75,7 +75,7 @@ $(RESOBJSRC)/%.c:	$(RESDIR)/%.png
 $(OBJDIR)/%.o:	$(RESOBJSRC)/%.c
 	$(LCC) $(CFLAGS) -c -o $@ $<
 
-# Dependencies
+# Dependencies (using output from -Wf-MMD -Wf-Wp-MP)
 DEPS = $(OBJS:%.o=%.d)
 
 -include $(DEPS)

--- a/gbdk-lib/examples/cross-platform/large_map/src/large_map.c
+++ b/gbdk-lib/examples/cross-platform/large_map/src/large_map.c
@@ -173,51 +173,73 @@ void set_camera(void)
     old_camera_x = camera_x, old_camera_y = camera_y;
 }
 
-void main(void){
-    DISPLAY_OFF;
-    //set_bkg_data(0, 241u, bigmap_tiles);
+
+void init_map(void) {
+
+    // Set up tile data
     set_native_tile_data(0, bigmap_TILE_COUNT, bigmap_tiles);
     
-#if defined(SEGA)
-    __WRITE_VDP_REG(VDP_R2, R2_MAP_0x3800);
-    __WRITE_VDP_REG(VDP_R5, R5_SAT_0x3F00);
-    set_palette(0, bigmap_PALETTE_COUNT, bigmap_palettes);
-#elif defined(GAMEBOY)
-    if (_cpu == CGB_TYPE) {
-        set_bkg_palette(BKGF_CGB_PAL0, bigmap_PALETTE_COUNT, bigmap_palettes);
-    }
-#elif defined(NINTENDO_NES)
-    set_bkg_palette(0, bigmap_PALETTE_COUNT, bigmap_palettes);
-#endif 
+    // Set up color palettes
+    #if defined(SEGA)
+        __WRITE_VDP_REG(VDP_R2, R2_MAP_0x3800);
+        __WRITE_VDP_REG(VDP_R5, R5_SAT_0x3F00);
+        set_palette(0, bigmap_PALETTE_COUNT, bigmap_palettes);
+    #elif defined(GAMEBOY)
+        if (_cpu == CGB_TYPE) {
+            set_bkg_palette(BKGF_CGB_PAL0, bigmap_PALETTE_COUNT, bigmap_palettes);
+        }
+    #elif defined(NINTENDO_NES)
+        set_bkg_palette(0, bigmap_PALETTE_COUNT, bigmap_palettes);
+    #endif 
 
-    map_pos_x = map_pos_y = 0; 
+
+    // Initial camera position can be set in pixels here.
+    // The coordinates + camera viewport size should be within the map boundaries.
+    // Map starts at 0
+    camera_x = 0;
+    camera_y = 0;
+    // Enforce map limits on initial camera position
+    if (camera_x > camera_max_x) camera_x = camera_max_x;
+    if (camera_y > camera_max_y) camera_y = camera_max_y;
+    old_camera_x = camera_x; old_camera_y = camera_y;
+
+    map_pos_x = camera_x >> 3;
+    map_pos_y = camera_y >> 3;
     old_map_pos_x = old_map_pos_y = 255;
+    move_bkg(camera_x, WRAP_SCROLL_Y(camera_y + SCROLL_Y_OFFSET));
+
+    // Draw the initial map view for the whole screen
     set_submap_indices(
         map_pos_x,
         map_pos_y,
-        DEVICE_SCREEN_WIDTH,
-        DEVICE_SCREEN_HEIGHT,
+        MIN(DEVICE_SCREEN_WIDTH + 1u, bigmap_mapWidth - map_pos_x),
+        MIN(DEVICE_SCREEN_HEIGHT + 1u, bigmap_mapHeight - map_pos_y),
         bigmap_map,
         bigmap_mapWidth);
+
     set_submap_attributes(
         map_pos_x,
         map_pos_y,
-        DEVICE_SCREEN_WIDTH,
-        DEVICE_SCREEN_HEIGHT,
+        MIN(DEVICE_SCREEN_WIDTH + 1u, bigmap_mapWidth - map_pos_x),
+        MIN(DEVICE_SCREEN_HEIGHT + 1u, bigmap_mapHeight - map_pos_y),
         bigmap_map_attributes,
         bigmap_mapWidth);
-    camera_x = camera_y = 0;
-    old_camera_x = camera_x; old_camera_y = camera_y;
 
     redraw = FALSE;
 
     move_bkg(camera_x, WRAP_SCROLL_Y(camera_y + SCROLL_Y_OFFSET));
-#if DEVICE_SCREEN_BUFFER_WIDTH == DEVICE_SCREEN_WIDTH
+    #if DEVICE_SCREEN_BUFFER_WIDTH == DEVICE_SCREEN_WIDTH
         // On platforms where screen buffer has no more space than physical screen,
         // the next map column will be written to the leftmost screen column.
         // So we blank the leftmost column to hide visual artifacts where possible.
         HIDE_LEFT_COLUMN;
-#endif
+    #endif
+}
+
+void main(void){
+    DISPLAY_OFF;
+    init_map();
+
     SHOW_BKG;
     DISPLAY_ON;
     while (TRUE) {


### PR DESCRIPTION
Support an initial camera position other than 0,0 in the large map example
- Required some reordering of var init and improvement of the initial full screen draw
- Came out of work with @EdvinDraw, who also suggested updating the example app

