### PR TITLE
NES: Double-buffered deferred LCD ISR support

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -1,5 +1,7 @@
         ;; Maximum number of times LCD ISR can be repeatedly called
         .MAX_LCD_ISR_CALLS = 4
+        ;; Total number is +1 to support VBL ISR with the same logic
+        .MAX_DEFERRED_ISR_CALLS = (.MAX_LCD_ISR_CALLS+1)
 
         ;; Transfer buffer (lower half of hardware stack)
         __vram_transfer_buffer = 0x100


### PR DESCRIPTION
NES: Double-buffered deferred LCD ISR support for less graphics glitches, at expense of more RAM usage.

- Define new constant .MAX_DEFERRED_ISR_CALLS as .MAX_LCD_ISR_CALLS+1

- Refactor vsync function for double-buffering, and have it flip the read index at completion

- Refactor .do_lcd_ppu_reg_writes, and rename to .do_hblank_writes

- Remove scroll glitch mitigation in .do_hblank_writes, as no longer needed

- Redefine __lcd_isr_ arrays sizes as 2*.MAX_DEFERRED_ISR_CALLS

- remove redundant ZP variable __crt0_disableNMI, as no longer needed

- TAB -> space conversion