### PR TITLE
Examples: Fix some warning messages

### DIFF
--- a/gbdk-lib/examples/cross-platform/platformer_template/src/common.c
+++ b/gbdk-lib/examples/cross-platform/platformer_template/src/common.c
@@ -27,13 +27,13 @@ void setBKGPalettes(uint8_t count, const palette_color_t *palettes) NONBANKED{
         //__WRITE_VDP_REG(VDP_R2, R2_MAP_0x3800);
         //__WRITE_VDP_REG(VDP_R5, R5_SAT_0x3F00);
         set_bkg_palette(0, count, palettes);
-    #elif defined(GAMEBOY)
+    #elif defined(NINTENDO) // With NINTENDO meaning GAMEBOY, ANALOGUEPOCKET, MEGADUCK
         if (_cpu == CGB_TYPE) {
             set_bkg_palette(OAMF_CGB_PAL0, count, palettes);
         }
     #elif defined(NINTENDO_NES)
         set_bkg_palette(0, count, palettes);
-    #endif 
+    #endif
 }
 
 

--- a/gbdk-lib/examples/cross-platform/rle_map/Makefile
+++ b/gbdk-lib/examples/cross-platform/rle_map/Makefile
@@ -15,14 +15,17 @@ LCC = $(GBDK_HOME)bin/lcc
 TARGETS=gb gg sms nes
 
 # Configure platform specific LCC flags here:
-LCCFLAGS_gb      = -Wl-yt0x19 -Wl-yo4 -Wm-yS -Wm-yn"$(PROJECTNAME)"
-LCCFLAGS_pocket  = -Wl-yt0x19 -Wl-yo4 -Wm-yS -Wm-yn"$(PROJECTNAME)"
-LCCFLAGS_duck    = -Wl-yt0x19 -Wl-yo4 -Wm-yS -Wm-yn"$(PROJECTNAME)"
-LCCFLAGS_sms     = -Wl-yo4 -Wm-yS
-LCCFLAGS_gg      = -Wl-yo4 -Wm-yS
+LCCFLAGS_gb      = -Wl-yt0x19 -Wl-yo4 -Wm-yn"$(PROJECTNAME)"
+LCCFLAGS_pocket  = -Wl-yt0x19 -Wl-yo4 -Wm-yn"$(PROJECTNAME)"
+LCCFLAGS_duck    = -Wl-yt0x19 -Wl-yo4 -Wm-yn"$(PROJECTNAME)"
+LCCFLAGS_sms     = -Wl-yo4
+LCCFLAGS_gg      = -Wl-yo4
 LCCFLAGS_nes     = 
 
 LCCFLAGS += $(LCCFLAGS_$(EXT)) # This adds the current platform specific LCC Flags
+
+# .noi symbol file output
+LCCFLAGS += -Wl-j -Wm-yS
 
 # LCCFLAGS += -Wl-j -Wm-yoA -Wm-ya4 -autobank -Wb-ext=.rel -Wb-v # MBC + Autobanking related flags
 

--- a/gbdk-lib/examples/gb/apa_image/Makefile
+++ b/gbdk-lib/examples/gb/apa_image/Makefile
@@ -59,7 +59,7 @@ compile.bat: Makefile
 # -c ...                  : Set C output file
 # Convert metasprite .pngs in res/ -> .c files in obj/<platform ext>/src/
 $(RESOBJSRC)/%.c:	$(RESDIR)/%.png
-	$(PNG2ASSET) $< -keep_duplicate_tiles -map -bpp2 -tiles_only -c $@
+	$(PNG2ASSET) $< -keep_duplicate_tiles -map -bpp 2 -tiles_only -c $@
 
 # Compile the pngs that were converted to .c files
 # .c files in obj/res/ -> .o files in obj/

