### PR TITLE
Refactor png2assets arguments for logo example

### DIFF
--- a/gbdk-lib/examples/cross-platform/logo/Makefile
+++ b/gbdk-lib/examples/cross-platform/logo/Makefile
@@ -12,6 +12,13 @@ PNG2ASSETS = $(GBDK_HOME)bin/png2asset
 # Possible are: gb gbc pocket megaduck sms gg
 TARGETS=gb gbc pocket megaduck sms gg nes
 
+# You can set the name of the resulting ROM file here
+PROJECTNAME = logo
+
+# You can set the name of the ROM title embedded in the ROM header here
+TITLE = LOGO # must be all upper case, maximum 15 characters
+
+
 # Configure platform specific LCC flags here:
 LCCFLAGS_gb      = -Wl-yt0x1B -autobank # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
 LCCFLAGS_pocket  = -Wl-yt0x1B -autobank # Usually the same as required for .gb
@@ -25,18 +32,28 @@ LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Fla
 
 LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
 
+LCCFLAGS += -Wm-yn"$(TITLE)"
+
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
 	LCCFLAGS += -debug -v
 endif
 
+# Configure platform specific png2Assets flags here
+# Note for GBC: --noflip is required for DMG compatibility, but is less space efficient
+PNG2ASSETSFLAGS_gb      = -map -noflip -bpp 2 -max_palettes 1 -pack_mode gb
+PNG2ASSETSFLAGS_pocket  = -map -noflip -bpp 2 -max_palettes 1 -pack_mode gb
+PNG2ASSETSFLAGS_duck    = -map -noflip -bpp 2 -max_palettes 1 -pack_mode gb
+PNG2ASSETSFLAGS_gbc     = -map -noflip -use_map_attributes -bpp 2 -max_palettes 8 -pack_mode gb
+PNG2ASSETSFLAGS_sms     = -map -use_map_attributes -bpp 4 -max_palettes 2 -pack_mode sms
+PNG2ASSETSFLAGS_gg      = -map -use_map_attributes -bpp 4 -max_palettes 2 -pack_mode sms
+PNG2ASSETSFLAGS_nes     = -map -use_nes_attributes -use_nes_colors -noflip -bpp 2 -max_palettes 4 -pack_mode nes
+
+PNG2ASSETSFLAGS += $(PNG2ASSETSFLAGS_$(EXT)) # This adds the current platform specific png2Assets flags
 
 RESFLAGS += $(RESFLAGS_$(TYP))
 
 CFLAGS += -I$(OBJDIR) -DSYSTEM_$(TYP)
-
-# You can set the name of the ROM file here
-PROJECTNAME = logo
 
 # EXT?=gb # Only sets extension to default (game boy .gb) if not populated
 SRCDIR      = src
@@ -56,7 +73,7 @@ all: $(TARGETS)
 
 .SECONDEXPANSION:
 $(OBJDIR)/%.c: $(RESDIR)/%.png $$(wildcard $(RESDIR)/gfx/$(PLAT)/backgrounds/%.png.meta)
-	$(PNG2ASSETS) $< `cat <$<.meta 2>/dev/null` -c $@
+	$(PNG2ASSETS) $< $(PNG2ASSETSFLAGS) -c $@
 
 $(OBJDIR)/%.o:	$(OBJDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/logo/res/CGB/GBDK_2020_logo.png.meta
+++ b/gbdk-lib/examples/cross-platform/logo/res/CGB/GBDK_2020_logo.png.meta
@@ -1,1 +1,0 @@
--map -use_map_attributes -bpp 2 -max_palettes 8 -pack_mode gb

--- a/gbdk-lib/examples/cross-platform/logo/res/DMG/GBDK_2020_logo.png.meta
+++ b/gbdk-lib/examples/cross-platform/logo/res/DMG/GBDK_2020_logo.png.meta
@@ -1,1 +1,0 @@
--map -noflip -bpp 2 -max_palettes 1 -pack_mode gb

--- a/gbdk-lib/examples/cross-platform/logo/res/NES/GBDK_2020_logo.png.meta
+++ b/gbdk-lib/examples/cross-platform/logo/res/NES/GBDK_2020_logo.png.meta
@@ -1,1 +1,0 @@
--map -use_nes_attributes -use_nes_colors -noflip -bpp 2 -max_palettes 4 -pack_mode nes

--- a/gbdk-lib/examples/cross-platform/logo/res/SEGA/GBDK_2020_logo.png.meta
+++ b/gbdk-lib/examples/cross-platform/logo/res/SEGA/GBDK_2020_logo.png.meta
@@ -1,1 +1,0 @@
--map -use_map_attributes -bpp 4 -max_palettes 2 -pack_mode sms


### PR DESCRIPTION
Hi, I encountered some issues figuring out how to build a logo ROM, and wanted to contribute back to this project by refactoring this to make it easier for future beginners.

Ultimately what needed to happen was adding -noflip to the pn2asset arguments list. However, those were stored in .meta files that could not include comments, so there didn't seem to be a good solution on how I could add this hint.

So what I chose to do instead was remove the meta files and include the arguments in the Makefile using PNG2ASSETSFLAGS. This follows the existing convention already used for LCCFLAGS. Hopefully this is easier to parse for future users, and more maintainable. 

I did set the default behavior for GBC to noflip, as I believe that is the most user-friendly option and the LCCFLAGS for GBC are already set for gb and gbc compatibility (-Wm-yc), so this mirrors that.

I also added the ability to set the title of the ROM within the cartridge header, in addition to the existing option to name the file itself.

Please let me know if there's a better way to accomplish similar results. It didn't seem like the meta files had any other use, but I don't understand the history of why they currently exist, so I may be missing something. I did confirm that the build still works with these modifications, and the resulting ROMs work on emulators.