### PR TITLE
Bankpack: -banktype arg, allow forcing a given bank type to CODE or LIT

### DIFF
--- a/gbdk-support/bankpack/bankpack.c
+++ b/gbdk-support/bankpack/bankpack.c
@@ -27,27 +27,29 @@ static void display_help(void) {
        "     Typically called by Lcc compiler driver before linker.\n"
        "\n"
        "Options\n"
-       "-h            : Show this help\n"
-       "-lkin=<file>  : Load object files specified in linker file <file>\n"
-       "-lkout=<file> : Write list of object files out to linker file <file>\n"
-       "-yt<mbctype>  : Set MBC type per ROM byte 149 in Decimal or Hex (0xNN)\n"
-       "               ([see pandocs](https://gbdev.io/pandocs/The_Cartridge_Header.html#0147---cartridge-type))\n"
-       "-mbc=N        : Similar to -yt, but sets MBC type directly to N instead\n"
-       "               of by intepreting ROM byte 149\n"
-       "               mbc1 will exclude banks {0x20,0x40,0x60} max=127, \n"
-       "               mbc2 max=15, mbc3 max=127, mbc5 max=255 (not 511!) \n"
-       "-min=N        : Min assigned ROM bank is N (default 1)\n"
-       "-max=N        : Max assigned ROM bank is N, error if exceeded\n"
-       "-ext=<.ext>   : Write files out with <.ext> instead of source extension\n"
-       "-path=<path>  : Write files out to <path> (<path> *MUST* already exist)\n"
-       "-sym=<prefix> : Add symbols starting with <prefix> to match + update list.\n"
-       "               Default entry is \"___bank_\" (see below)\n"
-       "-cartsize     : Print min required cart size as \"autocartsize:<NNN>\"\n"
-       "-plat=<plat>  : Select platform specific behavior (default:gb) (gb,sms)\n"
-       "-random       : Distribute banks randomly for testing (honors -min/-max)\n"
-       "-reserve=<b:n>: Reserve N bytes (hex) in bank B (decimal)\n"
-       "                Ex: -reserve=105:30F reserves 0x30F bytes in bank 105\n"
-       "-v            : Verbose output, show assignments\n"
+       "-h             : Show this help\n"
+       "-lkin=<file>   : Load object files specified in linker file <file>\n"
+       "-lkout=<file>  : Write list of object files out to linker file <file>\n"
+       "-yt<mbctype>   : Set MBC type per ROM byte 149 in Decimal or Hex (0xNN)\n"
+       "                ([see pandocs](https://gbdev.io/pandocs/The_Cartridge_Header.html#0147---cartridge-type))\n"
+       "-mbc=N         : Similar to -yt, but sets MBC type directly to N instead\n"
+       "                of by intepreting ROM byte 149\n"
+       "                mbc1 will exclude banks {0x20,0x40,0x60} max=127, \n"
+       "                mbc2 max=15, mbc3 max=127, mbc5 max=255 (not 511!) \n"
+       "-min=N         : Min assigned ROM bank is N (default 1)\n"
+       "-max=N         : Max assigned ROM bank is N, error if exceeded\n"
+       "-ext=<.ext>    : Write files out with <.ext> instead of source extension\n"
+       "-path=<path>   : Write files out to <path> (<path> *MUST* already exist)\n"
+       "-sym=<prefix>  : Add symbols starting with <prefix> to match + update list\n"
+       "                 Default entry is \"___bank_\" (see below)\n"
+       "-cartsize      : Print min required cart size as \"autocartsize:<NNN>\"\n"
+       "-plat=<plat>   : Select platform specific behavior (default:gb) (gb,sms)\n"
+       "-random        : Distribute banks randomly for testing (honors -min/-max)\n"
+       "-reserve=<b:n> : Reserve N bytes (hex) in bank B (decimal)\n"
+       "                 Ex: -reserve=105:30F reserves 0x30F bytes in bank 105\n"
+       "-banktype=<b:t>: Set bank B (decimal) to use type T (CODE or LIT). For sms/gg\n"
+       "                 Ex: -banktype=2:LIT sets bank 2 to type LIT\n"
+       "-v             : Verbose output, show assignments\n"
        "\n"
        "Example: \"bankpack -ext=.rel -path=some/newpath/ file1.o file2.o\"\n"
        "Unless -ext or -path specify otherwise, input files are overwritten.\n"
@@ -115,6 +117,12 @@ static int handle_args(int argc, char * argv[]) {
                 files_set_linkerfile_outname(argv[i] + strlen("-lkout="));
             } else if (strstr(argv[i], "-reserve=") == argv[i]) {
                 if (!option_bank_reserve_bytes(argv[i])) {
+                    fprintf(stdout,"BankPack: ERROR! Malformed argument: %s\n\n", argv[i]);
+                    display_help();
+                    return false;
+                }
+            } else if (strstr(argv[i], "-banktype=") == argv[i]) {
+                if (!option_bank_set_type(argv[i])) {
                     fprintf(stdout,"BankPack: ERROR! Malformed argument: %s\n\n", argv[i]);
                     display_help();
                     return false;

--- a/gbdk-support/bankpack/obj_data.c
+++ b/gbdk-support/bankpack/obj_data.c
@@ -95,7 +95,7 @@ int areas_add(char * area_str, uint32_t file_id) {
     // Only match areas which are banked ("_CODE_" vs "_CODE") and ("_LIT_")
     if (AREA_LINE_RECORDS == sscanf(area_str,"A _CODE _%3d size %4x flags %*4x addr %*4x",
                                     &newarea.bank_num_in, &newarea.size)) {
-        newarea.type = BANK_TYPE_DEFAULT;
+        newarea.type = BANK_TYPE_CODE;
     }
     else if (AREA_LINE_RECORDS == sscanf(area_str,"A _LIT_%3d size %4x flags %*4x addr %*4x",
                                         &newarea.bank_num_in, &newarea.size)) {
@@ -222,7 +222,7 @@ static void bank_report_mixed_area_error(bank_item * p_bank, uint16_t bank_num, 
 
     printf("BankPack: ERROR! Bank %d already assigned different area type.\n"
            "  Can't mix _CODE_ and _LIT_ areas in the same bank for this platform.\n"
-           "  Area %s, bank %d, file:%s\n",
+           "  Rejecting: Area %s, bank %d, file:%s\n",
            p_area->bank_num_in, p_area->name, bank_num, file_get_name_in_by_id(p_area->file_id));
 
     if (option_get_verbose())
@@ -230,7 +230,7 @@ static void bank_report_mixed_area_error(bank_item * p_bank, uint16_t bank_num, 
 }
 
 
-// Checks whether mixing area types in the same bankshould be rejected
+// Checks whether mixing area types in the same bank should be rejected
 static bool bank_check_mixed_area_types_ok(bank_item * p_bank, uint16_t bank_num, area_item * p_area) {
 
     // Don't allow mixing of _CODE_ and _LIT_ for sms/gg ports

--- a/gbdk-support/bankpack/obj_data.h
+++ b/gbdk-support/bankpack/obj_data.h
@@ -13,7 +13,7 @@
 #define SYMBOL_REWRITE_RECORDS 2 // Name, DefVal
 
 #define BANK_TYPE_UNSET             0
-#define BANK_TYPE_DEFAULT           1
+#define BANK_TYPE_CODE              1 // Default type is CODE
 #define BANK_TYPE_LIT_EXCLUSIVE     2
 
 

--- a/gbdk-support/bankpack/options.h
+++ b/gbdk-support/bankpack/options.h
@@ -7,6 +7,10 @@
 #define ARG_BANK_RESERVE_SIZE_REC_COUNT_MATCH 3u
 #define ARG_BANK_RESERVE_SIZE_MAX_SPLIT_WORDS (ARG_BANK_RESERVE_SIZE_REC_COUNT_MATCH + 1u)
 
+#define ARG_BANK_SET_TYPE_MAX_LEN 256u   //  -banktype=255:LIT
+#define ARG_BANK_SET_TYPE_REC_COUNT_MATCH 3u
+#define ARG_BANK_SET_TYPE_MAX_SPLIT_WORDS (ARG_BANK_RESERVE_SIZE_REC_COUNT_MATCH + 1u)
+
 #define PLATFORM_GB                 0
 #define PLATFORM_SMS                1
 #define PLATFORM_DEFAULT            PLATFORM_GB
@@ -30,6 +34,7 @@ void option_set_random_assign(bool is_enabled);
 bool option_get_random_assign(void);
 
 int  option_bank_reserve_bytes(char * arg_str);
+int option_bank_set_type(char * arg_str);
 
 void option_set_platform(char * platform_str);
 int  option_get_platform(void);


### PR DESCRIPTION
- Example: -banktype=105:LIT
- Only matching object files will be assigned to the bank
- Error if object with fixed bank num clashes with assigned bank type for that bank