### PR TITLE
build: fix asm lib errors not halting build

### DIFF
--- a/gbdk-lib/libc/Makefile
+++ b/gbdk-lib/libc/Makefile
@@ -29,10 +29,10 @@ all: ports platforms
 clean: port-clean ports-clean platform-clean
 
 ports:
-	for i in $(PORTS); do make port THIS=$$i PORT=$$i; done
+	for i in $(PORTS); do make port THIS=$$i PORT=$$i || exit 1; done
 
 platforms:
-	for j in $(PORTS); do for i in $(PLATFORMS); do if [ -d "targets/$$j/$$i" ]; then make -C targets/$$j/$$i platform THIS=$$i; fi done done
+	for j in $(PORTS); do for i in $(PLATFORMS); do if [ -d "targets/$$j/$$i" ]; then make -C targets/$$j/$$i platform THIS=$$i || exit 1; fi done done
 
 # Make all the std libs
 # Make all the port specific libs


### PR DESCRIPTION
- C errors to halt the build. sdcc returns error code 1 when failing on a syntax error, but sdas* returns error code 2 for syntax errors (even though that error code seems to be meant for incorrect arguments instead)
- So translate error codes to 1 in all cases in order to ensure the loop exits and halts the build