### PR TITLE
NES: Add PAL support

### DIFF
--- a/gbdk-lib/examples/cross-platform/display_system/src/display_system.c
+++ b/gbdk-lib/examples/cross-platform/display_system/src/display_system.c
@@ -1,0 +1,46 @@
+/*
+    display_system.c
+
+    Displays the system gbdk is running on.
+    
+    This can be one of these three:
+    * NTSC  (60Hz)
+    * PAL   (50Hz)
+    * Dendy (50Hz but with NTSC scanline cycle timing - only applicable to gbdk-nes port)
+    
+*/
+
+#include <stdio.h>
+#include <gbdk/platform.h>
+#include <gbdk/font.h>
+#include <gbdk/console.h>
+
+//const char* system_names[] = { "NTSC", "PAL", "Dendy", "Unknown" };
+
+const char* get_system_name(uint8_t system)
+{
+    switch(system)
+    {
+        case SYSTEM_NTSC:
+            return "NTSC";
+        case SYSTEM_PAL:
+            return "PAL";
+        case SYSTEM_DENDY:
+            return "Dendy";
+        default:
+            return "Unknown";
+    }
+}
+
+void main(void)
+{
+    font_t ibm_font;
+    uint8_t system = get_system();
+    // Init font system and load font
+    font_init();
+    ibm_font = font_load(font_ibm);
+    DISPLAY_ON;
+    gotoxy(4, 4);
+    printf("System: %s", get_system_name(system)); //system_names[system]);
+    vsync();
+}

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -24,6 +24,10 @@
 #undef MSX
 #endif
 
+#define SYSTEM_PAL     0x00
+#define SYSTEM_NTSC    0x01
+#define SYSTEM_DENDY   0x02
+
 #if defined(__TARGET_ap)
 #define ANALOGUEPOCKET
 #elif defined(__TARGET_gb)
@@ -409,6 +413,13 @@ void mode(uint8_t m);
     @see M_DRAWING, M_TEXT_OUT, M_TEXT_INOUT, M_NO_SCROLL, M_NO_INTERP
 */
 uint8_t get_mode(void) PRESERVES_REGS(b, c, d, e, h, l);
+
+/** Returns the system gbdk is running on.
+
+*/
+inline uint8_t get_system(void) {
+    return SYSTEM_NTSC;
+}
 
 /** GB CPU type
 

--- a/gbdk-lib/include/msx/msx.h
+++ b/gbdk-lib/include/msx/msx.h
@@ -28,6 +28,9 @@
 #define MSXDOS
 #endif
 
+#define SYSTEM_PAL     0x00
+#define SYSTEM_NTSC    0x01
+#define SYSTEM_DENDY   0x02
 
 #define VBK_REG VDP_ATTR_SHIFT
 
@@ -111,6 +114,13 @@ void mode(uint8_t m) OLDCALL;
     @see M_TEXT_OUT, M_TEXT_INOUT, M_NO_SCROLL, M_NO_INTERP
 */
 uint8_t get_mode(void) OLDCALL;
+
+/** Returns the system gbdk is running on.
+
+*/
+inline uint8_t get_system(void) {
+    return _SYSTEM;
+}
 
 /* Interrupt flags */
 /** Disable calling of interrupt service routines

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -25,6 +25,11 @@
 #undef MSX
 #endif
 
+extern const uint8_t _system_bits;
+
+#define SYSTEM_NTSC    0x00
+#define SYSTEM_PAL     0x01
+#define SYSTEM_DENDY   0x02
 
 #define RGB(r,g,b)        RGB_TO_NES(((r) | ((g) << 2) | ((b) << 4)))
 #define RGB8(r,g,b)       RGB_TO_NES((((r) >> 6) | (((g) >> 6) << 2) | (((b) >> 6) << 4)))
@@ -254,6 +259,13 @@ void mode(uint8_t m) NO_OVERLAY_LOCALS;
     @see M_DRAWING, M_TEXT_OUT, M_TEXT_INOUT, M_NO_SCROLL, M_NO_INTERP
 */
 uint8_t get_mode(void) NO_OVERLAY_LOCALS;
+
+/** Returns the system gbdk is running on.
+
+*/
+inline uint8_t get_system(void) {
+    return _system_bits >> 6;
+}
 
 /** Global Time Counter in VBL periods (60Hz)
 

--- a/gbdk-lib/include/sms/sms.h
+++ b/gbdk-lib/include/sms/sms.h
@@ -37,6 +37,7 @@ extern const UBYTE _SYSTEM;
 
 #define SYSTEM_PAL     0x00
 #define SYSTEM_NTSC    0x01
+#define SYSTEM_DENDY   0x02
 
 #define VBK_REG VDP_ATTR_SHIFT
 
@@ -120,6 +121,13 @@ void mode(uint8_t m) OLDCALL;
     @see M_TEXT_OUT, M_TEXT_INOUT, M_NO_SCROLL, M_NO_INTERP
 */
 uint8_t get_mode(void) OLDCALL;
+
+/** Returns the system gbdk is running on.
+
+*/
+inline uint8_t get_system(void) {
+    return _SYSTEM;
+}
 
 /* Interrupt flags */
 /** Disable calling of interrupt service routines

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -1,7 +1,7 @@
         ;; Transfer buffer (lower half of hardware stack)
         __vram_transfer_buffer = 0x100
         ;; Number of 8-cycles available each frame for transfer buffer
-        VRAM_DELAY_CYCLES_X8  = 174
+        VRAM_DELAY_CYCLES_X8  = 172
 
         ;;  Keypad
         .UP             = 0x08


### PR DESCRIPTION
* Add new zeropage variable _system_bits to indicate NTSC/PAL/Dendy system
* Modify init code to detect NTSC/PAL/Dendy via cycle counting, storing result in _system_bits
* Modify fake-LCD-ISR delays in NMI handler to accommodate PAL timings
* Add new cross-platform function get_system for all ports, to query whether running on NTSC/PAL/Dendy
* Add minimal cross-platform display_system example to exercise get_system