### PR TITLE
NES: Fix problem with deferred LCD isr special-case at scanline 0 not working unless _lcd_scanline was changed by LCD handler

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -442,10 +442,10 @@ _vsync::
 1$:
     pla
     sta *.lcd_scanline_previous
+2$:
     ; We are done if next scanline is <= the previous one
     cmp *__lcd_scanline
     bcs _wait_vbl_done_waitForNextFrame
-2$:
     ;
     ldy __lcd_isr_num_calls
     lda *__lcd_scanline


### PR DESCRIPTION
* Move label jumped to upwards, so if-less-than-reached-scanline check still happens for special-case