### PR TITLE
NES: Add PAL support

### DIFF
--- a/gbdk-lib/examples/cross-platform/display_system/src/display_system.c
+++ b/gbdk-lib/examples/cross-platform/display_system/src/display_system.c
@@ -1,0 +1,53 @@
+/*
+    display_system.c
+
+    Displays the system gbdk is running on.
+    
+    This will report one of these three:
+    * 60 Hz
+    * 50 Hz
+    * 50 Hz, Dendy-like (only applicable gbdk-nes port)
+    
+*/
+
+#include <stdio.h>
+#include <gbdk/platform.h>
+#include <gbdk/font.h>
+#include <gbdk/console.h>
+
+const char* get_system_name(uint8_t system)
+{
+    switch(system)
+    {
+        case SYSTEM_60HZ:
+            return "60 Hz";
+        case SYSTEM_50HZ:
+#if defined(NINTENDO_NES)
+            // For gbdk-nes, we can also inspect the _system_bits to more specifically
+            // report the console as a Dendy-like Famiclone instead of an official PAL NES.
+            // This distinction is rarely useful as both run on 50Hz, but can be a
+            // useful feature for running this detection program on unknown hardware.
+            if((_system_bits & 0xC0) == SYSTEM_BITS_DENDY)
+                return "50 Hz (Dendy-like)";
+            else
+                return "50 Hz";
+#else
+            return "50 Hz";
+#endif
+        default:
+            return "Unknown";
+    }
+}
+
+void main(void)
+{
+    font_t ibm_font;
+    uint8_t system = get_system();
+    // Init font system and load font
+    font_init();
+    ibm_font = font_load(font_ibm);
+    DISPLAY_ON;
+    gotoxy(4, 4);
+    printf("System: %s", get_system_name(system));
+    vsync();
+}

--- a/gbdk-lib/examples/cross-platform/display_system/src/display_system.c
+++ b/gbdk-lib/examples/cross-platform/display_system/src/display_system.c
@@ -23,11 +23,11 @@ const char* get_system_name(uint8_t system)
             return "60 Hz";
         case SYSTEM_50HZ:
 #if defined(NINTENDO_NES)
-            // For gbdk-nes, we can also inspect the _system_bits to more specifically
+            // For gbdk-nes, we can also inspect the bits in _SYSTEM to more specifically
             // report the console as a Dendy-like Famiclone instead of an official PAL NES.
             // This distinction is rarely useful as both run on 50Hz, but can be a
             // useful feature for running this detection program on unknown hardware.
-            if((_system_bits & 0xC0) == SYSTEM_BITS_DENDY)
+            if((_SYSTEM & 0xC0) == SYSTEM_BITS_DENDY)
                 return "50 Hz (Dendy-like)";
             else
                 return "50 Hz";

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -24,6 +24,9 @@
 #undef MSX
 #endif
 
+#define SYSTEM_50HZ     0x00
+#define SYSTEM_60HZ     0x01
+
 #if defined(__TARGET_ap)
 #define ANALOGUEPOCKET
 #elif defined(__TARGET_gb)
@@ -409,6 +412,13 @@ void mode(uint8_t m);
     @see M_DRAWING, M_TEXT_OUT, M_TEXT_INOUT, M_NO_SCROLL, M_NO_INTERP
 */
 uint8_t get_mode(void) PRESERVES_REGS(b, c, d, e, h, l);
+
+/** Returns the system gbdk is running on.
+
+*/
+inline uint8_t get_system(void) {
+    return SYSTEM_60HZ;
+}
 
 /** GB CPU type
 

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -24,8 +24,8 @@
 #undef MSX
 #endif
 
-#define SYSTEM_50HZ     0x00
-#define SYSTEM_60HZ     0x01
+#define SYSTEM_60HZ     0x00
+#define SYSTEM_50HZ     0x01
 
 #if defined(__TARGET_ap)
 #define ANALOGUEPOCKET

--- a/gbdk-lib/include/msx/msx.h
+++ b/gbdk-lib/include/msx/msx.h
@@ -28,6 +28,8 @@
 #define MSXDOS
 #endif
 
+#define SYSTEM_50HZ     0x00
+#define SYSTEM_60HZ     0x01
 
 #define VBK_REG VDP_ATTR_SHIFT
 
@@ -111,6 +113,13 @@ void mode(uint8_t m) OLDCALL;
     @see M_TEXT_OUT, M_TEXT_INOUT, M_NO_SCROLL, M_NO_INTERP
 */
 uint8_t get_mode(void) OLDCALL;
