### PR TITLE
NES: Fix bugs with non-multiple-of-2 (/4) map width in set_bkg_submap_attributes

### DIFF
--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -765,7 +765,7 @@ void set_bkg_submap_attributes_nes16x16(uint8_t x, uint8_t y, uint8_t w, uint8_t
 */
 inline void set_bkg_submap_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint8_t *attributes, uint8_t map_w)
 {
-    set_bkg_submap_attributes_nes16x16(x >> 1, y >> 1, (w + 1) >> 1, (h + 1) >> 1, attributes, map_w >> 1);
+    set_bkg_submap_attributes_nes16x16(x >> 1, y >> 1, (w + 1) >> 1, (h + 1) >> 1, attributes, (map_w + 1) >> 1);
 }
 
 

--- a/gbdk-lib/libc/targets/mos6502/nes/set_tile_submap_attributes.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_tile_submap_attributes.s
@@ -101,6 +101,7 @@ _set_bkg_submap_attributes_nes16x16::
     sta *.src_tiles+1
     lda *.map_width
     lsr
+    adc #0 ; Fix problem with skewed offset when original tilemap is not a multiple-of-two
     sta *.map_width
     ldx *.ypos
     jsr __muluchar


### PR DESCRIPTION
* Add +1 before shift in inline function set_bkg_submap_attributes
* Add-with carry after right-shift of width in set_bkg_submap_attributes_nes16x16