### PR TITLE
Palette Generation broken when using -source_tileset option

### DIFF
--- a/gbdk-support/png2asset/export_c_file.cpp
+++ b/gbdk-support/png2asset/export_c_file.cpp
@@ -113,9 +113,10 @@ static void export_c_palette_data(PNG2AssetData* assetData, FILE* file) {
 
     if (!(assetData->args->use_structs) || (assetData->args->includeTileData)) {
         fprintf(file, "const palette_color_t %s_palettes[%d] = {\n", assetData->args->data_name.c_str(), (unsigned int)exportOpt.color_count);
-        for(size_t i = exportOpt.color_start / assetData->image.colors_per_pal; i < assetData->image.total_color_count / assetData->image.colors_per_pal; ++i)
+        const size_t i0 = exportOpt.color_start / assetData->image.colors_per_pal;
+        for(size_t i = i0; i < assetData->image.total_color_count / assetData->image.colors_per_pal; ++i)
         {
-            if(i != 0)
+            if(i > i0)
                 fprintf(file, ",\n");
             fprintf(file, "\t");
 

--- a/gbdk-support/png2asset/export_c_file.cpp
+++ b/gbdk-support/png2asset/export_c_file.cpp
@@ -113,10 +113,11 @@ static void export_c_palette_data(PNG2AssetData* assetData, FILE* file) {
 
     if (!(assetData->args->use_structs) || (assetData->args->includeTileData)) {
         fprintf(file, "const palette_color_t %s_palettes[%d] = {\n", assetData->args->data_name.c_str(), (unsigned int)exportOpt.color_count);
-        const size_t i0 = exportOpt.color_start / assetData->image.colors_per_pal;
-        for(size_t i = i0; i < assetData->image.total_color_count / assetData->image.colors_per_pal; ++i)
+        const size_t palette_start = exportOpt.color_start / assetData->image.colors_per_pal;
+        const size_t total_palette_count = assetData->image.total_color_count / assetData->image.colors_per_pal;
+        for(size_t i = palette_start; i < total_palette_count; ++i)
         {
-            if(i > i0)
+            if(i > palette_start)
                 fprintf(file, ",\n");
             fprintf(file, "\t");
 


### PR DESCRIPTION
If the source tileset includes duplicate palette information, the exporter will exclude the redundant palettes. However, the exporter was checking if i != 0 to check for the first time through the loop, and this is not true in the case of the source_tileset excluding redundant palettes. This was generating a leading comma in the output, which causes a syntax error.