### PR TITLE
LCC: remove recently added -Wl-u from -debug since builds fail when .lst not present for object files

### DIFF
--- a/gbdk-lib/examples/cross-platform/banks/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks/Makefile
@@ -28,7 +28,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanki
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/banks_autobank/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_autobank/Makefile
@@ -28,7 +28,7 @@ LCCFLAGS += -Wl-j -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking relat
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/banks_farptr/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_farptr/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanki
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/banks_nonintrinsic/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_nonintrinsic/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanki
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/emu_debug/Makefile
+++ b/gbdk-lib/examples/cross-platform/emu_debug/Makefile
@@ -25,7 +25,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanki
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/fonts/Makefile
+++ b/gbdk-lib/examples/cross-platform/fonts/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/gbdecompress/Makefile
+++ b/gbdk-lib/examples/cross-platform/gbdecompress/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanki
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/incbin/Makefile
+++ b/gbdk-lib/examples/cross-platform/incbin/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/libc_memcpy/Makefile
+++ b/gbdk-lib/examples/cross-platform/libc_memcpy/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/libc_string/Makefile
+++ b/gbdk-lib/examples/cross-platform/libc_string/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/logo/Makefile
+++ b/gbdk-lib/examples/cross-platform/logo/Makefile
@@ -27,7 +27,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/metasprites/Makefile
+++ b/gbdk-lib/examples/cross-platform/metasprites/Makefile
@@ -27,7 +27,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/multiplayer/Makefile
+++ b/gbdk-lib/examples/cross-platform/multiplayer/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/pong/Makefile
+++ b/gbdk-lib/examples/cross-platform/pong/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/randtest/Makefile
+++ b/gbdk-lib/examples/cross-platform/randtest/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/rle_map/Makefile
+++ b/gbdk-lib/examples/cross-platform/rle_map/Makefile
@@ -28,7 +28,7 @@ LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Fla
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/scroller/Makefile
+++ b/gbdk-lib/examples/cross-platform/scroller/Makefile
@@ -26,7 +26,7 @@ LCCFLAGS += -Wl-j -Wm-yS -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Au
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/cross-platform/simple_physics/Makefile
+++ b/gbdk-lib/examples/cross-platform/simple_physics/Makefile
@@ -27,7 +27,7 @@ LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -Wb-ext=.rel -Wb-v # MBC + Autobanking related
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/apa_image/Makefile
+++ b/gbdk-lib/examples/gb/apa_image/Makefile
@@ -14,7 +14,7 @@ PNG2ASSET = $(GBDK_HOME)bin/png2asset
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/bcd/Makefile
+++ b/gbdk-lib/examples/gb/bcd/Makefile
@@ -10,7 +10,7 @@ BINS	= bcd.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/colorbar/Makefile
+++ b/gbdk-lib/examples/gb/colorbar/Makefile
@@ -8,7 +8,7 @@ LCC = $(GBDK_HOME)bin/lcc -Wa-l -Wl-m
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 # CFLAGS	=