--- a/gbdk-lib/examples/gb/galaxy/galaxy.c
+++ b/gbdk-lib/examples/gb/galaxy/galaxy.c
@@ -353,12 +353,12 @@ const unsigned char * const film[] = {
 
 #define NBDFRAMES 0x18                  /* Nb frames for the door */
 #define NBSFRAMES 0x07                  /* Nb frames for the sprite */
-#define WINSZX    0x80                  /* Size of the picture in the window */
-#define WINSZY    0x50
-#define MINWINX   (MAXWNDPOSX-WINSZX+1) /* Bounds of the window origin */
-#define MINWINY   (MAXWNDPOSY-WINSZY+1)
-#define MAXWINX   MAXWNDPOSX
-#define MAXWINY   MAXWNDPOSY
+#define WINSZX    0x80u                  /* Size of the picture in the window */
+#define WINSZY    0x50u
+#define MINWINX   ((uint8_t)MAXWNDPOSX-WINSZX + 1u) /* Bounds of the window origin */
+#define MINWINY   ((uint8_t)MAXWNDPOSY-WINSZY + 1u)
+#define MAXWINX   ((uint8_t)MAXWNDPOSX)
+#define MAXWINY   ((uint8_t)MAXWNDPOSY)
 #define FADESTEP  0x10                  /* Nb steps for the fading effect */
 #define STARTFADE (0x06*FADESTEP)       /* Initial value for the fading effect */
 
@@ -556,12 +556,12 @@ void main(void)
    * Height = 0x30 = 0x20 * 6
    */
   set_win_tiles(2, 2, 12, 6, door1_tiles);
-  wposx.b.h = MAXWNDPOSX;
+  wposx.b.h = MAXWINX;
   wposx.b.l = 0;
-  WX_REG = MAXWNDPOSX;
-  wposy.b.h = MAXWNDPOSY;
+  WX_REG = MAXWINX;
+  wposy.b.h = MAXWINY;
   wposy.b.l = 0;
-  WY_REG = MAXWNDPOSY;
+  WY_REG = MAXWINY;
   wspx.w = 0xFF80;
   wspy.w = 0xFFC0;
 
@@ -592,41 +592,41 @@ void main(void)
     i = joypad();
     if(i & J_B) {
       if(i & J_UP)
-	bspy.w -= 0x0010;
+    bspy.w -= 0x0010;
       if(i & J_DOWN)
-	bspy.w += 0x0010;
+    bspy.w += 0x0010;
       if(i & J_LEFT)
-	bspx.w -= 0x0010;
+    bspx.w -= 0x0010;
       if(i & J_RIGHT)
-	bspx.w += 0x0010;
+    bspx.w += 0x0010;
     } else if(i & J_A) {
       if(i & J_UP)
-	wspy.w -= 0x0010;
+    wspy.w -= 0x0010;
       if(i & J_DOWN)
-	wspy.w += 0x0010;
+    wspy.w += 0x0010;
       if(i & J_LEFT)
-	wspx.w -= 0x0010;
+    wspx.w -= 0x0010;
       if(i & J_RIGHT)
-	wspx.w += 0x0010;
+    wspx.w += 0x0010;
     } else {
       if(i & J_SELECT)
-	color = STARTFADE;
+    color = STARTFADE;
       if(i & J_START)
-	if(doorstate == CLOSED) {
-	  doorstate = OPENING;
-	  doorpos = 0;
-	} else if(doorstate == OPENED) {
-	  doorstate = CLOSING;
-	  doorpos = NBDFRAMES;
-	}
+    if(doorstate == CLOSED) {
+      doorstate = OPENING;
+      doorpos = 0;
+    } else if(doorstate == OPENED) {
+      doorstate = CLOSING;
+      doorpos = NBDFRAMES;
+    }
       if(i & J_UP)
-	sspy.w -= 0x0010;
+    sspy.w -= 0x0010;
       if(i & J_DOWN)
-	sspy.w += 0x0010;
+    sspy.w += 0x0010;
       if(i & J_LEFT)
-	sspx.w -= 0x0010;
+    sspx.w -= 0x0010;
       if(i & J_RIGHT)
-	sspx.w += 0x0010;
+    sspx.w += 0x0010;
     }
   }
 }

--- a/gbdk-lib/examples/gb/gbprinter/Makefile
+++ b/gbdk-lib/examples/gb/gbprinter/Makefile
@@ -59,7 +59,7 @@ compile.bat: Makefile
 # -c ...                  : Set C output file
 # Convert metasprite .pngs in res/ -> .c files in obj/<platform ext>/src/
 $(RESOBJSRC)/%.c:	$(RESDIR)/%.png
-	$(PNG2ASSET) $< -keep_duplicate_tiles -map -bpp2 -c $@
+	$(PNG2ASSET) $< -keep_duplicate_tiles -map -bpp 2 -c $@
 
 # Compile the pngs that were converted to .c files
 # .c files in obj/res/ -> .o files in obj/


### PR DESCRIPTION
- Some incorrect flags and combos of flags

- cross_platform/rle_map: error: can't open build/sms/rledecompress.noi: No such file or directory
- cross_platform/platformer_template: in function setBKGPalettes unreferenced function argument : 'count',  'palettes'
- gb/galaxy: overflow in implicit constant conversion
- gb/apa_image and gb/gbprinter: Argument "-bpp2" not recognized