### PR TITLE
romusage: upgrade from 1.2.8 to 1.3.0

### DIFF
--- a/gbdk-support/romusage/src/bank_templates.c
+++ b/gbdk-support/romusage/src/bank_templates.c
@@ -37,25 +37,25 @@
 // ===== Game Boy =====
 
 // ROM
-const bank_item ROM_0 =          {"ROM_0",   0x0000, 0x3FFF, BANKED_NO,  0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_0, BANK_MERGED_NO};
-const bank_item ROM_X_banked =   {"ROM_",    0x4000, 0x7FFF, BANKED_YES, 0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_1, BANK_MERGED_NO};
+const bank_item ROM_0 =          {"ROM_0",   0x0000, 0x3FFF, BANKED_NO,  0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_0, BANK_MERGED_NO, HIDDEN_NO};
+const bank_item ROM_X_banked =   {"ROM_",    0x4000, 0x7FFF, BANKED_YES, 0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_1, BANK_MERGED_NO, HIDDEN_NO};
 // Merged version
-const bank_item ROM_nonbanked =  {"ROM",     0x0000, 0x7FFF, BANKED_YES, 0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_0, BANK_MERGED_YES};
+const bank_item ROM_nonbanked =  {"ROM",     0x0000, 0x7FFF, BANKED_YES, 0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_0, BANK_MERGED_YES, HIDDEN_NO};
 
 // VRAM
-const bank_item VRAM =           {"VRAM_",   0x8000, 0x9FFF, BANKED_YES, 0x9FFF, 0,0,0, BANK_MEM_TYPE_VRAM, BANK_STARTNUM_0, BANK_MERGED_NO};
+const bank_item VRAM =           {"VRAM_",   0x8000, 0x9FFF, BANKED_YES, 0x9FFF, 0,0,0, BANK_MEM_TYPE_VRAM, BANK_STARTNUM_0, BANK_MERGED_NO, HIDDEN_NO};
 
 // SRAM
-const bank_item SRAM =           {"SRAM_",   0xA000, 0xBFFF, BANKED_YES, 0xBFFF, 0,0,0, BANK_MEM_TYPE_SRAM, BANK_STARTNUM_0, BANK_MERGED_NO};
+const bank_item SRAM =           {"SRAM_",   0xA000, 0xBFFF, BANKED_YES, 0xBFFF, 0,0,0, BANK_MEM_TYPE_SRAM, BANK_STARTNUM_0, BANK_MERGED_NO, HIDDEN_NO};
 
 // WRAM
-const bank_item WRAM_0 =         {"WRAM_LO", 0xC000, 0xCFFF, BANKED_NO,  0xDFFF, 0,0,0, BANK_MEM_TYPE_WRAM, BANK_STARTNUM_0, BANK_MERGED_NO};
-const bank_item WRAM_X_banked =  {"WRAM_HI_",0xD000, 0xDFFF, BANKED_YES, 0xDFFF, 0,0,0, BANK_MEM_TYPE_WRAM, BANK_STARTNUM_1, BANK_MERGED_NO};
+const bank_item WRAM_0 =         {"WRAM_LO", 0xC000, 0xCFFF, BANKED_NO,  0xDFFF, 0,0,0, BANK_MEM_TYPE_WRAM, BANK_STARTNUM_0, BANK_MERGED_NO, HIDDEN_NO};
+const bank_item WRAM_X_banked =  {"WRAM_HI_",0xD000, 0xDFFF, BANKED_YES, 0xDFFF, 0,0,0, BANK_MEM_TYPE_WRAM, BANK_STARTNUM_1, BANK_MERGED_NO, HIDDEN_NO};
 // Merged version
-const bank_item WRAM_nonbanked = {"WRAM",    0xC000, 0xDFFF, BANKED_YES, 0xDFFF, 0,0,0, BANK_MEM_TYPE_WRAM, BANK_STARTNUM_0, BANK_MERGED_YES};
+const bank_item WRAM_nonbanked = {"WRAM",    0xC000, 0xDFFF, BANKED_YES, 0xDFFF, 0,0,0, BANK_MEM_TYPE_WRAM, BANK_STARTNUM_0, BANK_MERGED_YES, HIDDEN_NO};
 
 // HRAM
