### PR TITLE
Improve logo example

### DIFF
--- a/gbdk-lib/examples/cross-platform/logo/Makefile
+++ b/gbdk-lib/examples/cross-platform/logo/Makefile
@@ -12,6 +12,12 @@ PNG2ASSETS = $(GBDK_HOME)bin/png2asset
 # Possible are: gb gbc pocket megaduck sms gg
 TARGETS=gb gbc pocket megaduck sms gg nes
 
+# You can set the name of the resulting ROM file here
+PROJECTNAME = logo
+
+# You can set the name of the ROM title embedded in the ROM header here
+TITLE = LOGO # must be all upper case, maximum 15 characters
+
 # Configure platform specific LCC flags here:
 LCCFLAGS_gb      = -Wl-yt0x1B -autobank # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)
 LCCFLAGS_pocket  = -Wl-yt0x1B -autobank # Usually the same as required for .gb
@@ -25,6 +31,8 @@ LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Fla
 
 LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
 
+LCCFLAGS += -Wm-yn"$(TITLE)" # Add title to rom cartridge header
+
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
 	LCCFLAGS += -debug -v
@@ -34,9 +42,6 @@ endif
 RESFLAGS += $(RESFLAGS_$(TYP))
 
 CFLAGS += -I$(OBJDIR) -DSYSTEM_$(TYP)
-
-# You can set the name of the ROM file here
-PROJECTNAME = logo
 
 # EXT?=gb # Only sets extension to default (game boy .gb) if not populated
 SRCDIR      = src

--- a/gbdk-lib/examples/cross-platform/logo/Readme.md
+++ b/gbdk-lib/examples/cross-platform/logo/Readme.md
@@ -5,7 +5,7 @@ This project shows how assets can be managed for multiple different console targ
 Arguments for png2asset are stored in .meta files next to the PNG files of the same name. This allows parameters to be set based on the individual characteristics of the image, and is useful when handling many images (versus defining parameters for each image in the Makefile or elsewhere). Arguments for png2asset can be found in this repository's documentation. In particular, note that -noflip is required for DMG-based systems, and is the default for DMG and CGB examples here, but is less space efficient.
 
 Users who wish to build their own logo ROM should:
-* Replace the image files in the res directories (if changing the name, change the meta file name to match)
+* Replace the image files in the res directories, preserving the filename GBDK_2020_logo.png
 * Set the PROJECTNAME and TITLE in the Makefile
 * Run "make" within the logos directory (use "make clean" before trying again)
 * Find the resulting roms in the build directory

--- a/gbdk-lib/examples/cross-platform/logo/Readme.md
+++ b/gbdk-lib/examples/cross-platform/logo/Readme.md
@@ -2,3 +2,10 @@ This project shows how assets can be managed for multiple different console targ
 
 `png2asset` is used to generate assets in the native format for each console at compile-time from separate source PNG images. The Makefile is set to use the source PNG folder which matches the current console being compiled, and the source code uses @ref set_native_tile_data() to load the assets tiles in native format.
 
+Arguments for png2asset are stored in .meta files next to the PNG files of the same name. This allows parameters to be set based on the individual characteristics of the image, and is useful when handling many images (versus defining parameters for each image in the Makefile or elsewhere). Arguments for png2asset can be found in this repository's documentation. In particular, note that -noflip is required for DMG-based systems, and is the default for DMG and CGB examples here, but is less space efficient.
+
+Users who wish to build their own logo ROM should:
+* Replace the image files in the res directories (if changing the name, change the meta file name to match)
+* Set the PROJECTNAME and TITLE in the Makefile
+* Run "make" within the logos directory (use "make clean" before trying again)
+* Find the resulting roms in the build directory

--- a/gbdk-lib/examples/cross-platform/logo/res/CGB/GBDK_2020_logo.png.meta
+++ b/gbdk-lib/examples/cross-platform/logo/res/CGB/GBDK_2020_logo.png.meta
@@ -1,1 +1,1 @@
--map -use_map_attributes -bpp 2 -max_palettes 8 -pack_mode gb
+-map -noflip -use_map_attributes -bpp 2 -max_palettes 8 -pack_mode gb


### PR DESCRIPTION
This is a less disruptive attempt at making the logos example a little more obvious for beginners.

This does three small things:
* Changes default png2asset arguments for GBC logo to use -noflip. The reasoning is that the GBC build for this example project defaults to GB and GBC compatibility (LCC flag -Wm-yc), so the default behavior for the image processing should match.
* Updates the readme with a little more context, and a note about noflip should the user need to remove the option for space efficiency reasons
* Adds the ability to set the rom title in the cartridge header