### PR TITLE
NES: Fix bug with set_sprite_palette indexing. Sprite palettes are now indexed from 0..3 instead of 4..7

### DIFF
--- a/gbdk-lib/examples/cross-platform/metasprites/src/metasprites.c
+++ b/gbdk-lib/examples/cross-platform/metasprites/src/metasprites.c
@@ -167,10 +167,10 @@ void main(void) {
     set_sprite_palette(OAMF_CGB_PAL2, 1, cyan_pal);
     set_sprite_palette(OAMF_CGB_PAL3, 1, green_pal);
 #elif defined(NINTENDO_NES)
-    set_sprite_palette(4, 1, gray_pal);
-    set_sprite_palette(5, 1, pink_pal);
-    set_sprite_palette(6, 1, cyan_pal);
-    set_sprite_palette(7, 1, green_pal);
+    set_sprite_palette(0, 1, gray_pal);
+    set_sprite_palette(1, 1, pink_pal);
+    set_sprite_palette(2, 1, cyan_pal);
+    set_sprite_palette(3, 1, green_pal);
 #endif
 
     // Fill the screen background with a single tile pattern

--- a/gbdk-lib/examples/cross-platform/platformer_template/src/player.c
+++ b/gbdk-lib/examples/cross-platform/platformer_template/src/player.c
@@ -33,13 +33,7 @@ uint8_t threeFrameCounter=0;
 uint16_t playerX, playerY;
 int16_t playerXVelocity, playerYVelocity;
 
-    // Flip horizontally, if we aren't facing right
-
-#if defined(NINTENDO_NES)
-    const uint8_t baseProp=4;
-#else
-    const uint8_t baseProp=0;
-#endif
+const uint8_t baseProp=0;
 
 #if defined(SEGA)
     #define PLAYER_PALETTES_BANK CURRENT_BANK

--- a/gbdk-lib/libc/targets/mos6502/nes/nes_palettes.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/nes_palettes.s
@@ -34,8 +34,8 @@ _set_sprite_palette::
     pla
     asl
     asl
-    tax
     adc #16
+    tax
     ; jmp .set_palette_impl
 
 .set_palette_impl:


### PR DESCRIPTION
* Move misplaced "adc #16" instruction in nes_palettes.s
* Update metasprites and platformer_template examples to use the new 0..3 indexing