### PR TITLE
SMS tilemap attributes set upper palette bit

### DIFF
--- a/gbdk-support/png2asset/maps.cpp
+++ b/gbdk-support/png2asset/maps.cpp
@@ -79,7 +79,7 @@ void GetMap( PNG2AssetData* assetData)
                     }
                     else if(assetData->args->pack_mode == Tile::SMS)
                     {
-                        props = props >> 4;
+                        props = (props >> 4) | ((pal_idx & 1) << 3);
                         if(idx > 255)
                             props |= 1;
                         assetData->map.push_back(props);


### PR DESCRIPTION
Palette id was missing in the attributes for displaying multi palette background on SMS