--- a/gbdk-lib/examples/gb/comm/Makefile
+++ b/gbdk-lib/examples/gb/comm/Makefile
@@ -10,7 +10,7 @@ BINS	= comm.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/crash/Makefile
+++ b/gbdk-lib/examples/gb/crash/Makefile
@@ -10,7 +10,7 @@ BINS	= crash.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/dscan/Makefile
+++ b/gbdk-lib/examples/gb/dscan/Makefile
@@ -9,7 +9,7 @@ BINS	= dscan.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/filltest/Makefile
+++ b/gbdk-lib/examples/gb/filltest/Makefile
@@ -10,7 +10,7 @@ BINS	= filltest.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/galaxy/Makefile
+++ b/gbdk-lib/examples/gb/galaxy/Makefile
@@ -10,7 +10,7 @@ BINS	= galaxy.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/gbprinter/Makefile
+++ b/gbdk-lib/examples/gb/gbprinter/Makefile
@@ -14,7 +14,7 @@ PNG2ASSET = $(GBDK_HOME)bin/png2asset
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/gbtype/Makefile
+++ b/gbdk-lib/examples/gb/gbtype/Makefile
@@ -15,7 +15,7 @@ LCCFLAGS =  -Wm-ys
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/hblank_copy/Makefile
+++ b/gbdk-lib/examples/gb/hblank_copy/Makefile
@@ -16,7 +16,7 @@ LCCFLAGS += -Wm-yt0x19 -Wm-yoA -autobank -I$(OBJDIR)
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/hicolor/Makefile
+++ b/gbdk-lib/examples/gb/hicolor/Makefile
@@ -27,7 +27,7 @@ LCCFLAGS += -I$(OBJDIR) -I$(SRCDIR)
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/irq/Makefile
+++ b/gbdk-lib/examples/gb/irq/Makefile
@@ -10,7 +10,7 @@ BINS	= irq.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/isr_vector/Makefile
+++ b/gbdk-lib/examples/gb/isr_vector/Makefile
@@ -9,7 +9,7 @@ BINS	= lcd_isr_wobble.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/lcd_isr_wobble/Makefile
+++ b/gbdk-lib/examples/gb/lcd_isr_wobble/Makefile
@@ -10,7 +10,7 @@ BINS	= lcd_isr_wobble.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/linkerfile/Makefile
+++ b/gbdk-lib/examples/gb/linkerfile/Makefile
@@ -13,7 +13,7 @@ LCC = $(GBDK_HOME)bin/lcc
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/paint/Makefile
+++ b/gbdk-lib/examples/gb/paint/Makefile
@@ -9,7 +9,7 @@ BINS	= paint.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/ram_function/Makefile
+++ b/gbdk-lib/examples/gb/ram_function/Makefile
@@ -10,7 +10,7 @@ BINS	= ram_fn.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/rpn/Makefile
+++ b/gbdk-lib/examples/gb/rpn/Makefile
@@ -10,7 +10,7 @@ BINS	= rpn.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/sgb_border/Makefile
+++ b/gbdk-lib/examples/gb/sgb_border/Makefile
@@ -9,7 +9,7 @@ PNG2ASSET = $(GBDK_HOME)bin/png2asset
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/sgb_pong/Makefile
+++ b/gbdk-lib/examples/gb/sgb_pong/Makefile
@@ -10,7 +10,7 @@ BINS	= sgb_pong.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/sgb_sfx/Makefile
+++ b/gbdk-lib/examples/gb/sgb_sfx/Makefile
@@ -8,7 +8,7 @@ LCC = $(GBDK_HOME)bin/lcc
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/sound/Makefile
+++ b/gbdk-lib/examples/gb/sound/Makefile
@@ -11,7 +11,7 @@ BINS	= sound.gb sound.duck
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/space/Makefile
+++ b/gbdk-lib/examples/gb/space/Makefile
@@ -9,7 +9,7 @@ BINS	= space.gb
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/template_minimal/Makefile
+++ b/gbdk-lib/examples/gb/template_minimal/Makefile
@@ -12,7 +12,7 @@ LCC = $(GBDK_HOME)bin/lcc
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/template_subfolders/Makefile
+++ b/gbdk-lib/examples/gb/template_subfolders/Makefile
@@ -13,7 +13,7 @@ LCC = $(GBDK_HOME)bin/lcc
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/gb/wav_sample/Makefile
+++ b/gbdk-lib/examples/gb/wav_sample/Makefile
@@ -15,7 +15,7 @@ LCCFLAGS += -Wl-yt1 -Wl-yo4
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/msxdos/hello/Makefile
+++ b/gbdk-lib/examples/msxdos/hello/Makefile
@@ -10,7 +10,7 @@ BINS	= test.com
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/msxdos/smoke/Makefile
+++ b/gbdk-lib/examples/msxdos/smoke/Makefile
@@ -10,7 +10,7 @@ BINS	= smoketest.com
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/msxdos/test/Makefile
+++ b/gbdk-lib/examples/msxdos/test/Makefile
@@ -10,7 +10,7 @@ BINS	= test.com
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/nes/smoke/Makefile
+++ b/gbdk-lib/examples/nes/smoke/Makefile
@@ -10,7 +10,7 @@ BINS	= smoketest.nes
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/nes/snes_joypads/Makefile
+++ b/gbdk-lib/examples/nes/snes_joypads/Makefile
@@ -10,7 +10,7 @@ BINS	= snes_joypads.nes
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 

--- a/gbdk-lib/examples/sms/wav_sample/Makefile
+++ b/gbdk-lib/examples/sms/wav_sample/Makefile
@@ -14,7 +14,7 @@ LCC = $(GBDK_HOME)bin/lcc
 
 # GBDK_DEBUG = ON
 ifdef GBDK_DEBUG
-	LCCFLAGS += -debug -v
+	LCCFLAGS += -debug -v -Wl-u
 endif
 
 # You can set flags for LCC here

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -781,7 +781,7 @@ static void help(void) {
 "-c             compile only\n",
 "-dn            set switch statement density to `n'\n",
 "-debug         Turns on --debug for compiler, -y (.cdb), -j (.noi), -w (wide .map format) for linker\n",
-"                       -Wa-l (assembler .lst), -Wl-u (.lst -> .rst address update)\n",
+"                       -Wa-l (assembler .lst)\n",
 "-Dname=def     define the preprocessor symbol `name'\n",
 "-E             only run preprocessor on named .c and .h files files -> stdout\n",
 "--save-preproc Use with -E for output to *.i files instead of stdout\n",
@@ -976,7 +976,11 @@ static void opt(char *arg) {
 			llist[L_ARGS] = append("-j", llist[L_ARGS]);	// linker: .noi output
 
 			alist         = append("-l", alist);            // assembler: .lst output
-			llist[L_ARGS] = append("-u", llist[L_ARGS]);    // linker: .lst -> .rst address update
+			// -Wl-u is turned off for now because SDCC generates a build error if no matching
+			// .lst file is present for an object file. It does not fail gracefully.
+			// For example when the user includes a pre-built object file for a music driver
+			//
+			// llist[L_ARGS] = append("-u", llist[L_ARGS]);    // linker: .lst -> .rst address update
 			llist[L_ARGS] = append("-w", llist[L_ARGS]);    // linker: wide listing in .map file
 			return;
 		}


### PR DESCRIPTION
LCC: remove recently added -Wl-u from -debug since builds fail when .lst not present for object files
- The failure mode will likely trip up many users
- For the GBDK examples add -Wl-u wrapped in the GBDK_DEBUG toggle as a compromise