### PR TITLE
png2asset: -sprite_no_optimize (keep empty tiles, keep duplciate tiles)

### DIFF
--- a/gbdk-support/png2asset/metasprites.cpp
+++ b/gbdk-support/png2asset/metasprites.cpp
@@ -30,7 +30,10 @@ void GetMetaSprite(int _x, int _y, int _w, int _h, int pivot_x, int pivot_y, PNG
         for(int x = _x; x < _x + _w && x < (int)assetData->image.w; x += assetData->image.tile_w)
         {
             Tile tile(assetData->image.tile_h * assetData->image.tile_w);
-            if(assetData->image.ExtractTile(x, y, tile, assetData->args->sprite_mode, assetData->args->export_as_map, assetData->args->use_map_attributes, assetData->args->bpp))
+            // For sprites, unlike maps, Tiles are only kept and processed if NOT Empty
+            // This default behavior can be overridden with -spr_no_optimize (which sets keep_empty_sprite_tiles and keep_duplicate_tiles to TRUE) 
+            bool tile_not_empty = (assetData->image.ExtractTile(x, y, tile, assetData->args->sprite_mode, assetData->args->export_as_map, assetData->args->use_map_attributes, assetData->args->bpp));
+            if (tile_not_empty || (assetData->args->keep_empty_sprite_tiles))
             {
                 size_t idx;
                 unsigned char props;

--- a/gbdk-support/png2asset/process_arguments.cpp
+++ b/gbdk-support/png2asset/process_arguments.cpp
@@ -143,7 +143,7 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
         {
             args->props_default = strtol(argv[++i], NULL, 16);
         }
-        if(!strcmp(argv[i], "-px"))
+        else if(!strcmp(argv[i], "-px"))
         {
             args->pivot.x = atoi(argv[++i]);
         }
@@ -294,6 +294,9 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
         else if(!strcmp(argv[i], "-transposed"))
         {
             args->output_transposed = true;
+        }
+        else {
+            printf("Warning: Argument \"%s\" not recognized\n", argv[i]);
         }
     }
 

--- a/gbdk-support/png2asset/process_arguments.cpp
+++ b/gbdk-support/png2asset/process_arguments.cpp
@@ -57,6 +57,7 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
     args->includeTileData = true;
     args->includedMapOrMetaspriteData = true;
     args->keep_duplicate_tiles = false;
+    args->keep_empty_sprite_tiles = false;
     args->include_palettes = true;
     args->use_structs = false;
     args->flip_tiles = true;
@@ -93,6 +94,7 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
         printf("-spr8x8             use SPRITES_8x8\n");
         printf("-spr8x16            use SPRITES_8x16 (this is the default)\n");
         printf("-spr16x16msx        use SPRITES_16x16\n");
+        printf("-sprite_no_optimize keep empty sprite tiles, do not remote duplicate tiles\n");
         printf("-b <bank>           bank (default: fixed bank)\n");
         printf("-keep_palette_order use png palette\n");
         printf("-repair_indexed_pal try to repair indexed tile palettes (implies \"-keep_palette_order\")\n");
@@ -270,6 +272,11 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
         else if(!strcmp(argv[i], "-keep_duplicate_tiles"))
         {
             args->keep_duplicate_tiles = true;
+        }
+        else if(!strcmp(argv[i], "-sprite_no_optimize"))
+        {
+            args->keep_duplicate_tiles = true;
+            args->keep_empty_sprite_tiles = true;
         }
         else if(!strcmp(argv[i], "-no_palettes"))
         {

--- a/gbdk-support/png2asset/process_arguments.h
+++ b/gbdk-support/png2asset/process_arguments.h
@@ -45,6 +45,7 @@ struct PNG2AssetArguments {
     bool includeTileData;
     bool includedMapOrMetaspriteData;
     bool keep_duplicate_tiles;
+    bool keep_empty_sprite_tiles;
     bool include_palettes;
     bool use_structs;
     bool flip_tiles;


### PR DESCRIPTION
Empty tiles are those which are entirely filled with color 0 for the given palette.

Under the hood this turns on:
 - args->keep_duplicate_tiles = true
 - args->keep_empty_sprite_tiles = true

This is not applicable to maps because they (already) do not discard tiles even if they are filled entirely with color zero. 

Also fix missing else statement and warn about unrecognized args