### PR TITLE
Docs: fix some missed search results

### DIFF
--- a/docs/doxygen_search_override.js
+++ b/docs/doxygen_search_override.js
@@ -140,7 +140,7 @@ SearchResults = function () {
           // {
           // CHANGED START
           rowMatchName = rowMatchName.replace(/^[sr\d_]*5f_/, ''); // strip 'sr123_5f'
-          rowMatchName = rowMatchName.replace(/5f/, ''); // strip '5f' chars
+          rowMatchName = rowMatchName.replace(/5f/g, ''); // strip '5f' chars
           // rowMatchName = rowMatchName.replace(/_/, ' '); // underscores to spaces
 
           if (rowMatchName.includes(search))


### PR DESCRIPTION
Search format regex must replace all formatting instances, not just first. Otherwise matching will fail.
Example: `set_bkg_tiles` was returning zero results. Now fixed.