### PR TITLE
Png2asset/fixes and export

### DIFF
--- a/gbdk-support/png2asset/image_data.cpp
+++ b/gbdk-support/png2asset/image_data.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <fstream>
 #include <cstdint>
+#include <cstdlib>
 
 #include "lodepng.h"
 #include "mttile.h"
@@ -59,12 +60,12 @@ int ReadImageData_KeepPaletteOrder(  PNG2AssetData* assetData, string input_file
     if(error)
     {
         printf("decoder error %s\n", lodepng_error_text(error));
-        return 1;
+        return EXIT_FAILURE;
     }
 
     // Unpack the image if needed. Also checks and errors on incompatible palette type if needed
     if(!image_indexed_ensure_8bpp(assetData->image.data, (int)state.info_png.color.bitdepth, (int)state.info_png.color.colortype))
-        return 1;
+        return EXIT_FAILURE;
 
     // Use source image palette since lodepng conversion to indexed (LCT_PALETTE) won't create a palette
     // So: state->info_png.color.palette/size instead of state->info_raw.palette/size
@@ -84,14 +85,14 @@ int ReadImageData_KeepPaletteOrder(  PNG2AssetData* assetData, string input_file
 
     if(assetData->args->repair_indexed_pal)
         if(!image_indexed_repair_tile_palettes(assetData->image, assetData->args->use_2x2_map_attributes))
-            return 1;
+            return EXIT_FAILURE;
 
     // TODO: Enable dimension check
     // // Validate image dimensions
     // if (((image.w % tile_w) != 0) || ((image.h % tile_h) != 0))
     // {
     //     printf("Error: Image size %d x %d isn't an even multiple of tile size %d x %d\n", image.w, image.h, tile_w, tile_h);
-    //     return 1;
+    //     return EXIT_FAILURE;
     // }
 
     // Only check this for the main image, not for source tilesets
@@ -102,7 +103,7 @@ int ReadImageData_KeepPaletteOrder(  PNG2AssetData* assetData, string input_file
 
             printf("error: The number of color palettes for your source tileset (%d) and target image (%d) do not match.",
                    (unsigned int)assetData->args->source_total_color_count, (unsigned int)assetData->image.total_color_count);
-            return 1;
+            return EXIT_FAILURE;
         }
 
         size_t size = max(assetData->image.total_color_count, assetData->args->source_total_color_count);
@@ -112,10 +113,10 @@ int ReadImageData_KeepPaletteOrder(  PNG2AssetData* assetData, string input_file
         if (memcmp(assetData->image.palette, assetData->image.source_tileset_palette, size) != 0) {
 
             printf("error: The palettes for your source tileset and target image do not match.");
-            return 1;
+            return EXIT_FAILURE;
         }
     }
-    return 0;
+    return EXIT_SUCCESS;
 }
 
 int ReadImageData_Default(PNG2AssetData* assetData, string  input_filename) {
@@ -134,14 +135,14 @@ int ReadImageData_Default(PNG2AssetData* assetData, string  input_filename) {
     if(error)
     {
         printf("decoder error %s\n", lodepng_error_text(error));
-        return 1;
+        return EXIT_FAILURE;
     }
 
     // Validate image dimensions
     if(((image32.w % image32.tile_w) != 0) || ((image32.h % image32.tile_h) != 0))
     {
         printf("Error: Image size %d x %d isn't an even multiple of tile size %d x %d\n", image32.w, image32.h, image32.tile_w, image32.tile_h);
-        return 1;
+        return EXIT_FAILURE;
     }
 
     int* palettes_per_tile = BuildPalettesAndAttributes(image32, assetData->palettes, assetData->args->use_2x2_map_attributes);
@@ -193,7 +194,7 @@ int ReadImageData_Default(PNG2AssetData* assetData, string  input_filename) {
 
     //Test: output png to see how it looks
     //Export(image, "temp.png");
-    return 0;
+    return EXIT_SUCCESS;
 }
 
 int ReadImageData( PNG2AssetData* assetData, string  input_filename) {
@@ -211,22 +212,22 @@ int ReadImageData( PNG2AssetData* assetData, string  input_filename) {
     }
 
 
-    int errorCode = 0;
+    int errorCode = EXIT_SUCCESS;
 
     // Will the specified PNG have a palette provided with it?
-    if(assetData->args->keep_palette_order) {
-        
+    if (assetData->args->keep_palette_order) {
+
         // Save the error code
-        errorCode= ReadImageData_KeepPaletteOrder(assetData, input_filename);
+        errorCode = ReadImageData_KeepPaletteOrder(assetData, input_filename);
     }
     else
     {
 
         // Save the error code
-        errorCode= ReadImageData_Default(assetData, input_filename);
+        errorCode = ReadImageData_Default(assetData, input_filename);
     }
 
-    if(errorCode != 0)return errorCode;
+    if (errorCode != EXIT_SUCCESS) return errorCode;
 
 
     // Only set this data when processing the main image
@@ -238,6 +239,6 @@ int ReadImageData( PNG2AssetData* assetData, string  input_filename) {
         if(assetData->args->pivot.width == 0xFFFFFF)  assetData->args->pivot.width = assetData->args->spriteSize.width;
         if(assetData->args->pivot.height == 0xFFFFFF) assetData->args->pivot.height = assetData->args->spriteSize.height;
     }
-    return 0;
+    return EXIT_SUCCESS;
 }
 

--- a/gbdk-support/png2asset/image_data.cpp
+++ b/gbdk-support/png2asset/image_data.cpp
@@ -56,13 +56,15 @@ int ReadImageData_KeepPaletteOrder(  PNG2AssetData* assetData, string input_file
     assetData->image.data.clear();
 
     unsigned error = lodepng::decode(assetData->image.data, assetData->image.w, assetData->image.h, state, buffer);
-    // Unpack the image if needed. Also checks and errors on incompatible palette type if needed
-    if(!image_indexed_ensure_8bpp(assetData->image.data, (int)state.info_png.color.bitdepth, (int)state.info_png.color.colortype))
-        return 1;
-    else if(error) {
+    if(error)
+    {
         printf("decoder error %s\n", lodepng_error_text(error));
         return 1;
     }
+
+    // Unpack the image if needed. Also checks and errors on incompatible palette type if needed
+    if(!image_indexed_ensure_8bpp(assetData->image.data, (int)state.info_png.color.bitdepth, (int)state.info_png.color.colortype))
+        return 1;
 
     // Use source image palette since lodepng conversion to indexed (LCT_PALETTE) won't create a palette
     // So: state->info_png.color.palette/size instead of state->info_raw.palette/size

--- a/gbdk-support/png2asset/main.cpp
+++ b/gbdk-support/png2asset/main.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <fstream>
 #include <cstdint>
+#include <cstdlib>
 
 #include "lodepng.h"
 #include "mttile.h"
@@ -35,13 +36,13 @@ string extract_path(bool extract, string const & path, string const & name)
 
 int main(int argc, char* argv[])
 {
-    int errorCode = 0;
+    int errorCode = EXIT_SUCCESS;
 
     // Read all arguments
     PNG2AssetArguments arguments;
 
     // Make sure we had no errors
-    if((errorCode = processPNG2AssetArguments(argc, argv, &arguments)) != 0) {
+    if ((errorCode = processPNG2AssetArguments(argc, argv, &arguments)) != EXIT_SUCCESS) {
         return errorCode;
     }
 
@@ -61,7 +62,7 @@ int main(int argc, char* argv[])
             errorCode = png2AssetInstance.Execute(&arguments, extract_path(arguments.relative_paths, arguments.input_filename, *sourceTilesetFileNameIter));
 
             // Return the error code if the function returns non-zero
-            if(errorCode != 0) {
+            if (errorCode != EXIT_SUCCESS) {
                 return errorCode;
             }
 
@@ -87,7 +88,7 @@ int main(int argc, char* argv[])
         errorCode = png2AssetInstance.Execute(&arguments, extract_path(arguments.relative_paths, arguments.input_filename, arguments.entity_tileset_filename));
 
         // Return the error code if the function returns non-zero
-        if(errorCode != 0) {
+        if (errorCode != EXIT_SUCCESS) {
             return errorCode;
         }
 
@@ -98,7 +99,7 @@ int main(int argc, char* argv[])
     // Run the primary input file
     // Return the error code if the function returns non-zero
     arguments.processing_mode = MODE_MAIN_IMAGE;
-    if((errorCode = png2AssetInstance.Execute(&arguments, arguments.input_filename)) != 0) {
+    if ((errorCode = png2AssetInstance.Execute(&arguments, arguments.input_filename)) != EXIT_SUCCESS) {
         return errorCode;
     }
 

--- a/gbdk-support/png2asset/png2asset.cpp
+++ b/gbdk-support/png2asset/png2asset.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <fstream>
 #include <cstdint>
+#include <cstdlib>
 
 #include "lodepng.h"
 #include "mttile.h"
@@ -47,11 +48,11 @@ int PNG2AssetData::Execute(PNG2AssetArguments* arguments, string  input_filename
         this->image.tile_h = 16;
     }
 
-    int readImageDataValue = ReadImageData(this, input_filename);
+    int errorCode = ReadImageData(this, input_filename);
 
     // Return the error code if the function returns non-zero
-    if(readImageDataValue != 0) {
-        return readImageDataValue;
+    if (errorCode != EXIT_SUCCESS) {
+        return errorCode;
     }
 
     // Extract the data depending on what type it is
@@ -67,13 +68,13 @@ int PNG2AssetData::Execute(PNG2AssetArguments* arguments, string  input_filename
     else
         GetAllMetasprites(this);
 
-    return 0;
+    return EXIT_SUCCESS;
 }
 
 int PNG2AssetData::Export() {
 
     // Header file export
-    if(export_h_file(this) == false) return 1; // Exit with Fail
+    if(export_h_file(this) == false) return EXIT_FAILURE;
 
     if((this->args->export_as_map) && (this->args->output_binary)) {
         // Handle special case of binary map export
@@ -81,10 +82,10 @@ int PNG2AssetData::Export() {
     }
     else {
         // Normal source file export
-        if(export_c_file(this) == false) return 1; // Exit with Fail
+        if(export_c_file(this) == false) return EXIT_FAILURE;
     }
 
-    return 0;
+    return EXIT_SUCCESS;
 }
 
 

--- a/gbdk-support/png2asset/process_arguments.cpp
+++ b/gbdk-support/png2asset/process_arguments.cpp
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <fstream>
 #include <cstdint>
+#include <cstdlib>
 
 #include "lodepng.h"
 #include "mttile.h"
@@ -125,7 +126,7 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
         printf("-transposed         export transposed (column-by-column instead of row-by-row)\n");
 
         printf("-rel_paths          paths to tilesets are relative to the input file path\n");
-        return 0;
+        return EXIT_SUCCESS;
     }
 
     //default params
@@ -180,10 +181,10 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
         {
             if ((i + 1) >= argc) {
                 printf("Error: -c or -o requires a filename, none specified\n");
-                return 1;
+                return EXIT_FAILURE;
             } else if (argv[i+1][0] == '-') {
                 printf("Error: next argument after -o looks like an option instead of a filename (\"%s\")\n", argv[i + 1]);
-                return 1;
+                return EXIT_FAILURE;
             }
 
             args->output_filename = argv[++i];
@@ -237,7 +238,7 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
             if(args->max_palettes == 0)
             {
                 printf("-max_palettes must be larger than zero\n");
-                return 1;
+                return EXIT_FAILURE;
             }
         }
         else if(!strcmp(argv[i], "-pack_mode"))
@@ -259,7 +260,7 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
             else
             {
                 printf("-pack_mode must be one of gb, nes, sgb, sms, 1bpp\n");
-                return 1;
+                return EXIT_FAILURE;
             }
         }
         else if(!strcmp(argv[i], "-tile_origin"))
@@ -325,6 +326,6 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
     args->data_name = args->output_filename.substr(slash_pos + 1, dot_pos - 1 - slash_pos);
     replace(args->data_name.begin(), args->data_name.end(), '-', '_');
 
-    return 0;
+    return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
- png load error handling code was mislocated to 8bpp check below it
- use standard constants instead of numbers for readability for return codes