### PR TITLE
NES: Add PAL support

### DIFF
--- a/gbdk-lib/examples/nes/display_system/Makefile
+++ b/gbdk-lib/examples/nes/display_system/Makefile
@@ -1,0 +1,42 @@
+# If you move this project you can change the directory
+# to match your GBDK root directory (ex: GBDK_HOME = "C:/GBDK/")
+ifndef GBDK_HOME
+	GBDK_HOME = ../../../
+endif
+
+LCC = $(GBDK_HOME)bin/lcc -mmos6502:nes -Wm-yoA -Wl-j
+
+BINS	= display_system.nes
+
+# GBDK_DEBUG = ON
+ifdef GBDK_DEBUG
+	LCCFLAGS += -debug -v -Wl-u
+endif
+
+
+all:	$(BINS)
+
+ASRC = $(wildcard *.s)
+CSRC = $(wildcard *.c) 
+
+OBJS = $(CSRC:%.c=%.o) $(ASRC:%.s=%.o)
+
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
+
+# Compile and link single file in one pass
+
+%.o:	%.c
+	$(LCC) $(LCCFLAGS) -c -o $@ $<
+
+%.o:	%.s
+	$(LCC) $(LCCFLAGS) -c -o $@ $<
+
+$(BINS):	$(OBJS)
+	$(LCC) $(LCCFLAGS) -Wm-yS -o $@ $^
+	rm -f *.map *.noi *.ihx *.lst *.rst
+
+clean:
+	rm -f *.o *.lst *.map *.nes *~ *.rel *.cdb *.adb *.ihx *.lnk *.sym *.asm *.noi *.rst
+

--- a/gbdk-lib/examples/nes/display_system/display_system.c
+++ b/gbdk-lib/examples/nes/display_system/display_system.c
@@ -1,0 +1,26 @@
+/*
+    display_system.c
+
+    Displays the graphics system gbdk-nes is running on. (NTSC/PAL/Dendy)
+    
+*/
+
+#include <stdio.h>
+#include <gbdk/platform.h>
+#include <gbdk/font.h>
+#include <gbdk/console.h>
+
+const char* system_names[] = { "NTSC", "PAL", "Dendy", "Unknown" };
+
+void main(void)
+{
+    font_t ibm_font;
+    uint8_t system = get_display_system();
+    // Init font system and load font
+    font_init();
+    ibm_font = font_load(font_ibm);
+    DISPLAY_ON;
+    gotoxy(4, 4);
+    printf("System: %s", system_names[system]);
+    vsync();
+}

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -255,6 +255,17 @@ void mode(uint8_t m) NO_OVERLAY_LOCALS;
 */
 uint8_t get_mode(void) NO_OVERLAY_LOCALS;
 
+#define DISPLAY_SYSTEM_NTSC 0
+#define DISPLAY_SYSTEM_PAL 1
+#define DISPLAY_SYSTEM_DENDY 2
+extern uint8_t _system_bits;
+/** Returns the display system gbdk-nes is running on.
+
+*/
+inline uint8_t get_display_system(void) {
+    return _system_bits >> 6;
+}
+
 /** Global Time Counter in VBL periods (60Hz)
 
     Increments once per Frame

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -1,7 +1,7 @@
         ;; Transfer buffer (lower half of hardware stack)
         __vram_transfer_buffer = 0x100
         ;; Number of 8-cycles available each frame for transfer buffer
-        VRAM_DELAY_CYCLES_X8  = 174
+        VRAM_DELAY_CYCLES_X8  = 172
 
         ;;  Keypad
         .UP             = 0x08


### PR DESCRIPTION
* Add new zeropage variable _system_bits to indicate NTSC/PAL/Dendy system
* Modify init code to detect NTSC/PAL/Dendy via cycle counting, storing result in _system_bits
* Modify fake-LCD-ISR delays in NMI handler to accommodate PAL timings
* Add new NES-specific function get_display_system, to query whether running on NTSC/PAL/Dendy
* Add minimal display_system example to exercise get_display_system