### PR TITLE
png2asset: incorrect tile count for use_structs + source_tileset when there are excess tiles

### DIFF
--- a/gbdk-support/png2asset/export_c_file.cpp
+++ b/gbdk-support/png2asset/export_c_file.cpp
@@ -345,7 +345,7 @@ static void export_c_zgb_tiles_struct(PNG2AssetData* assetData, FILE* file, int 
         fprintf(file, "const struct TilesInfo %s_tiles_info = {\n",        assetData->args->data_name.c_str());
     }
 
-    fprintf(file, "\t.num_frames=%d,"            " // num tiles\n",    (unsigned int)assetData->tiles.size() * (assetData->image.tile_h >> 3));
+    fprintf(file, "\t.num_frames=%d,"            " // num tiles\n",    (unsigned int)exportOpt.tiles_count);
     fprintf(file, "\t.data=%s_tiles,"            " // tiles\n",        assetData->args->data_name.c_str());
     fprintf(file, "\t.num_pals=%d,"              " // num palettes\n", (unsigned int)(exportOpt.color_count / assetData->image.colors_per_pal));
     fprintf(file, "\t.pals=%s_palettes,"         " // palettes\n",     assetData->args->data_name.c_str());

--- a/gbdk-support/png2asset/testing/ref/zgb_color_indexed_nums_map_2.c
+++ b/gbdk-support/png2asset/testing/ref/zgb_color_indexed_nums_map_2.c
@@ -148,7 +148,7 @@ extern const struct TilesInfo color_indexed_nums8x8_9_to_0.png;
 
 BANKREF(zgb_color_indexed_nums_map_2_tiles_info)
 const struct TilesInfo zgb_color_indexed_nums_map_2_tiles_info = {
-	.num_frames=40, // num tiles
+	.num_frames=30, // num tiles
 	.data=zgb_color_indexed_nums_map_2_tiles, // tiles
 	.num_pals=4, // num palettes
 	.pals=zgb_color_indexed_nums_map_2_palettes, // palettes

--- a/gbdk-support/png2asset/testing/ref/zgb_color_indexed_nums_map_4.c
+++ b/gbdk-support/png2asset/testing/ref/zgb_color_indexed_nums_map_4.c
@@ -108,7 +108,7 @@ extern const struct TilesInfo color_indexed_nums8x8_9_to_0.png;
 
 BANKREF(zgb_color_indexed_nums_map_4_tiles_info)
 const struct TilesInfo zgb_color_indexed_nums_map_4_tiles_info = {
-	.num_frames=30, // num tiles
+	.num_frames=20, // num tiles
 	.data=zgb_color_indexed_nums_map_4_tiles, // tiles
 	.num_pals=4, // num palettes
 	.pals=zgb_color_indexed_nums_map_4_palettes, // palettes

--- a/gbdk-support/png2asset/testing/ref/zgb_color_nums_map_2.c
+++ b/gbdk-support/png2asset/testing/ref/zgb_color_nums_map_2.c
@@ -148,7 +148,7 @@ extern const struct TilesInfo color_nums8x8_9_to_0.png;
 
 BANKREF(zgb_color_nums_map_2_tiles_info)
 const struct TilesInfo zgb_color_nums_map_2_tiles_info = {
-	.num_frames=40, // num tiles
+	.num_frames=30, // num tiles
 	.data=zgb_color_nums_map_2_tiles, // tiles
 	.num_pals=4, // num palettes
 	.pals=zgb_color_nums_map_2_palettes, // palettes

--- a/gbdk-support/png2asset/testing/ref/zgb_color_nums_map_4.c
+++ b/gbdk-support/png2asset/testing/ref/zgb_color_nums_map_4.c
@@ -108,7 +108,7 @@ extern const struct TilesInfo color_nums8x8_9_to_0.png;
 
 BANKREF(zgb_color_nums_map_4_tiles_info)
 const struct TilesInfo zgb_color_nums_map_4_tiles_info = {
-	.num_frames=30, // num tiles
+	.num_frames=20, // num tiles
 	.data=zgb_color_nums_map_4_tiles, // tiles
 	.num_pals=4, // num palettes
 	.pals=zgb_color_nums_map_4_palettes, // palettes

--- a/gbdk-support/png2asset/testing/ref/zgb_nums_map_2.c
+++ b/gbdk-support/png2asset/testing/ref/zgb_nums_map_2.c
@@ -141,12 +141,12 @@ BANKREF_EXTERN(nums8x8_9_to_0.png)
 extern const struct TilesInfo nums8x8_9_to_0.png;
 
 const uint8_t zgb_nums_map_2_tile_pals[30] = {
-	, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
 BANKREF(zgb_nums_map_2_tiles_info)
 const struct TilesInfo zgb_nums_map_2_tiles_info = {
-	.num_frames=40, // num tiles
+	.num_frames=30, // num tiles
 	.data=zgb_nums_map_2_tiles, // tiles
 	.num_pals=1, // num palettes
 	.pals=zgb_nums_map_2_palettes, // palettes

--- a/gbdk-support/png2asset/testing/ref/zgb_nums_map_4.c
+++ b/gbdk-support/png2asset/testing/ref/zgb_nums_map_4.c
@@ -101,12 +101,12 @@ BANKREF_EXTERN(nums8x8_9_to_0.png)
 extern const struct TilesInfo nums8x8_9_to_0.png;
 
 const uint8_t zgb_nums_map_4_tile_pals[20] = {
-	, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
 BANKREF(zgb_nums_map_4_tiles_info)
 const struct TilesInfo zgb_nums_map_4_tiles_info = {
-	.num_frames=30, // num tiles
+	.num_frames=20, // num tiles
 	.data=zgb_nums_map_4_tiles, // tiles
 	.num_pals=1, // num palettes
 	.pals=zgb_nums_map_4_palettes, // palettes

--- a/gbdk-support/png2asset/testing/ref/zgb_nums_map_6.c
+++ b/gbdk-support/png2asset/testing/ref/zgb_nums_map_6.c
@@ -141,12 +141,12 @@ BANKREF_EXTERN(nums8x8_9_to_0.png)
 extern const struct TilesInfo nums8x8_9_to_0.png;
 
 const uint8_t zgb_nums_map_6_tile_pals[30] = {
-	, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
 BANKREF(zgb_nums_map_6_tiles_info)
 const struct TilesInfo zgb_nums_map_6_tiles_info = {
-	.num_frames=40, // num tiles
+	.num_frames=30, // num tiles
 	.data=zgb_nums_map_6_tiles, // tiles
 	.num_pals=1, // num palettes
 	.pals=zgb_nums_map_6_palettes, // palettes

--- a/gbdk-support/png2asset/testing/ref/zgb_nums_map_8.c
+++ b/gbdk-support/png2asset/testing/ref/zgb_nums_map_8.c
@@ -101,12 +101,12 @@ BANKREF_EXTERN(nums8x8_9_to_0.png)
 extern const struct TilesInfo nums8x8_9_to_0.png;
 
 const uint8_t zgb_nums_map_8_tile_pals[20] = {
-	, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
 BANKREF(zgb_nums_map_8_tiles_info)
 const struct TilesInfo zgb_nums_map_8_tiles_info = {
-	.num_frames=30, // num tiles
+	.num_frames=20, // num tiles
 	.data=zgb_nums_map_8_tiles, // tiles
 	.num_pals=1, // num palettes
 	.pals=zgb_nums_map_8_palettes, // palettes


### PR DESCRIPTION


- update test output