### PR TITLE
NES: Add support for TIM handlers

### DIFF
--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -184,6 +184,11 @@ void remove_VBL(int_handler h) NO_OVERLAY_LOCALS;
 */
 void remove_LCD(int_handler h) NO_OVERLAY_LOCALS;
 
+/** Removes the TIM interrupt handler.
+    @see add_TIM(), remove_VBL()
+*/
+void remove_TIM(int_handler h) NO_OVERLAY_LOCALS;
+
 /** Adds a Vertical Blanking interrupt handler.
 
     @param h  The handler to be called whenever a V-blank
@@ -247,6 +252,21 @@ void add_VBL(int_handler h) NO_OVERLAY_LOCALS;
     @see add_VBL, nowait_int_handler, ISR_VECTOR()
 */
 void add_LCD(int_handler h) NO_OVERLAY_LOCALS;
+
+/** Adds a timer interrupt handler.
+
+    Can not be used together with @ref add_low_priority_TIM
+
+    This interrupt handler is invoked at the end of the NMI handler 
+    for gbdk-nes, after first processing the registers writes done 
+    by the VBL and and LCD handlers. 
+    It is therefore currently limited to 60Hz / 50Hz 
+    (depending on system).
+
+    @see add_VBL
+    @see set_interrupts() with TIM_IFLAG, ISR_VECTOR()
+*/
+void add_TIM(int_handler h) NO_OVERLAY_LOCALS;
 
 /** The maximum number of times the LCD handler will be called per frame.
  */

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -279,6 +279,9 @@ __crt0_NMI:
     jsr .do_lcd_ppu_reg_writes
 __crt0_NMI_skip:
 
+    ; Call the timer interrupt for non-graphics events
+    jsr .jmp_to_TIM_isr
+
     ; Update frame counter
     lda *_sys_time
     clc

--- a/gbdk-lib/libc/targets/mos6502/nes/lcd.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/lcd.s
@@ -6,10 +6,16 @@
 __lcd_scanline::    .ds 1
 
 .area   _DATA
+.jmp_to_xyz_isr::
+.jmp_to_TIM_isr::   .ds 3
 .jmp_to_VBL_isr::   .ds 3
 .jmp_to_LCD_isr::   .ds 3
 
 .area   _XINIT
+; .jmp_to_TIM_isr
+rts
+nop
+nop
 ; .jmp_to_VBL_isr
 rts
 nop
@@ -20,38 +26,45 @@ nop
 nop
 
 .area _CODE
-
-_add_VBL::
-.add_VBL::
+_add_TIM::
+.add_TIM::
     ldy #0
     beq .add_common
+_add_VBL::
+.add_VBL::
+    ldy #3
+    bne .add_common
 _add_LCD::
 .add_LCD::
-    ldy #3
+    ldy #6
 .add_common:
     ; Remove old handler
     jsr .remove_common
     ; Store new handler address
-    sta .jmp_to_VBL_isr+1,y
+    sta .jmp_to_xyz_isr+1,y
     txa
-    sta .jmp_to_VBL_isr+2,y
+    sta .jmp_to_xyz_isr+2,y
     ; Re-enable handler by replacing RTS with JMP instruction
     lda #0x4C
-    sta .jmp_to_VBL_isr,y
+    sta .jmp_to_xyz_isr,y
     rts
 
-_remove_VBL::
-.remove_VBL::
+_remove_TIM::
+.remove_TIM::
     ldy #0
     beq .remove_common
+_remove_VBL::
+.remove_VBL::
+    ldy #3
+    bne .remove_common
 _remove_LCD::
 .remove_LCD::
-    ldy #3
+    ldy #6
 .remove_common:
     pha
     ; Replace jump instruction with RTS instruction to disable handler
     lda #0x60
-    sta .jmp_to_VBL_isr,y
+    sta .jmp_to_xyz_isr,y
     pla
 .return_instruction:
     rts


### PR DESCRIPTION
- Add add_TIM / remove_TIM functions to nes.h

- Add implementation in lcd.s

- Add call to TIM function at end of NMI handler in crt0.s

- Update documentation to describe use-cases and limitations of TIM handler