### PR TITLE
lcc: Remove obsolete options from help, warn if found

### DIFF
--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -292,7 +292,7 @@ int option(char *arg) {
 			setTokenVal("port", words[0]);
 			setTokenVal("plat", words[1]);
 			if (!setClass(words[0], words[1])) {
-				fprintf(stderr, "Error: %s: unrecognised PORT:PLATFORM from %s:%s\n", progname, words[0], words[1]);
+				fprintf(stderr, "Error: %s: unrecognized PORT:PLATFORM from %s:%s\n", progname, words[0], words[1]);
 				exit(-1);
 			}
 		} else {

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -773,10 +773,6 @@ static void help(void) {
 "    unrecognized options are taken to be linker options\n",
 "-A             warn about nonANSI usage; 2nd -A warns more\n",
 "-b             emit expression-level profiling code; see bprint(1)\n",
-#ifdef sparc
-"-Bstatic       specify static libraries\n",
-"-Bdynamic      specify dynamic libraries\n",
-#endif
 "-Bdir/         use the compiler named `dir/rcc'\n",
 "-c             compile only\n",
 "-dn            set switch statement density to `n'\n",
@@ -1022,11 +1018,6 @@ static void opt(char *arg) {
 			return;
 		}
 	case 'B':	/* -Bdir -Bstatic -Bdynamic */
-#ifdef sparc
-		if (strcmp(arg, "-Bstatic") == 0 || strcmp(arg, "-Bdynamic") == 0)
-			llist[L_FILES] = append(arg, llist[L_FILES]);
-		else
-#endif
 		{
 			static char *path;
 			if (path)


### PR DESCRIPTION
The obsolete options are not supported by the current compiler