### PR TITLE
NES: Fix bug with fake LCD ISR occurring at scanline 0 causing next LCD ISR to be 1 line up

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -422,7 +422,7 @@ _vsync::
     lda *__lcd_scanline
     bne 0$
     jsr .jmp_to_LCD_isr
-    lda #0
+    lda #0xFF
     sta *.lcd_scanline_previous
 0$:
     ; disable NMI, as we are saving and restoring shadow registers that it may use


### PR DESCRIPTION
NES: Fix bug with fake LCD ISR occurring at scanline 0 causing next LCD ISR to be 1 line up
* Make sure that *.lcd_scanline_previous is initialize as -1 for the special case of scanline 0