+
+/** Returns the system gbdk is running on.
+
+*/
+inline uint8_t get_system(void) {
+    return _SYSTEM;
+}
 
 /* Interrupt flags */
 /** Disable calling of interrupt service routines

--- a/gbdk-lib/include/msx/msx.h
+++ b/gbdk-lib/include/msx/msx.h
@@ -28,8 +28,10 @@
 #define MSXDOS
 #endif
 
-#define SYSTEM_50HZ     0x00
-#define SYSTEM_60HZ     0x01
+extern const uint8_t _SYSTEM;
+
+#define SYSTEM_60HZ     0x00
+#define SYSTEM_50HZ     0x01
 
 #define VBK_REG VDP_ATTR_SHIFT
 

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -25,6 +25,13 @@
 #undef MSX
 #endif
 
+#define SYSTEM_BITS_NTSC    0x00
+#define SYSTEM_BITS_PAL     0x40
+#define SYSTEM_BITS_DENDY   0x80
+extern const uint8_t _system_bits;
+
+#define SYSTEM_60HZ    0x00
+#define SYSTEM_50HZ    0x01
 
 #define RGB(r,g,b)        RGB_TO_NES(((r) | ((g) << 2) | ((b) << 4)))
 #define RGB8(r,g,b)       RGB_TO_NES((((r) >> 6) | (((g) >> 6) << 2) | (((b) >> 6) << 4)))
@@ -254,6 +261,16 @@ void mode(uint8_t m) NO_OVERLAY_LOCALS;
     @see M_DRAWING, M_TEXT_OUT, M_TEXT_INOUT, M_NO_SCROLL, M_NO_INTERP
 */
 uint8_t get_mode(void) NO_OVERLAY_LOCALS;
