### PR TITLE
text_scroller example: Fix problem with '*' fill characters not appearing on GG/SMS

### DIFF
--- a/gbdk-lib/examples/cross-platform/scroller/src/text_scroller.c
+++ b/gbdk-lib/examples/cross-platform/scroller/src/text_scroller.c
@@ -1,4 +1,5 @@
 #include <gbdk/platform.h>
+#include <gbdk/font.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -64,10 +65,13 @@ uint8_t * base, * limit;
 
 void main(void) {
     DISPLAY_OFF;
+    // Init font system / clear screen
+    font_init();
+    font_set(font_load(font_ibm));
     // Fill the screen background with '*'
     fill_bkg_rect(0, 0, DEVICE_SCREEN_WIDTH, DEVICE_SCREEN_HEIGHT, '*' - ' ');
-    SHOW_BKG; SHOW_SPRITES;
-    
+    DISPLAY_ON;
+
     printf(" Scrolling %d chars", sizeof(scroller_text) - 1);
 
     CRITICAL {


### PR DESCRIPTION
* Make fill_bkg_rect to happen *after* an explicit initialization of font system (otherwise the printf causes a font load which in turn causes a screen clear)