### PR TITLE
NES: Optimize CRT0 zeropage usage

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -67,8 +67,6 @@ _sys_time::                             .ds 2
 _shadow_PPUCTRL::                       .ds 1
 _shadow_PPUMASK::                       .ds 1
 __crt0_spritePageValid:                 .ds 1
-__crt0_NMI_insideNMI:                   .ds 1
-__crt0_ScrollHV:                        .ds 1
 _bkg_scroll_x::                         .ds 1
 _bkg_scroll_y::                         .ds 1
 _attribute_row_dirty::                  .ds 1
@@ -199,19 +197,11 @@ ProcessDrawList:
     rts
 
 __crt0_NMI:
-    ; Prevent NMI re-entry
-    bit *__crt0_NMI_insideNMI
-    bpl NotInsideNMI
-    rti
-NotInsideNMI:
     pha
     txa
     pha
     tya
     pha
-
-    lda #0x80
-    sta *__crt0_NMI_insideNMI
     
     ; Skip graphics updates if blanked, to allow main code to do VRAM address / scroll updates
     lda *_shadow_PPUMASK
@@ -232,7 +222,6 @@ NotInsideNMI:
   
     ; Re-write PPUCTRL (clobbered by vram transfer buffer code)
     lda *_shadow_PPUCTRL
-    ora *__crt0_ScrollHV
     sta PPUCTRL
 
     ; Write shadow_PPUMASK to PPUMASK, in case it was disabled
@@ -273,7 +262,6 @@ __crt0_NMI_skip:
     pla
     tax
     pla
-    asl *__crt0_NMI_insideNMI
     rti
 
 DoUpdateVRAM:

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -284,25 +284,22 @@ DoUpdateVRAM:
     bit *__vram_transfer_buffer_valid
     bmi DoUpdateVRAM_drawListValid
 DoUpdateVRAM_drawListInvalid:
-    ; Delay for remaining cycles to keep timing consistent
-    ldx #(VRAM_DELAY_CYCLES_X8+7)
-DoUpdateVRAM_invalid_loop:
-    lda *__vram_transfer_buffer_num_cycles_x8
-    dex
-    bne DoUpdateVRAM_invalid_loop
+    ; Delay for all unused cycles and ProcessDrawList overhead to keep timing consistent
+    lda *0x00
     nop
-    rts
+    ldx #(VRAM_DELAY_CYCLES_X8+6)
+    bne DoUpdateVRAM_loop
 DoUpdateVRAM_drawListValid:
     jsr ProcessDrawList
-    ; Delay for remaining cycles to keep timing consistent
-    ; ...plus fixed-cost of 56 cycles
+    ; Delay for remaining unused cycles to keep timing consistent
     ldx *__vram_transfer_buffer_num_cycles_x8
-DoUpdateVRAM_valid_loop:
-    stx *__vram_transfer_buffer_num_cycles_x8
-    dex
-    bne DoUpdateVRAM_valid_loop
+    ; Reset available cycles to initial value
     lda #VRAM_DELAY_CYCLES_X8
     sta *__vram_transfer_buffer_num_cycles_x8
+DoUpdateVRAM_loop:
+    lda *0x00
+    dex
+    bne DoUpdateVRAM_loop
     rts
 
 __crt0_IRQ:

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -1,7 +1,7 @@
         ;; Transfer buffer (lower half of hardware stack)
         __vram_transfer_buffer = 0x100
         ;; Number of 8-cycles available each frame for transfer buffer
-        VRAM_DELAY_CYCLES_X8  = 170
+        VRAM_DELAY_CYCLES_X8  = 172
 
         ;;  Keypad
         .UP             = 0x08

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -1,7 +1,7 @@
         ;; Transfer buffer (lower half of hardware stack)
         __vram_transfer_buffer = 0x100
         ;; Number of 8-cycles available each frame for transfer buffer
-        VRAM_DELAY_CYCLES_X8  = 167
+        VRAM_DELAY_CYCLES_X8  = 170
 
         ;;  Keypad
         .UP             = 0x08

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -1,7 +1,7 @@
         ;; Transfer buffer (lower half of hardware stack)
         __vram_transfer_buffer = 0x100
         ;; Number of 8-cycles available each frame for transfer buffer
-        VRAM_DELAY_CYCLES_X8  = 172
+        VRAM_DELAY_CYCLES_X8  = 174
 
         ;;  Keypad
         .UP             = 0x08


### PR DESCRIPTION
NES: Optimize CRT0 zeropage usage
* Remove __crt0_ScrollHV. This is redundant with single-screen mirroring
* Remove __crt0_NMI_insideNMI. NMI time should be deterministic and re-entry should not be possible.
  (user-installed LCD handler assumption could break this assumption, but is planned to be moved to vsync call)