-const bank_item HRAM =           {"HRAM",    0xFF80, 0xFFFE, BANKED_NO,  0xFFFE, 0,0,0, BANK_MEM_TYPE_HRAM, BANK_STARTNUM_0, BANK_MERGED_NO};
+const bank_item HRAM =           {"HRAM",    0xFF80, 0xFFFE, BANKED_NO,  0xFFFE, 0,0,0, BANK_MEM_TYPE_HRAM, BANK_STARTNUM_0, BANK_MERGED_NO, HIDDEN_NO};
 
 
 // ===== Game Gear =====
@@ -66,15 +66,15 @@ const bank_item HRAM =           {"HRAM",    0xFF80, 0xFFFE, BANKED_NO,  0xFFFE,
 // _LIT_<N> is at base address 0x8000 (assets)
 // _DATA_N is also at base address 0x8000 (RAM)
 
-const bank_item smsgg_ROM_0 =          {"ROM_0",   0x0000, 0x3FFF, BANKED_NO,  0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_0, BANK_MERGED_NO};
-const bank_item smsgg_ROM_X_banked =   {"ROM_",    0x4000, 0x7FFF, BANKED_YES, 0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_1, BANK_MERGED_NO};
+const bank_item smsgg_ROM_0 =          {"ROM_0",   0x0000, 0x3FFF, BANKED_NO,  0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_0, BANK_MERGED_NO, HIDDEN_NO};
+const bank_item smsgg_ROM_X_banked =   {"ROM_",    0x4000, 0x7FFF, BANKED_YES, 0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_1, BANK_MERGED_NO, HIDDEN_NO};
 // Merged version
-const bank_item smsgg_ROM_nonbanked =  {"ROM",     0x0000, 0x7FFF, BANKED_YES, 0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_0, BANK_MERGED_YES};
+const bank_item smsgg_ROM_nonbanked =  {"ROM",     0x0000, 0x7FFF, BANKED_YES, 0x7FFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_0, BANK_MERGED_YES, HIDDEN_NO};
 
-const bank_item smsgg_LIT_X_banked =   {"LIT_",    0x8000, 0xBFFF, BANKED_YES, 0xBFFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_1, BANK_MERGED_NO};
+const bank_item smsgg_LIT_X_banked =   {"LIT_",    0x8000, 0xBFFF, BANKED_YES, 0xBFFF, 0,0,0, BANK_MEM_TYPE_ROM,  BANK_STARTNUM_1, BANK_MERGED_NO, HIDDEN_NO};
 // Data can also be in the 0x8000 region.. requires some special handling in banks_check()
-const bank_item smsgg_DATA_X_banked =  {"DATA_",   0x8000, 0xBFFF, BANKED_YES, 0xBFFF, 0,0,0, BANK_MEM_TYPE_SRAM,  BANK_STARTNUM_1, BANK_MERGED_NO};
-const bank_item smsgg_RAM_nonbanked =  {"RAM",     0xC000, 0xDFFF, BANKED_YES, 0xDFFF, 0,0,0, BANK_MEM_TYPE_WRAM, BANK_STARTNUM_0, BANK_MERGED_YES};
+const bank_item smsgg_DATA_X_banked =  {"DATA_",   0x8000, 0xBFFF, BANKED_YES, 0xBFFF, 0,0,0, BANK_MEM_TYPE_SRAM,  BANK_STARTNUM_1, BANK_MERGED_NO, HIDDEN_NO};
+const bank_item smsgg_RAM_nonbanked =  {"RAM",     0xC000, 0xDFFF, BANKED_YES, 0xDFFF, 0,0,0, BANK_MEM_TYPE_WRAM, BANK_STARTNUM_0, BANK_MERGED_YES, HIDDEN_NO};
 
 
 static int bank_template_add(int idx, bank_item * p_bank_templates, const bank_item  * p_bank) {

--- a/gbdk-support/romusage/src/banks.c
+++ b/gbdk-support/romusage/src/banks.c
@@ -657,6 +657,16 @@ static void bank_fill_area_gaps_with_unknown(void) {
 }
 
 
+// Check if a bank name matches any substrings on the hide list
+static bool bank_name_check_hidden(char * str_bank_name) {
+
+    for (int c = 0; c < banks_hide_count; c++) {
+        if (strstr(str_bank_name, banks_hide_list[c])) return true;
+    }
+    return false;
+}
+
+
 // Print banks to output
 void banklist_finalize_and_show(void) {
 
@@ -672,6 +682,7 @@ void banklist_finalize_and_show(void) {
     for (c = 0; c < bank_list.count; c++) {
         // Sort areas in bank and calculate usage
         banks[c].size_used = bank_areas_calc_used(&banks[c], banks[c].start, banks[c].end);
+        banks[c].hidden = bank_name_check_hidden(banks[c].name);
 
         if (get_option_area_sort() == OPT_AREA_SORT_SIZE_DESC)
             qsort (banks[c].area_list.p_array, banks[c].area_list.count, sizeof(area_item), area_item_compare_size_desc);
@@ -725,7 +736,7 @@ void bank_areas_split_to_buckets(bank_item * p_bank, uint32_t range_start, uint3
     bank_item bank_copy = *p_bank;
     bank_copy.area_list.p_array = (void *)malloc(bank_copy.area_list.size * bank_copy.area_list.typesize);
     if (!bank_copy.area_list.p_array) {
-        log_error("ERROR: Failed to reallocate memory for list!\n");
+        log_error("Error: Failed to reallocate memory for list!\n");
         exit(EXIT_FAILURE);
     }
     // Copy main list of areas to copy of bank for modification

--- a/gbdk-support/romusage/src/banks.h
+++ b/gbdk-support/romusage/src/banks.h
@@ -39,6 +39,9 @@
 #define BANK_MERGED_NO     false
 #define BANK_MERGED_YES    true
 
+#define HIDDEN_NO          false
+#define HIDDEN_YES         true
+
 #define MINIGRAPH_SIZE (2 * 14) // Number of characters wide (inside edge brackets)
 #define LARGEGRAPH_BYTES_PER_CHAR 16
 
@@ -79,6 +82,7 @@ typedef struct bank_item {
     int      base_bank_num;
     bool     is_merged_bank;
     // End of templating vars
+    bool     hidden;
 
     // TODO: track overflow bytes and report them in graph
     list_type area_list;

--- a/gbdk-support/romusage/src/banks_print.c
+++ b/gbdk-support/romusage/src/banks_print.c
@@ -254,12 +254,15 @@ void banklist_printall(list_type * p_bank_list) {
     // Print all banks
     for (c = 0; c < p_bank_list->count; c++) {
 
-        bank_print_info(&banks[c]);
-        fprintf(stdout,"\n");
+        if (!banks[c].hidden) {
+            bank_print_info(&banks[c]);
+            fprintf(stdout,"\n");
 
-        if (get_option_area_sort() != OPT_AREA_SORT_HIDE) // This is a hack-workaround, TODO:fixme
-            if (banks_display_areas)
-                bank_print_area(&banks[c]);
+            if (get_option_area_sort() != OPT_AREA_SORT_HIDE) { // This is a hack-workaround, TODO:fixme
+                if (banks_display_areas)
+                    bank_print_area(&banks[c]);
+            }
+        }
 
     } // End: Print all banks loop
 
@@ -333,10 +336,12 @@ void banklist_printall_json(list_type * p_bank_list) {
 
     // Print each bank as an array object item
     for (c = 0; c < p_bank_list->count; c++) {
-        // Comma separator between array items
-        if (c > 0) fprintf(stdout,"    ,\n");
+        if (!banks[c].hidden) {
+            // Comma separator between array items
+            if (c > 0) fprintf(stdout,"    ,\n");
 
-        bank_print_info_json(&banks[c]);
+            bank_print_info_json(&banks[c]);
+        }
     }
 
     // JSON array footer

--- a/gbdk-support/romusage/src/cdb_file.c
+++ b/gbdk-support/romusage/src/cdb_file.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 
 #include "common.h"
+#include "logging.h"
 #include "list.h"
 #include "banks.h"
 #include "cdb_file.h"
@@ -288,7 +289,10 @@ int cdb_file_process_symbols(char * filename_in) {
         cdb_symbollist_add_all_to_banks();
 
     } // end: if valid file
-    else return (false);
+    else {
+        log_error("Error: Failed to open input file %s\n", filename_in);
+        return false;
+    }
 
    return true;
 }

--- a/gbdk-support/romusage/src/common.h
+++ b/gbdk-support/romusage/src/common.h
@@ -38,6 +38,9 @@
 #define OPT_PLAT_GAMEBOY     0u
 #define OPT_PLAT_SMS_GG_GBDK 1u  // GBDK specific layout of sms/gg
 
+#define BANKS_HIDE_SZ 30  // How many hide substrings to support
+#define BANKS_HIDE_MAX (BANKS_HIDE_SZ - 1)
+
 
 extern bool banks_display_areas;
 extern bool banks_display_headers;
@@ -64,6 +67,9 @@ extern unsigned int option_merged_banks;
 extern uint32_t option_area_hide_size;
 extern bool exit_error;
 
+extern int  banks_hide_count;
+extern char banks_hide_list[BANKS_HIDE_SZ][DEFAULT_STR_LEN];
+
 
 void set_option_all_areas_exclusive(bool value);
 void set_option_quiet_mode(bool value);
@@ -81,9 +87,11 @@ void set_option_show_compact(bool value);
 void set_option_show_json(bool value);
 void set_option_summarized(bool value);
 
-bool option_set_displayed_bank_range(char * arg_str);
+bool set_option_displayed_bank_range(char * arg_str);
 
 void set_option_merged_banks(unsigned int value);
+bool set_option_banks_hide_add(char * str_bank_hide_substring);
+bool set_option_binary_rom_empty_values(char * arg_str);
 
 int  get_option_input_source(void);
 int  get_option_area_sort(void);
@@ -98,5 +106,6 @@ uint32_t round_up_power_of_2(uint32_t val);
 
 uint32_t min(uint32_t a, uint32_t b);
 uint32_t max(uint32_t a, uint32_t b);
+
 
 #endif // _COMMON_H

--- a/gbdk-support/romusage/src/ihx_file.c
+++ b/gbdk-support/romusage/src/ihx_file.c
@@ -229,7 +229,6 @@ void area_convert_and_add(area_item area) {
 
 int ihx_file_process_areas(char * filename_in) {
 
-    int  ret = true;  // default to success
     char cols;
     char strline_in[MAX_STR_LEN] = "";
     FILE * ihx_file = fopen(filename_in, "r");
@@ -301,9 +300,11 @@ int ihx_file_process_areas(char * filename_in) {
         fclose(ihx_file);
 
     } // end: if valid file
-    else
-        ret = false;
+    else {
+        log_error("Error: Failed to open input file %s\n", filename_in);
+        return false;
+    }
 
-    return ret;
+    return true;
 }
 

--- a/gbdk-support/romusage/src/list.c
+++ b/gbdk-support/romusage/src/list.c
@@ -21,7 +21,7 @@ void list_init(list_type * p_list, size_t array_typesize) {
     p_list->p_array = (void *)malloc(p_list->size * p_list->typesize);
 
     if (!p_list->p_array) {
-        log_error("ERROR: Failed to allocate memory for list!\n");
+        log_error("Error: Failed to allocate memory for list!\n");
         exit(EXIT_FAILURE);
     }
 }
@@ -54,7 +54,7 @@ void list_additem(list_type * p_list, void * p_newitem) {
         p_list->p_array = (void *)realloc(p_list->p_array, p_list->size * p_list->typesize);
         // If realloc failed, free original buffer before quitting
         if (!p_list->p_array) {
-            log_error("ERROR: Failed to reallocate memory for list!\n");
+            log_error("Error: Failed to reallocate memory for list!\n");
             if (tmp_list) {
                 free(tmp_list);
                 tmp_list = NULL;

--- a/gbdk-support/romusage/src/map_file.c
+++ b/gbdk-support/romusage/src/map_file.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 
 #include "common.h"
+#include "logging.h"
 #include "banks.h"
 #include "map_file.h"
 
@@ -141,7 +142,10 @@ int map_file_process_areas(char * filename_in) {
         fclose(map_file);
 
     } // end: if valid file
-    else return (false);
+    else {
+        log_error("Error: Failed to open input file %s\n", filename_in);
+        return false;
+    }
 
    return true;
 }

--- a/gbdk-support/romusage/src/noi_file.c
+++ b/gbdk-support/romusage/src/noi_file.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 
 #include "common.h"
+#include "logging.h"
 #include "list.h"
 #include "banks.h"
 #include "noi_file.h"
@@ -172,7 +173,10 @@ int noi_file_process_areas(char * filename_in) {
         noi_arealist_add_all_to_banks();
 
     } // end: if valid file
-    else return (false);
+    else {
+        log_error("Error: Failed to open input file %s\n", filename_in);
+        return false;
+    }
 
    return true;
 }

--- a/gbdk-support/romusage/src/rom_file.h
+++ b/gbdk-support/romusage/src/rom_file.h
@@ -3,3 +3,6 @@
 // bbbbbr 2020
 
 int rom_file_process(char * filename_in);
+void romfile_empty_value_table_clear(void);
+void romfile_empty_value_table_add_entry(uint8_t value);
+void romfile_init_defaults(void);

--- a/gbdk-support/romusage/src/romusage.c
+++ b/gbdk-support/romusage/src/romusage.c
@@ -19,10 +19,15 @@
 #include "cdb_file.h"
 #include "rom_file.h"
 
-#define VERSION "version 1.2.8"
+#define VERSION "version 1.3.0"
+
+enum {
+    HELP_FULL = 0,
+    HELP_BRIEF
+};
 
 void static display_cdb_warning(void);
-void static display_help(void);
+void static display_help(int mode);
 int handle_args(int argc, char * argv[]);
 static bool matches_extension(char *, char *);
 static void init(void);
@@ -42,7 +47,7 @@ static void display_cdb_warning() {
            "   ************************ NOTICE ************************ \n");
 }
 
-static void display_help(void) {
+static void display_help(int mode) {
     fprintf(stdout,
            "romusage input_file.[map|noi|ihx|cdb|.gb[c]|.pocket|.duck|.gg|.sms] [options]\n"
            VERSION", by bbbbbr\n"
@@ -60,6 +65,7 @@ static void display_help(void) {
            "\n"
            "-m  : Manually specify an Area -m:NAME:HEXADDR:HEXLENGTH\n"
            "-e  : Manually specify an Area that should not overlap -e:NAME:HEXADDR:HEXLENGTH\n"
+           "-b  : Set hex bytes treated as Empty in ROM files (.gb/etc) -b:HEXVAL[...] (default FF)\n"
            "-E  : All areas are exclusive (except HEADERs), warn for any overlaps\n"
            "-q  : Quiet, no output except warnings and errors\n"
            "-Q  : Suppress output of warnings and errors\n"
@@ -73,11 +79,15 @@ static void display_help(void) {
            "-smROM  : Show Merged ROM_0  and ROM_1  output (i.e. bare 32K ROM)\n"
            "-smWRAM : Show Merged WRAM_0 and WRAM_1 output (i.e DMG/MGB not CGB)\n"
            "          -sm* compatible with banked ROM_x or WRAM_x when used with -B\n"
-           "-sJ : Show JSON output. Some options not applicable. When used, -Q recommended\n"
-           "-nB : Hide warning banner (for .cdb output)\n"
-           "-nA : Hide areas (shown by default in .cdb output)\n"
-           "-z  : Hide areas smaller than SIZE -z:DECSIZE\n"
-           "\n"
+           "-sJ   : Show JSON output. Some options not applicable. When used, -Q recommended\n"
+           "-nB   : Hide warning banner (for .cdb output)\n"
+           "-nA   : Hide areas (shown by default in .cdb output)\n"
+           "-z    : Hide areas smaller than SIZE -z:DECSIZE\n"
+           "-nMEM : Hide banks matching case sensitive substring (ex hide all RAM: -nMEM:RAM)\n"
+           "\n");
+
+    if (mode == HELP_FULL) {
+        fprintf(stdout,
            "Use: Read a .map, .noi, .cdb or .ihx file to display area sizes\n"
            "Example 1: \"romusage build/MyProject.map\"\n"
            "Example 2: \"romusage build/MyProject.noi -a -e:STACK:DEFF:100 -e:SHADOW_OAM:C000:A0\"\n"
@@ -85,6 +95,7 @@ static void display_help(void) {
            "Example 4: \"romusage build/MyProject.map -q -R\"\n"
            "Example 5: \"romusage build/MyProject.noi -sR -sP:90:32:90:35:33:36\"\n"
            "Example 6: \"romusage build/MyProject.map -sRp -g -B -F:255:15 -smROM -smWRAM\"\n"
+           "Example 7: \"romusage build/MyProject.gb  -g -b:FF:00\"\n"
            "\n"
            "Notes:\n"
            "  * GBDK / RGBDS map file format detection is automatic.\n"
@@ -97,6 +108,7 @@ static void display_help(void) {
            "    so bank totals may be incorrect/missing.\n"
            "  * GB/GBC/ROM files are just guessing, no promises.\n"
            );
+    }
 }
 
 
@@ -114,19 +126,15 @@ int handle_args(int argc, char * argv[]) {
     int i;
 
     if( argc < 2 ) {
-        display_help();
+        display_help(HELP_FULL);
         return false;
     }
 
-    // Copy input filename (if not preceded with option dash)
-    if (argv[1][0] != '-')
-        snprintf(filename_in, sizeof(filename_in), "%s", argv[1]);
-
     // Start at first optional argument, argc is zero based
-    for (i = 1; i <= (argc -1); i++ ) {
+    for (i = 0; i <= (argc -1); i++ ) {
 
         if (strstr(argv[i], "-h") == argv[i]) {
-            display_help();
+            display_help(HELP_FULL);
             show_help_and_exit = true;
             return true;  // Don't parse further input when -h is used
         } else if (strstr(argv[i], "-a") == argv[i]) {
@@ -144,8 +152,8 @@ int handle_args(int argc, char * argv[]) {
             }
         } else if (strstr(argv[i], "-sP") == argv[i]) {
             if (!set_option_custom_bank_colors(argv[i])) {
-                fprintf(stdout,"malformed custom color palette: %s\n\n", argv[i]);
-                display_help();
+                log_error("Malformed -sP custom color palette: %s\n\n", argv[i]);
+                // display_help();
                 return false;
             }
         } else if (strstr(argv[i], "-sH") == argv[i]) {
@@ -178,9 +186,15 @@ int handle_args(int argc, char * argv[]) {
         } else if (strstr(argv[i], "-B") == argv[i]) {
             set_option_summarized(true);
         } else if (strstr(argv[i], "-F") == argv[i]) {
-            if (!option_set_displayed_bank_range(argv[i])) {
-                fprintf(stdout,"Malformed -F forced display max bank range\n\n");
-                display_help();
+            if (!set_option_displayed_bank_range(argv[i])) {
+                log_error("Malformed -F forced display max bank range\n\n");
+                // display_help();
+                return false;
+            }
+
+        } else if (strstr(argv[i], "-b") == argv[i]) {
+            if (!set_option_binary_rom_empty_values(argv[i] + strlen("-b"))) {
+                log_error("Malformed or no entries found -b set hex values treated as empty for ROM files: %s\n\n", argv[i]);
                 return false;
             }
 
@@ -199,19 +213,31 @@ int handle_args(int argc, char * argv[]) {
         } else if (strstr(argv[i], "-z:") == argv[i]) {
             set_option_area_hide_size( strtol(argv[i] + 3, NULL, 10));
 
+        } else if (strstr(argv[i], "-nMEM:") == argv[i]) {
+            if (!set_option_banks_hide_add(argv[i] + strlen("-nMEM:"))) {
+                log_error("Adding memory region to hide failed: %s\n\n", argv[i]);
+                // display_help();
+                return false;
+            }
+
         } else if ((strstr(argv[i], "-m") == argv[i]) ||
                    (strstr(argv[i], "-e") == argv[i])) {
             if (!area_manual_queue(argv[i])) {
-                fprintf(stdout,"Malformed manual area argument: %s\n\n", argv[i]);
-                display_help();
+                log_error("Malformed -m or -e manual area argument: %s\n\n", argv[i]);
+                // display_help();
                 return false;
             }
+
         } else if (argv[i][0] == '-') {
-            fprintf(stdout,"Unknown argument: %s\n\n", argv[i]);
-            display_help();
+            log_error("Error: Unknown argument: %s\n\n", argv[i]);
+            display_help(HELP_BRIEF);
             return false;
         }
 
+        // Copy input filename (if not preceded with option dash)
+        else if (argv[i][0] != '-') {
+            snprintf(filename_in, sizeof(filename_in), "%s", argv[i]);
+        }
     }
 
     return true;
@@ -235,6 +261,7 @@ static void init(void) {
     cdb_init();
     noi_init();
     banks_init();
+    romfile_init_defaults();
 }
 
 
@@ -305,13 +332,14 @@ int main( int argc, char *argv[] )  {
                     if (!get_option_hide_banners()) display_cdb_warning();
                     ret = EXIT_SUCCESS; // Exit with success
                 }
+            } else {
+                log_error("Error: Incompatible file extension\n");
             }
-
         }
     }
 
-    if (ret == EXIT_FAILURE)
-        printf("Problem with filename or unable to open file! %s\n", filename_in);
+    // if (ret == EXIT_FAILURE)
+    //     printf("Problem with filename or unable to open file! %s\n", filename_in);
 
     // Override exit code if was set during processing
     if (get_exit_error())


### PR DESCRIPTION
# Version 1.3.0
- `-b:HEXVAL:[...]` Set hex bytes treated as Empty in ROM files (.gb/etc) (default `FF`(255), ex use 255 AND 0: `-b:FF:00`
- Improve error messaging
- Allow filename at any location in option arguments

# Version 1.2.9
- `-nMEM` Hide memory regions with case sensitive substring (ex hide all RAM: `-nMEM:RAM`)