### PR TITLE
NES: Add deferred hblank system for fake LCD ISRs

### DIFF
--- a/gbdk-lib/examples/cross-platform/scroller/src/text_scroller.c
+++ b/gbdk-lib/examples/cross-platform/scroller/src/text_scroller.c
@@ -7,14 +7,27 @@ const uint8_t * scanline_offsets = scanline_offsets_tbl;
 
 #define SCROLL_POS 15
 #define SCROLL_POS_PIX_START ((SCROLL_POS + DEVICE_SCREEN_Y_OFFSET) * 8) - 1
-#define SCROLL_POS_PIX_END ((SCROLL_POS + DEVICE_SCREEN_X_OFFSET + 1) * 8) - 1
+#define SCROLL_POS_PIX_END ((SCROLL_POS + DEVICE_SCREEN_Y_OFFSET + 1) * 8) - 1
+
+extern uint8_t _lcd_scanline;
 
 uint8_t scroller_x = 0;
 void scanline_isr(void) {
 #if defined(NINTENDO_NES)
-    // Write directly to hardware scroll registers (only first write will have an effect)
-    PPUSCROLL = scroller_x;
-    PPUSCROLL = 0; // 2nd write (dummy)
+    switch (_lcd_scanline) {
+        case 0: 
+            move_bkg(0, 0);
+            _lcd_scanline = SCROLL_POS_PIX_START;
+            break;
+        case SCROLL_POS_PIX_START:
+            move_bkg(scroller_x, SCROLL_POS_PIX_START);
+            _lcd_scanline = SCROLL_POS_PIX_END;
+            break;
+        case SCROLL_POS_PIX_END:
+            move_bkg(0, SCROLL_POS_PIX_END);
+            _lcd_scanline = 0;
+            break;
+    }
 #elif defined(NINTENDO)
     switch (LYC_REG) {
         case 0: 
@@ -49,9 +62,12 @@ const uint8_t * scroller_next_char = scroller_text;
 uint8_t * scroller_vram_addr;
 uint8_t * base, * limit;
 
-extern uint8_t _lcd_scanline;
-
 void main(void) {
+    DISPLAY_OFF;
+    // Fill the screen background with '*'
+    fill_bkg_rect(0, 0, DEVICE_SCREEN_WIDTH, DEVICE_SCREEN_HEIGHT, '*' - ' ');
+    SHOW_BKG; SHOW_SPRITES;
+    
     printf(" Scrolling %d chars", sizeof(scroller_text) - 1);
 
     CRITICAL {
@@ -92,7 +108,7 @@ void main(void) {
 #ifdef NINTENDO_NES
         // Normal indirect setting of scroll via shadow registers (written by vblank handler)
         move_bkg(0,0);
-        _lcd_scanline = SCROLL_POS;
+        _lcd_scanline = 0;
 #endif
         vsync();        
     }

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -248,6 +248,10 @@ void add_VBL(int_handler h) NO_OVERLAY_LOCALS;
 */
 void add_LCD(int_handler h) NO_OVERLAY_LOCALS;
 
+/** The maximum number of times the LCD handler will be called per frame.
+ */
+#define MAX_LCD_ISR_CALLS 4
+
 /** Set the current screen mode - one of M_* modes
 
     Normally used by internal functions only.

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -67,6 +67,7 @@ _sys_time::                             .ds 2
 _shadow_PPUCTRL::                       .ds 1
 _shadow_PPUMASK::                       .ds 1
 __crt0_spritePageValid:                 .ds 1
+__crt0_disableNMI:                      .ds 1
 _bkg_scroll_x::                         .ds 1
 _bkg_scroll_y::                         .ds 1
 _attribute_row_dirty::                  .ds 1
@@ -79,6 +80,12 @@ __SYSTEM::                              .ds 1
 .area _BSS
 __crt0_paletteShadow::                  .ds 25
 .mode::                                 .ds 1
+__lcd_isr_PPUCTRL:                      .ds .MAX_LCD_ISR_CALLS
+__lcd_isr_PPUMASK:                      .ds .MAX_LCD_ISR_CALLS
+__lcd_isr_scroll_x:                     .ds .MAX_LCD_ISR_CALLS
+__lcd_isr_scroll_y:                     .ds .MAX_LCD_ISR_CALLS
+__lcd_isr_delay_num_scanlines:          .ds .MAX_LCD_ISR_CALLS
+__lcd_isr_num_calls:                    .ds 1
 
 .area _CODE
 
@@ -161,36 +168,35 @@ ProcessDrawList:
 ;
 ; Delays until specified (non-zero) scanline is reached
 ;
-; First scanline's delay needs adjusting for cycle cost of subroutine execution:
-; beq-not-taken -1
-; jsr           +6
-; lda #0        +2
-; sta *.acc     +3
-; ldy #N        +2
-; nop           +2
-; nop           +2
-; bne-taken     +3
-; rts           +6
-; -> 25 cycles less
-; -> N = 19-25/5 = 19-5
+; First scanline's delay needs adjusting in coordination with .do_lcd_ppu_reg_writes
 ;
 .define .acc "___SDCC_m6502_ret4"
 .delay_to_lcd_scanline::
-    lda #0
-    sta *.acc
-    ldy #(19-5)
-    nop
-    nop
-    bne 2$
+    jsr .delay_12_cycles
+    jmp 2$
 1$:
-    ldy #15
+    jsr .delay_28_cycles
+    jsr .delay_28_cycles
+    jsr .delay_12_cycles ; -> 28 + 28 + 12 = 68 cycles
 2$:
-    dey
-    bne 2$      ; -> 2 + 14*5 + 4 = 76 cycles
 
+    jsr .delay_fractional   ; -> 40.666 NTSC cycles  33.5625 PAL cycles
+  
+    dex
+    bne 1$      ; -> 5 cycles
+    rts
+
+.delay_28_cycles:
+    jsr .delay_12_cycles
     nop
-    nop         ; -> 4 cycles
+    nop
+.delay_12_cycles:
+    rts
 
+;
+; Takes 40.666 NTSC cycles / 33.5626 PAL cycles
+;
+.delay_fractional:
     lda #144 ; Initialize A with PAL fractional cycle count
     ; +7 cycles for NTSC scanlines
     bit *__SYSTEM
@@ -207,12 +213,13 @@ ProcessDrawList:
     bcs 4$
 4$:
     sta *.acc   ; -> 13.666 NTSC cycles / 13.5625 PAL cycles
-    
-    dex
-    bne 1$      ; -> 5 cycles
-    rts
+    rts         ; -> 6 cycles for RTS, 6 cycles for JSR = 12 cycles
 
+__crt0_NMI_earlyout:
+    rti
 __crt0_NMI:
+    bit *__crt0_disableNMI
+    bmi __crt0_NMI_earlyout
     pha
     txa
     pha
@@ -259,6 +266,7 @@ __crt0_NMI:
     bit *__SYSTEM
     bvc 2$
     nop
+    nop
     ldy #5
     ldx #(14-7)
 3$:
@@ -267,11 +275,8 @@ __crt0_NMI:
     dey
     bne 3$
 2$:
-    ; ...then delay for desired number of scanlines
-    ldx *__lcd_scanline
-    jsr .delay_to_lcd_scanline
-    ; Call the handler
-    jsr .jmp_to_LCD_isr
+    ; Call the write reg subroutine
+    jsr .do_lcd_ppu_reg_writes
 __crt0_NMI_skip:
 
     ; Update frame counter
@@ -402,12 +407,113 @@ __crt0_clearVRAM_loop:
 .wait_vbl_done::
 _wait_vbl_done::
 _vsync::
+
+    .define .lcd_scanline_previous "REGTEMP"
     jsr _flush_shadow_attributes
     jsr .jmp_to_VBL_isr
+
+    ; Set initial scanline value
+    lda #0xFF
+    sta *.lcd_scanline_previous
+    ;
+    ldy #0
+    sty __lcd_isr_num_calls
+    ; Special-case: LCD at scanline 0 should just directly replace VBL shadow_ values
+    lda *__lcd_scanline
+    bne 0$
+    jsr .jmp_to_LCD_isr
+    lda #0
+    sta *.lcd_scanline_previous
+0$:
+    ; disable NMI, as we are saving and restoring shadow registers that it may use
+    sec
+    ror *__crt0_disableNMI
+    ; Save shadow registers that LCD isr could change
+    lda *_shadow_PPUMASK
+    pha
+    lda *_shadow_PPUCTRL
+    pha
+    lda *_bkg_scroll_x
+    pha
+    lda *_bkg_scroll_y
+    pha
+
+    jmp 2$
+1$:
+    pla
+    sta *.lcd_scanline_previous
+    ; We are done if next scanline is <= the previous one
+    cmp *__lcd_scanline
+    bcs _wait_vbl_done_waitForNextFrame
+2$:
+    ;
+    ldy __lcd_isr_num_calls
+    lda *__lcd_scanline
+    ; We are done if next LCD scanline >= SCREENHEIGHT
+    cmp #.SCREENHEIGHT
+    bcs _wait_vbl_done_waitForNextFrame
+    pha
+    clc ; -1 to compensate for LCD PPU write taking up a scanline on its own
+    sbc *.lcd_scanline_previous
+    sta __lcd_isr_delay_num_scanlines,y
+    ; Call LCD isr
+    jsr .jmp_to_LCD_isr
+    ; Copy shadow registers
+    ldy __lcd_isr_num_calls
+    lda *_shadow_PPUMASK
+    sta __lcd_isr_PPUMASK,y
+    lda *_shadow_PPUCTRL
+    sta __lcd_isr_PPUCTRL,y
+    lda *_bkg_scroll_x
+    sta __lcd_isr_scroll_x,y
+    lda *_bkg_scroll_y
+    sta __lcd_isr_scroll_y,y
+       
+    iny
+    sty __lcd_isr_num_calls
+    cpy #.MAX_LCD_ISR_CALLS
+    bne 1$
+    
+    ; Clear last-scanline-value from stack
+    pla
+
+_wait_vbl_done_waitForNextFrame:
+    ; Restore shadow registers
+    pla
+    sta *_bkg_scroll_y
+    pla
+    sta *_bkg_scroll_x
+    pla
+    sta *_shadow_PPUCTRL
+    pla
+    sta *_shadow_PPUMASK
+
+    asl *__crt0_disableNMI
     lda *_sys_time
 _wait_vbl_done_waitForNextFrame_loop:
     cmp *_sys_time
     beq _wait_vbl_done_waitForNextFrame_loop
+    rts
+
+.display_off::
+_display_off::
+    lda *_shadow_PPUMASK
+    and #~(PPUMASK_SHOW_BG | PPUMASK_SHOW_SPR)
+    sta *_shadow_PPUMASK
+    sta PPUMASK
+    ; Set forced blanking bit
+    sec
+    ror *.crt0_forced_blanking
+    rts
+
+.display_on::
+_display_on::
+    lda *_shadow_PPUMASK
+    ora #(PPUMASK_SHOW_BG | PPUMASK_SHOW_SPR)
+    sta *_shadow_PPUMASK
+    ; Clear forced blanking bit
+    clc
+    ror *.crt0_forced_blanking
     rts
 
 __crt0_RESET:
@@ -482,26 +588,91 @@ __crt0_RESET_bankSwitchValue:
 __crt0_waitForever:
     jmp __crt0_waitForever
 
-.display_off::
-_display_off::
-    lda *_shadow_PPUMASK
-    and #~(PPUMASK_SHOW_BG | PPUMASK_SHOW_SPR)
-    sta *_shadow_PPUMASK
-    sta PPUMASK
-    ; Set forced blanking bit
-    sec
-    ror *.crt0_forced_blanking
-    rts
+.do_lcd_ppu_reg_writes:
+    .define .reg_write_index    "__crt0_NMITEMP+1"
+    .define .lda_PPUADDR        "__crt0_NMITEMP+2"
+    .define .ldx_PPUMASK        "__crt0_NMITEMP+3"
 
-.display_on::
-_display_on::
-    lda *_shadow_PPUMASK
-    ora #(PPUMASK_SHOW_BG | PPUMASK_SHOW_SPR)
-    sta *_shadow_PPUMASK
-    sta PPUMASK
-    ; Clear forced blanking bit
-    clc
-    ror *.crt0_forced_blanking
+    nop
+
+    ; Skip if empty buffer (no calls were made within frame)
+    lda __lcd_isr_num_calls
+    beq 2$
+
+    ldy #0
+    sty *.acc
+1$:
+    sty *.reg_write_index
+    ldx __lcd_isr_delay_num_scanlines,y
+    beq 3$
+    jsr .delay_to_lcd_scanline
+3$:
+
+    ; Pre-write PPUADDR (1st write) and y-scroll
+    sty PPUADDR
+    lda __lcd_isr_scroll_y,y
+    sta PPUSCROLL
+    and #0xF8
+    asl
+    asl
+    sta *.lda_PPUADDR
+    ; A <- PPUADDR (2nd write)
+    lda __lcd_isr_scroll_x,y
+    lsr
+    lsr
+    lsr
+    ora *.lda_PPUADDR
+    sta *.lda_PPUADDR
+    ; ldx <- PPUMASK
+    ldx __lcd_isr_PPUMASK,y
+    stx *.ldx_PPUMASK
+    ; X <- SCROLLX
+    ldx __lcd_isr_scroll_x,y
+    ; Y <- PPUCTRL
+    lda __lcd_isr_PPUCTRL,y
+    tay
+    lda *.lda_PPUADDR
+    ;
+    ; Write 4 PPU registers in following order.
+    ;
+    ; 1. PPUSCROLL          (needs to be written to set fine-x)
+    ; 2. PPUADDR 2nd write  (highest priority as needs to happen before the two-tile pre-fetch) 
+    ; 3. PPUCTRL            (PPU pattern table switch can affect two-tile pre-fetch)
+    ; 4. PPUMASK            (emphasis and render on/off are maybe less distracting?)
+    ;
+    ; TODO: Self-modifying code could build a non-redundant write sequence in RAM.
+    ;
+    stx PPUSCROLL
+    sta PPUADDR
+    sty PPUCTRL
+    ldx *.ldx_PPUMASK
+    stx PPUMASK
+
+    ; Delay for 40.666 NTSC cycles / 33.5625 PAL cycles
+    jsr .delay_fractional
+    ldy *.reg_write_index
+    
+    ; Finally, write Y-scroll part of T with original non-LCD shadow values, but 
+    ; *without* triggering an update of V, to mitigate glitches on lag frames.
+    ; In normal circumstances, NMI will re-write T with the new proper Y-scroll 
+    ; value for start of screen. Or the next iteration of this loop may overwrite
+    ; it as well.
+    ; But if our calls to VBL/LCD handlers disable NMI just at the wrong moment in
+    ; the vsync routine, and cause the scroll update in NMI to be skipped, 
+    ; this mitigation will leave T with a "reasonable" value of the old shadow 
+    ; bkg scroll register for Y at scanline 0.
+    sty PPUADDR
+    lda *_bkg_scroll_y
+    sta PPUSCROLL
+
+    nop
+    nop
+    lda *0x00
+
+    iny
+    cpy __lcd_isr_num_calls
+    bne 1$
+2$:
     rts
 
 ; Interrupt / RESET vector table

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -1,7 +1,10 @@
+        ;; Maximum number of times LCD ISR can be repeatedly called
+        .MAX_LCD_ISR_CALLS = 4
+
         ;; Transfer buffer (lower half of hardware stack)
         __vram_transfer_buffer = 0x100
         ;; Number of 8-cycles available each frame for transfer buffer
-        VRAM_DELAY_CYCLES_X8  = 172
+        VRAM_DELAY_CYCLES_X8  = 171
 
         ;;  Keypad
         .UP             = 0x08


### PR DESCRIPTION
* Refactor .delay_to_lcd_scanline to not use Y register. Remove outdated comments.
* Move .jmp_to_LCD_isr call to vsync routine, and have it copy shadow PPU register values to a buffer
* Add MAX_LCD_ISR_CALLS define to limit the deferred PPU register write buffer size
* Add .do_lcd_ppu_reg_writes for writing buffer aligned to hblank, and calls to .delay_to_lcd_scanline
* Make .do_lcd_ppu_reg_write restore Y-scroll for start-of-frame after every update, to mitigate glitches in lag frames
* Have LCD at scanline#0 be treated as a special-case, where VBL shadow values are replaced without adding to the buffer
* Re-introduce variable to skip NMI as __crt0_disableNMI, and set it in vsync during buffer building

Update text_scroller example:
* Fix NES-version of code to do multiple splits like the other platforms do
* Fill nametable with '*' to make splits more visible
* TODO: Find out why fill_bkg_rect isn't working on GB