+
+/** Returns the system gbdk is running on.
+
+*/
+inline uint8_t get_system(void) {
+    if(_system_bits == SYSTEM_BITS_NTSC)
+        return SYSTEM_60HZ;
+    else
+        return SYSTEM_50HZ;
+}
 
 /** Global Time Counter in VBL periods (60Hz)
 

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -25,10 +25,10 @@
 #undef MSX
 #endif
 
-#define SYSTEM_BITS_NTSC    0x00
-#define SYSTEM_BITS_PAL     0x40
-#define SYSTEM_BITS_DENDY   0x80
-extern const uint8_t _system_bits;
+#define SYSTEM_BITS_NTSC        0x00
+#define SYSTEM_BITS_PAL         0x40
+#define SYSTEM_BITS_DENDY       0x80
+extern const uint8_t _SYSTEM;
 
 #define SYSTEM_60HZ    0x00
 #define SYSTEM_50HZ    0x01
@@ -266,7 +266,7 @@ uint8_t get_mode(void) NO_OVERLAY_LOCALS;
 
 */
 inline uint8_t get_system(void) {
-    if(_system_bits == SYSTEM_BITS_NTSC)
+    if(_SYSTEM == SYSTEM_BITS_NTSC)
         return SYSTEM_60HZ;
     else
         return SYSTEM_50HZ;

--- a/gbdk-lib/include/sms/sms.h
+++ b/gbdk-lib/include/sms/sms.h
@@ -35,8 +35,8 @@ extern const UBYTE _BIOS;
 
 extern const UBYTE _SYSTEM;
 
-#define SYSTEM_PAL     0x00
-#define SYSTEM_NTSC    0x01
+#define SYSTEM_50HZ     0x00
+#define SYSTEM_60HZ     0x01
 
 #define VBK_REG VDP_ATTR_SHIFT
 
@@ -120,6 +120,13 @@ void mode(uint8_t m) OLDCALL;
     @see M_TEXT_OUT, M_TEXT_INOUT, M_NO_SCROLL, M_NO_INTERP
 */
 uint8_t get_mode(void) OLDCALL;
+
+/** Returns the system gbdk is running on.
+
+*/
+inline uint8_t get_system(void) {
+    return _SYSTEM;
+}
 
 /* Interrupt flags */
 /** Disable calling of interrupt service routines

--- a/gbdk-lib/include/sms/sms.h
+++ b/gbdk-lib/include/sms/sms.h
@@ -33,10 +33,10 @@
 
 extern const UBYTE _BIOS;
 
-extern const UBYTE _SYSTEM;
+extern const uint8_t _SYSTEM;
 
-#define SYSTEM_50HZ     0x00
-#define SYSTEM_60HZ     0x01
+#define SYSTEM_60HZ     0x00
+#define SYSTEM_50HZ     0x01
 
 #define VBK_REG VDP_ATTR_SHIFT
 

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -72,7 +72,7 @@ _bkg_scroll_y::                         .ds 1
 _attribute_row_dirty::                  .ds 1
 _attribute_column_dirty::               .ds 1
 .crt0_forced_blanking::                 .ds 1
-__system_bits::                         .ds 1
+__SYSTEM::                              .ds 1
 
 .define __crt0_NMITEMP "___SDCC_m6502_ret4"
 
@@ -193,7 +193,7 @@ ProcessDrawList:
 
     lda #144 ; Initialize A with PAL fractional cycle count
     ; +7 cycles for NTSC scanlines
-    bit *__system_bits
+    bit *__SYSTEM
     bvs 3$
     lda #171 ; NTSC fractional cycle count
     nop
@@ -256,7 +256,7 @@ __crt0_NMI:
     bne 1$
     ; Do additional delay of 5186 cycles if running on a PAL system, and -5*7 + 2 = -33 for alignment
     ; This is to compensate for the longer vblank period of 7459 vs NTSC's 2273
-    bit *__system_bits
+    bit *__SYSTEM
     bvc 2$
     nop
     ldy #5
@@ -429,12 +429,12 @@ __crt0_RESET_bankSwitchValue:
     bit PPUSTATUS
     CRT0_WAIT_PPU
     CRT0_WAIT_PPU_AND_DETECT_SYSTEM
-    ; Store system in upper two bits of __system_bits, to allow bit instruction to quickly test for PAL
+    ; Store system in upper two bits of __SYSTEM, to allow bit instruction to quickly test for PAL
     clc
     ror
     ror
     ror
-    sta *__system_bits
+    sta *__SYSTEM
     ; Clear VRAM
     jsr __crt0_clearVRAM
     ; Hide sprites in shadow OAM, and perform OAM DMA

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -1,7 +1,7 @@
         ;; Transfer buffer (lower half of hardware stack)
         __vram_transfer_buffer = 0x100
         ;; Number of 8-cycles available each frame for transfer buffer
-        VRAM_DELAY_CYCLES_X8  = 174
+        VRAM_DELAY_CYCLES_X8  = 172
 
         ;;  Keypad
         .UP             = 0x08

--- a/gbdk-lib/libc/targets/z80/gg/global.s
+++ b/gbdk-lib/libc/targets/z80/gg/global.s
@@ -225,8 +225,8 @@
 
         .BIOS           = 0xC000
 
-        .SYSTEM_PAL     = 0x00
-        .SYSTEM_NTSC    = 0x01
+        .SYSTEM_NTSC    = 0x00
+        .SYSTEM_PAL     = 0x01
 
         .CPU_CLOCK      = 3579545
 

--- a/gbdk-lib/libc/targets/z80/msxdos/global.s
+++ b/gbdk-lib/libc/targets/z80/msxdos/global.s
@@ -287,8 +287,8 @@
         .MAP_FRAME2     = 0xfffe
         .MAP_FRAME3     = 0xffff
 
-        .SYSTEM_PAL     = 0x00
-        .SYSTEM_NTSC    = 0x01
+        .SYSTEM_NTSC    = 0x00
+        .SYSTEM_PAL     = 0x01
 
         .CPU_CLOCK      = 3579545
 

--- a/gbdk-lib/libc/targets/z80/sms/global.s
+++ b/gbdk-lib/libc/targets/z80/sms/global.s
@@ -227,8 +227,8 @@
 
         .BIOS           = 0xC000
 
-        .SYSTEM_PAL     = 0x00
-        .SYSTEM_NTSC    = 0x01
+        .SYSTEM_NTSC    = 0x00
+        .SYSTEM_PAL     = 0x01
 
         .CPU_CLOCK      = 3579545
 


### PR DESCRIPTION
NES: Add PAL support
* Add new zeropage variable _system_bits to indicate NTSC/PAL/Dendy system
* Modify init code to detect NTSC/PAL/Dendy via cycle counting, storing result in _system_bits
* Modify fake-LCD-ISR delays in NMI handler to accommodate PAL timings

Cross-platform:
* Change existing SYSTEM_NTSC / SYSTEM_PAL defines in sms.h to SYSTEM_60HZ / SYSTEM_50HZ, and copy them to gb.h / nes.h / msx.h
* Add new cross-platform function get_system for all ports, to query whether running on a 60Hz or 50Hz system
* Add minimal cross-platform display_system example to exercise get_system