### PR TITLE
NES: Timer interrupt emulation + support for set_interrupts(...)

### DIFF
--- a/docs/pages/06b_supported_consoles.md
+++ b/docs/pages/06b_supported_consoles.md
@@ -438,6 +438,10 @@ During direct mode, all graphics routines will write directly to the PPUADDR / P
 
 Direct mode is typically used for initializing large amounts of tile data at boot and/or level loading time. Unless you plan to have an animated loading screen and decompress a lot of data, it makes more sense to just fade the screen to black and allow direct mode to write data as fast as possible.
 
+Direct mode also affects how (fake) interrupt handlers are processed. As long as vsync() is called on each frame, the VBL and LCD handlers will still be executed in direct mode - but no graphics registers will be written.
+
+The TIM handler will still be executed as normal.
+
 #### Caveat: Make sure the transfer buffer is emptied before switching to direct mode
 
 Because the switch to direct mode is instant and doesn't wait for the next invocation of the vblank, it is possible to create situations where there is still remaining data in the transfer buffer that would only get written once the system is switched back to buffered mode.
@@ -506,6 +510,20 @@ If you are using LCD handlers to achieve a top-screen stationary status bar, it 
 * Use move_bkg in the second invocation of the LCD handler, to reset the background scrolling
 
 In short: Ensuring that the last called LCD handler sets the scroll back to the original value means the PPU rendering keeps rendering the background from the same scrolling position even when the NMI handling was missed.
+
+### Implementation of timer handler
+
+The nature of the deferred handling for fake VBL and LCD handlers in gbdk-nes means that lag frames will cause these handlers to be called at delayed irregular times.
+
+For graphics updates this is the behaviour you usually want. But for non-graphics tasks like music playback it will cause distracting stutter.
+
+The timer overflow handler (TIM) provides an alternative method that is guaranteed to be stutter-free. The TIM handler is always called if timer overflow occurs at the end of the NMI handler in both buffered and direct mode. 
+
+The TMA_REG hardware register is emulated via a RAM variable with the same name. TMA_REG is set to 0xFF at reset, corresponding to 60Hz for a Famicom / US NES, and 50Hz for a PAL NES / PAL Famiclone. Changing TMA_REG allows setting a slower frequency for this emulated timer overflow interrupt if your GB game uses the timer overflow hardware for regular events like music that are slower than 60Hz (50Hz for PAL).
+
+If you are porting a GB game to gbdk-nes where the music handler is called in the VBL or LCD handler then it is advisable to move this call to the timer handler, in order to achieve reliable music playback at 60Hz (50Hz for PAL).
+
+Keep in mind that you should NOT write any graphics registers in the TIM handler. This will likely not do what you want, and it may result in bad graphical glitches.
 
 ### Tile Data and Tile Map loading
 

--- a/gbdk-lib/examples/cross-platform/irq/Makefile
+++ b/gbdk-lib/examples/cross-platform/irq/Makefile
@@ -9,7 +9,7 @@ LCC = $(GBDK_HOME)bin/lcc
 # Set platforms to build here, spaced separated. (These are in the separate Makefile.targets)
 # They can also be built/cleaned individually: "make gg" and "make gg-clean"
 # Possible are: gb gbc pocket megaduck sms gg
-TARGETS=gb sms
+TARGETS=gb sms nes
 
 # Configure platform specific LCC flags here:
 LCCFLAGS_gb      = -Wl-yt0x1B # Set an MBC for banking (1B-ROM+MBC5+RAM+BATT)

--- a/gbdk-lib/examples/cross-platform/irq/src/irq.c
+++ b/gbdk-lib/examples/cross-platform/irq/src/irq.c
@@ -54,7 +54,7 @@ void main(void)
     TMA_REG = 0x00U;
     // Set clock to 4096 Hertz 
     TAC_REG = 0x04U;
-#elif defined(SEGA)
+#elif defined(SEGA) || defined(NINTENDO_NES)
     TMA_REG = 0xFCU;
 #endif
 
@@ -63,6 +63,9 @@ void main(void)
 
     for(;;) {
         print_counter();
-        delay(1000UL);
+        // Loop for 60 frames (1 second)
+        for(int i = 0; i < 60; i++) {
+            vsync();
+        }
     }
 }

