### PR TITLE
Mention that HIDE_BKG/SHOW_BKG don't work on CGB

### DIFF
--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -893,8 +893,8 @@ void hiramcpy(uint8_t dst, const void *src, uint8_t n) OLDCALL PRESERVES_REGS(b,
 
     Doesn't work in CGB mode - the bit is reused to control sprite priority
     over background and window layers instead.
-    If 1 @ref (SHOW_BKG), everything works as usual.
-    If 0 @ref (HIDE_BKG), all sprites are always drawn over background and window,
+    If 1 (SHOW_BKG), everything works as usual.
+    If 0 (HIDE_BKG), all sprites are always drawn over background and window,
     ignoring any other priority settings.
 */
 #define SHOW_BKG \
@@ -905,9 +905,9 @@ void hiramcpy(uint8_t dst, const void *src, uint8_t n) OLDCALL PRESERVES_REGS(b,
 
     Doesn't work in CGB mode - the bit is reused to control sprite priority
     over background and window layers instead.
-    If 1 @ref (SHOW_BKG), everything works as usual.
-    If 0 @ref (HIDE_BKG), all sprites are always drawn over background and window,
-    ignoring any other priority settings.
+    If 1 (SHOW_BKG), everything works as usual.
+    If 0 (HIDE_BKG), all sprites are always drawn over background and window,
+    ignoring any  other priority settings.
 */
 #define HIDE_BKG \
   LCDC_REG&=~LCDCF_BGON

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -890,12 +890,24 @@ void hiramcpy(uint8_t dst, const void *src, uint8_t n) OLDCALL PRESERVES_REGS(b,
 
 /** Turns on the background layer.
     Sets bit 0 of the LCDC register to 1.
+
+    Doesn't work in CGB mode - the bit is reused to control sprite priority
+    over background and window layers instead.
+    If 1 @ref (SHOW_BKG), everything works as usual.
+    If 0 @ref (HIDE_BKG), all sprites are always drawn over background and window,
+    ignoring any other priority settings.
 */
 #define SHOW_BKG \
   LCDC_REG|=LCDCF_BGON
 
 /** Turns off the background layer.
     Sets bit 0 of the LCDC register to 0.
+
+    Doesn't work in CGB mode - the bit is reused to control sprite priority
+    over background and window layers instead.
+    If 1 @ref (SHOW_BKG), everything works as usual.
+    If 0 @ref (HIDE_BKG), all sprites are always drawn over background and window,
+    ignoring any other priority settings.
 */
 #define HIDE_BKG \
   LCDC_REG&=~LCDCF_BGON

--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -893,8 +893,8 @@ void hiramcpy(uint8_t dst, const void *src, uint8_t n) OLDCALL PRESERVES_REGS(b,
 
     Doesn't work in CGB mode - the bit is reused to control sprite priority
     over background and window layers instead.
-    If 1 (SHOW_BKG), everything works as usual.
-    If 0 (HIDE_BKG), all sprites are always drawn over background and window,
+    \li If 1 (SHOW_BKG), everything works as usual.
+    \li If 0 (HIDE_BKG), all sprites are always drawn over background and window,
     ignoring any other priority settings.
 */
 #define SHOW_BKG \
@@ -905,9 +905,9 @@ void hiramcpy(uint8_t dst, const void *src, uint8_t n) OLDCALL PRESERVES_REGS(b,
 
     Doesn't work in CGB mode - the bit is reused to control sprite priority
     over background and window layers instead.
-    If 1 (SHOW_BKG), everything works as usual.
-    If 0 (HIDE_BKG), all sprites are always drawn over background and window,
-    ignoring any  other priority settings.
+    \li If 1 (SHOW_BKG), everything works as usual.
+    \li If 0 (HIDE_BKG), all sprites are always drawn over background and window,
+    ignoring any other priority settings.
 */
 #define HIDE_BKG \
   LCDC_REG&=~LCDCF_BGON


### PR DESCRIPTION
Adds a mention to the docs that HIDE_BKG and SHOW_BKG do not work while running in CGB mode, the relevant bit instead overrides all background/window priority over the sprite layer, see Pandocs 4.4