### PR TITLE
fix mode flags such as M_NO_SCROLL being discarded when setting M_TEXT_OUT

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/font.s
+++ b/gbdk-lib/libc/targets/mos6502/font.s
@@ -436,6 +436,8 @@ _posy::
 .tmode_out::
         ;; Clear screen
         jsr .cls_no_reset_pos
-        lda #.T_MODE
+        lda .mode
+        AND #.S_M_MASK
+        ORA #.T_MODE
         sta .mode
         rts

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -93,8 +93,10 @@
         .T_MODE         = 0x02  ; Text mode (bit 2)
         .T_MODE_OUT     = 0x02  ; Text mode output only
         .T_MODE_INOUT   = 0x03  ; Text mode with input
+        .S_MODE_MASK    = 0x03  ; Mask screen modes above
         .M_NO_SCROLL    = 0x04  ; Disables scrolling of the screen in text mode
         .M_NO_INTERP    = 0x08  ; Disables special character interpretation
+        .S_M_MASK       = 0x0C  ; Mask special modes above
 
         ;; Table of routines for modes
         .MODE_TABLE     = 0xFFE0

--- a/gbdk-lib/libc/targets/sm83/ap/global.s
+++ b/gbdk-lib/libc/targets/sm83/ap/global.s
@@ -418,8 +418,10 @@
         .T_MODE         = 0x02  ; Text mode (bit 2)
         .T_MODE_OUT     = 0x02  ; Text mode output only
         .T_MODE_INOUT   = 0x03  ; Text mode with input
+        .S_MODE_MASK    = 0x03  ; Mask screen modes above
         .M_NO_SCROLL    = 0x04  ; Disables scrolling of the screen in text mode
         .M_NO_INTERP    = 0x08  ; Disables special character interpretation
+        .S_M_MASK       = 0x0C  ; Mask special modes above
 
         ;; Status codes for IO
         .IO_IDLE        = 0x00

--- a/gbdk-lib/libc/targets/sm83/duck/global.s
+++ b/gbdk-lib/libc/targets/sm83/duck/global.s
@@ -418,8 +418,10 @@
         .T_MODE         = 0x02  ; Text mode (bit 2)
         .T_MODE_OUT     = 0x02  ; Text mode output only
         .T_MODE_INOUT   = 0x03  ; Text mode with input
+        .S_MODE_MASK    = 0x03  ; Mask screen modes above
         .M_NO_SCROLL    = 0x04  ; Disables scrolling of the screen in text mode
         .M_NO_INTERP    = 0x08  ; Disables special character interpretation
+        .S_M_MASK       = 0x0C  ; Mask special modes above
 
         ;; Status codes for IO
         .IO_IDLE        = 0x00

--- a/gbdk-lib/libc/targets/sm83/font.s
+++ b/gbdk-lib/libc/targets/sm83/font.s
@@ -547,7 +547,9 @@ _posy::
         ;; Clear screen
         CALL    .cls_no_reset_pos
 
-        LD      A,#.T_MODE
+        LD      A,(.mode)
+        AND     #.S_M_MASK
+        OR      #.T_MODE
         LD      (.mode),A
 
         RET

--- a/gbdk-lib/libc/targets/sm83/gb/global.s
+++ b/gbdk-lib/libc/targets/sm83/gb/global.s
@@ -418,8 +418,10 @@
         .T_MODE         = 0x02  ; Text mode (bit 2)
         .T_MODE_OUT     = 0x02  ; Text mode output only
         .T_MODE_INOUT   = 0x03  ; Text mode with input
+        .S_MODE_MASK    = 0x03  ; Mask screen modes above
         .M_NO_SCROLL    = 0x04  ; Disables scrolling of the screen in text mode
         .M_NO_INTERP    = 0x08  ; Disables special character interpretation
+        .S_M_MASK       = 0x0C  ; Mask special modes above
 
         ;; Status codes for IO
         .IO_IDLE        = 0x00

--- a/gbdk-lib/libc/targets/z80/gg/global.s
+++ b/gbdk-lib/libc/targets/z80/gg/global.s
@@ -204,8 +204,10 @@
         .T_MODE         = 0x02  ; Text mode (bit 2)
         .T_MODE_OUT     = 0x02  ; Text mode output only
         .T_MODE_INOUT   = 0x03  ; Text mode with input
+        .S_MODE_MASK    = 0x03  ; Mask screen modes above
         .M_NO_SCROLL    = 0x04  ; Disables scrolling of the screen in text mode
         .M_NO_INTERP    = 0x08  ; Disables special character interpretation
+        .S_M_MASK       = 0x0C  ; Mask special modes above
 
         ;; Screen dimentions in tiles
 

--- a/gbdk-lib/libc/targets/z80/msxdos/global.s
+++ b/gbdk-lib/libc/targets/z80/msxdos/global.s
@@ -342,8 +342,10 @@
         .T_MODE         = 0x02  ; Text mode (bit 2)
         .T_MODE_OUT     = 0x02  ; Text mode output only
         .T_MODE_INOUT   = 0x03  ; Text mode with input
+        .S_MODE_MASK    = 0x03  ; Mask screen modes above
         .M_NO_SCROLL    = 0x04  ; Disables scrolling of the screen in text mode
         .M_NO_INTERP    = 0x08  ; Disables special character interpretation
+        .S_M_MASK       = 0x0C  ; Mask special modes above
 
         ;; Screen dimentions in tiles
 

--- a/gbdk-lib/libc/targets/z80/sms/global.s
+++ b/gbdk-lib/libc/targets/z80/sms/global.s
@@ -168,8 +168,10 @@
         .T_MODE         = 0x02  ; Text mode (bit 2)
         .T_MODE_OUT     = 0x02  ; Text mode output only
         .T_MODE_INOUT   = 0x03  ; Text mode with input
+        .S_MODE_MASK    = 0x03  ; Mask screen modes above
         .M_NO_SCROLL    = 0x04  ; Disables scrolling of the screen in text mode
         .M_NO_INTERP    = 0x08  ; Disables special character interpretation
+        .S_M_MASK       = 0x0C  ; Mask special modes above
 
         ;; Screen dimentions in tiles
 


### PR DESCRIPTION
Setting `mode(M_TEXT_OUT);` causes the `.tmode_out` routine to be called internally.
That routine always sets `.mode` to `M_TEXT_OUT`, which discards additional flags.
This commit, makes sure that flags like `M_NO_SCROLL` persist this routine and disabling scrolling the screen works as intended