--- a/gbdk-lib/examples/cross-platform/scroller/src/text_scroller.c
+++ b/gbdk-lib/examples/cross-platform/scroller/src/text_scroller.c
@@ -83,7 +83,7 @@ void main(void) {
 #if defined(SEGA)
     __WRITE_VDP_REG(VDP_R10, 0x07);
 #endif
-#if defined(NINTENDO) || defined(SEGA)
+#if defined(NINTENDO) || defined(NINTENDO_NES) || defined(SEGA)
     set_interrupts(VBL_IFLAG | LCD_IFLAG);
 #endif
     HIDE_LEFT_COLUMN;    

--- a/gbdk-lib/include/nes/hardware.h
+++ b/gbdk-lib/include/nes/hardware.h
@@ -56,4 +56,8 @@ __REG(0x4014) OAMDMA;
 __SHADOW_REG bkg_scroll_x;
 __SHADOW_REG bkg_scroll_y;
 
+extern volatile UBYTE TIMA_REG;
+extern volatile UBYTE TMA_REG;
+extern volatile UBYTE TAC_REG;
+
 #endif

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -132,6 +132,25 @@ void set_sprite_palette_entry(uint8_t palette, uint8_t entry, palette_color_t rg
 */
 #define S_PAL(n)     n
 
+/* Interrupt flags */
+/** Disable calling of interrupt service routines
+ */
+#define EMPTY_IFLAG  0x00U
+/** VBlank Interrupt occurs at the start of the vertical blank.
+
+    During this period the video ram may be freely accessed.
+    @see set_interrupts(), @see add_VBL
+ */
+#define VBL_IFLAG    0x01U
+/** LCD Interrupt when triggered by the STAT register.
+    @see set_interrupts(), @see add_LCD
+*/
+#define LCD_IFLAG    0x02U
+/** Timer Interrupt when the timer @ref TIMA_REG overflows.
+    @see set_interrupts(), @see add_TIM
+ */
+#define TIM_IFLAG    0x04U
+
 /* DMG Palettes */
 #define DMG_BLACK     0x03
 #define DMG_DARK_GRAY 0x02
@@ -183,6 +202,11 @@ void remove_VBL(int_handler h) NO_OVERLAY_LOCALS;
     @see add_LCD(), remove_VBL()
 */
 void remove_LCD(int_handler h) NO_OVERLAY_LOCALS;
+
+/** Removes the TIM interrupt handler.
+    @see add_TIM(), remove_VBL()
+*/
+void remove_TIM(int_handler h) NO_OVERLAY_LOCALS;
 
 /** Adds a Vertical Blanking interrupt handler.
 
@@ -247,6 +271,21 @@ void add_VBL(int_handler h) NO_OVERLAY_LOCALS;
     @see add_VBL, nowait_int_handler, ISR_VECTOR()
 */
 void add_LCD(int_handler h) NO_OVERLAY_LOCALS;
+
+/** Adds a timer interrupt handler.
+
+    Can not be used together with @ref add_low_priority_TIM
+
+    This interrupt handler is invoked at the end of the NMI handler 
+    for gbdk-nes, after first processing the registers writes done 
+    by the VBL and and LCD handlers. 
+    It is therefore currently limited to 60Hz / 50Hz 
+    (depending on system).
+
+    @see add_VBL
+    @see set_interrupts() with TIM_IFLAG, ISR_VECTOR()
+*/
+void add_TIM(int_handler h) NO_OVERLAY_LOCALS;
 
 /** The maximum number of times the LCD handler will be called per frame.
  */
@@ -466,6 +505,13 @@ inline void enable_interrupts(void) {
 inline void disable_interrupts(void) {
     __asm__("sei");
 }
+
+/** Sets the interrupt mask to flags.
+    @param flags	A logical OR of *_IFLAGS
+
+    @see VBL_IFLAG, LCD_IFLAG, TIM_IFLAG
+*/
+void set_interrupts(uint8_t flags) NO_OVERLAY_LOCALS;
 
 /** Performs a soft reset.
 

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -77,6 +77,11 @@
         ;
         JOY2            = 0x4017
 
+        ; Interrupt handler flags
+        .VBL_IFLAG      = 0x01
+        .LCD_IFLAG      = 0x02
+        .TIM_IFLAG      = 0x04
+
         ;; OAM related constants
 
         OAM_COUNT       = 64  ; number of OAM entries in OAM RAM

--- a/gbdk-lib/libc/targets/mos6502/nes/lcd.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/lcd.s
@@ -6,52 +6,102 @@
 __lcd_scanline::    .ds 1
 
 .area   _DATA
-.jmp_to_VBL_isr::   .ds 3
+.jmp_to_xyz_isr::
+.jmp_to_TIM_isr::   .ds 3
 .jmp_to_LCD_isr::   .ds 3
+.jmp_to_VBL_isr::   .ds 3
 
 .area   _XINIT
-; .jmp_to_VBL_isr
-rts
-nop
-nop
-; .jmp_to_LCD_isr
-rts
-nop
-nop
+; .jmp_to_TIM_isr - default to OFF
+.db 0x60
+.dw .rts_instruction
+; .jmp_to_LCD_isr - default to OFF
+.db 0x60
+.dw .rts_instruction
+; .jmp_to_VBL_isr - default to ON
+jmp .rts_instruction
 
 .area _CODE
-
-_add_VBL::
-.add_VBL::
+_add_TIM::
+.add_TIM::
     ldy #0
     beq .add_common
 _add_LCD::
 .add_LCD::
     ldy #3
+    bne .add_common
+_add_VBL::
+.add_VBL::
+    ldy #6
 .add_common:
+    pha
+    stx *.tmp
     ; Remove old handler
-    jsr .remove_common
+    jsr .irq_call_disable
     ; Store new handler address
-    sta .jmp_to_VBL_isr+1,y
-    txa
-    sta .jmp_to_VBL_isr+2,y
-    ; Re-enable handler by replacing RTS with JMP instruction
-    lda #0x4C
-    sta .jmp_to_VBL_isr,y
+    pla
+    sta .jmp_to_xyz_isr+1,y
+    lda *.tmp
+    sta .jmp_to_xyz_isr+2,y
+    jsr .irq_call_restore
+.rts_instruction:
     rts
 
-_remove_VBL::
-.remove_VBL::
+_remove_TIM::
+.remove_TIM::
     ldy #0
     beq .remove_common
 _remove_LCD::
 .remove_LCD::
     ldy #3
+    bne .remove_common
+_remove_VBL::
+.remove_VBL::
+    ldy #6
 .remove_common:
-    pha
-    ; Replace jump instruction with RTS instruction to disable handler
-    lda #0x60
-    sta .jmp_to_VBL_isr,y
-    pla
+    ; Replace handler address with dummy address pointing to RTS instruction
+    jsr .irq_call_disable
+    lda .rts_instruction
+    sta .jmp_to_xyz_isr+1,y
+    lda .rts_instruction+1
+    sta .jmp_to_xyz_isr+2,y
+    jsr .irq_call_restore
 .return_instruction:
+    rts
+
+.irq_call_disable:
+    ; Temporarily replace JMP instruction with RTS
+    ldx .jmp_to_xyz_isr,y
+    lda #0x60
+    sta .jmp_to_xyz_isr,y
+    rts
+
+.irq_call_restore:
+    ; Rewrite old instruction (unknown - could be JMP or RTS)
+    txa
+    sta .jmp_to_xyz_isr,y
+    rts
+
+_set_interrupts::
+    ; TIM isr
+    lsr
+    ldx #0x60
+    bcc 0$
+    ldx #0x4C
+0$:
+    stx .jmp_to_VBL_isr
+    ; LCD isr
+    lsr
+    ldx #0x60
+    bcc 1$
+    ldx #0x4C
+1$:
+    stx .jmp_to_LCD_isr
+    ; VBL isr
+    lsr
+    ldx #0x60
+    bcc 2$
+    ldx #0x4C
+2$:
+    stx .jmp_to_TIM_isr
     rts


### PR DESCRIPTION
- Add add_TIM / remove_TIM functions to nes.h

- Refactor implementation in lcd.s to support add_TIM / remove_TIM

- Add TMA_REG / TIMA_REG / TAC_REG vars to emulate GB hardware timer register

- Add call to TIM function at end of NMI handler in crt0.s, and make it use TMA_REG / TIMA_REG vars

- Add implementation for set_interrupts in lcd.s, replacing JMP instruction with RTS when disabled

- Enable NES target in examples/cross-platform/irq and replace delay(1000) call with 60 vsyncs

- Update examples/cross-platform/scroller and examples/cross-platform/irq to use set_interrupts

- Update documentation to describe use-cases and limitations of TIM handler