### PR TITLE
Adding support for layered metasprites

### DIFF
--- a/gbdk-support/png2asset/metasprites.cpp
+++ b/gbdk-support/png2asset/metasprites.cpp
@@ -18,6 +18,58 @@
 
 using namespace std;
 
+void ProcessMetaspriteTile(int _x, int _y, int x, int y, int* last_x, int* last_y, int _w, int _h, int pivot_x, int pivot_y, PNG2AssetData* assetData, int palleteIndex, MetaSprite& mt_sprite) {
+    Tile tile(assetData->image.tile_h * assetData->image.tile_w);
+
+    // For sprites, unlike maps, Tiles are only kept and processed if NOT Empty
+    // This default behavior can be overridden with -spr_no_optimize (which sets keep_empty_sprite_tiles and keep_duplicate_tiles to TRUE)
+    bool tile_not_empty = (assetData->image.ExtractTile(x, y, tile, assetData->args->sprite_mode, assetData->args->export_as_map, assetData->args->use_map_attributes, assetData->args->bpp, palleteIndex));
+    if(tile_not_empty || (assetData->args->keep_empty_sprite_tiles && palleteIndex == 0))
+    {
+        if(palleteIndex > 0) {
+
+            printf("adding  layer (%d) for tile at %d,%d\n", palleteIndex + 1, x, y);
+        }
+
+        size_t idx;
+        unsigned char props;
+        unsigned char pal_idx = tile.pal;
+
+        // When both -keep_duplicate_tiles and source tilesets are used then
+        // keep_duplicate_tiles should only apply to source tilesets, not the main image
+        if((assetData->args->keep_duplicate_tiles) && (assetData->args->has_source_tilesets == false)) {
+            assetData->tiles.push_back(tile);
+            idx = assetData->tiles.size() - 1;
+            props = assetData->args->props_default;
+        }
+        else
+        {
+            if(!FindTile(tile, idx, props, assetData->tiles, assetData))
+            {
+                if(assetData->args->has_source_tilesets) {
+                    printf("found a tile not in the source tileset at %d,%d\n", x, y);
+                    assetData->args->includeTileData = true;
+                }
+                assetData->tiles.push_back(tile);
+                idx = assetData->tiles.size() - 1;
+                props = assetData->args->props_default;
+            }
+        }
+
+        props |= pal_idx;
+
+        // Scale up index based on 8x8 tiles-per-hardware sprite
+        if(assetData->args->sprite_mode == SPR_8x16)
+            idx *= 2;
+        else if(assetData->args->sprite_mode == SPR_16x16_MSX)
+            idx *= 4;
+
+        mt_sprite.push_back(MTTile(x - *last_x, y - *last_y, (unsigned char)idx, props));
+        *last_x = x;
+        *last_y = y;
+    }
+}
+
 void GetMetaSprite(int _x, int _y, int _w, int _h, int pivot_x, int pivot_y, PNG2AssetData* assetData)
 {
     int last_x = _x + pivot_x;
@@ -29,48 +81,18 @@ void GetMetaSprite(int _x, int _y, int _w, int _h, int pivot_x, int pivot_y, PNG
     {
         for(int x = _x; x < _x + _w && x < (int)assetData->image.w; x += assetData->image.tile_w)
         {
-            Tile tile(assetData->image.tile_h * assetData->image.tile_w);
-            // For sprites, unlike maps, Tiles are only kept and processed if NOT Empty
-            // This default behavior can be overridden with -spr_no_optimize (which sets keep_empty_sprite_tiles and keep_duplicate_tiles to TRUE)
-            bool tile_not_empty = (assetData->image.ExtractTile(x, y, tile, assetData->args->sprite_mode, assetData->args->export_as_map, assetData->args->use_map_attributes, assetData->args->bpp));
-            if (tile_not_empty || (assetData->args->keep_empty_sprite_tiles))
-            {
-                size_t idx;
-                unsigned char props;
-                unsigned char pal_idx = assetData->image.data[y * assetData->image.w + x] >> assetData->args->bpp; //We can pick the palette from the first pixel of this tile
+            if(assetData->args->enable_layered_sprites) {
 
-                // When both -keep_duplicate_tiles and source tilesets are used then
-                // keep_duplicate_tiles should only apply to source tilesets, not the main image
-                if ((assetData->args->keep_duplicate_tiles) && (assetData->args->has_source_tilesets == false)) {
-                    assetData->tiles.push_back(tile);
-                    idx = assetData->tiles.size() - 1;
-                    props = assetData->args->props_default;
+
+                int paletteCount = (int)assetData->args->max_palettes;
+                for(int palleteIndex = 0; palleteIndex < paletteCount; palleteIndex++) {
+
+                    ProcessMetaspriteTile(_x, _y,x,y, &last_x, &last_y, _w, _h, pivot_x, pivot_y, assetData, palleteIndex, mt_sprite);
                 }
-                else
-                {
-                    if(!FindTile(tile, idx, props, assetData->tiles, assetData))
-                    {
-                        if (assetData->args->has_source_tilesets) {
-                            printf("found a tile not in the source tileset at %d,%d\n", x, y);
-                            assetData->args->includeTileData = true;
-                        }
-                        assetData->tiles.push_back(tile);
-                        idx = assetData->tiles.size() - 1;
-                        props = assetData->args->props_default;
-                    }
-                }
+            }
+            else {
 
-                props |= pal_idx;
-
-                // Scale up index based on 8x8 tiles-per-hardware sprite
-                if(assetData->args->sprite_mode == SPR_8x16)
-                    idx *= 2;
-                else if(assetData->args->sprite_mode == SPR_16x16_MSX)
-                    idx *= 4;
-
-                mt_sprite.push_back(MTTile(x - last_x, y - last_y, (unsigned char)idx, props));
-                last_x = x;
-                last_y = y;
+                ProcessMetaspriteTile(_x,_y,x, y, &last_x, &last_y, _w, _h, pivot_x, pivot_y, assetData, -1, mt_sprite);
             }
         }
     }

--- a/gbdk-support/png2asset/metasprites.cpp
+++ b/gbdk-support/png2asset/metasprites.cpp
@@ -33,7 +33,11 @@ void ProcessMetaspriteTile(int _x, int _y, int x, int y, int* last_x, int* last_
 
         size_t idx;
         unsigned char props;
-        unsigned char pal_idx = tile.pal;
+
+        // If a specific palette was specified, use it. 
+        // Otherwise, We can pick the palette from the first pixel of this tile
+        unsigned char pal_idx = palleteIndex!=-1 ?  palleteIndex  : assetData->image.data[y * assetData->image.w + x] >> assetData->args->bpp; 
+
 
         // When both -keep_duplicate_tiles and source tilesets are used then
         // keep_duplicate_tiles should only apply to source tilesets, not the main image

--- a/gbdk-support/png2asset/png2asset.cpp
+++ b/gbdk-support/png2asset/png2asset.cpp
@@ -94,6 +94,7 @@ int PNG2AssetData::Export() {
 
 bool FindTile(const Tile& t, size_t& idx, unsigned char& props, vector< Tile > & tileset, PNG2AssetData* assetData)
 {
+
     vector< Tile >::iterator it;
     it = find(tileset.begin(), tileset.end(), t);
     if(it != tileset.end())

--- a/gbdk-support/png2asset/process_arguments.cpp
+++ b/gbdk-support/png2asset/process_arguments.cpp
@@ -62,6 +62,7 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
     args->include_palettes = true;
     args->use_structs = false;
     args->flip_tiles = true;
+    args->enable_layered_sprites = false;
 
     // args->errorCode;
     args->bank = BANK_NUM_UNSET;
@@ -128,6 +129,7 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
         printf("-transposed         export transposed (column-by-column instead of row-by-row)\n");
 
         printf("-rel_paths          paths to tilesets are relative to the input file path\n");
+        printf("-layered-sprites    allows for automatically handling multi-palette tiles.\n");
         return EXIT_SUCCESS;
     }
 
@@ -325,7 +327,10 @@ int processPNG2AssetArguments(int argc, char* argv[], PNG2AssetArguments* args) 
         else if(!strcmp(argv[i], "-rel_paths")) {
             args->relative_paths = true;
         }
-        else {
+        else if(!strcmp(argv[i], "-layered-sprites")) {
+            args->enable_layered_sprites = true;
+            printf("Warning! Layered metasprites have been enabled. Some retro consoles have limits on how many 'sprites' they can draw on a single scanline.\n");
+        } else {
             printf("Warning: Argument \"%s\" not recognized\n", argv[i]);
         }
     }

--- a/gbdk-support/png2asset/process_arguments.h
+++ b/gbdk-support/png2asset/process_arguments.h
@@ -22,6 +22,8 @@ struct PNG2AssetArguments {
     Vector2Size map_attributes_size;
     Vector2Size map_attributes_packed_size;
 
+    bool enable_layered_sprites;
+
     Rectangle pivot;
 
     //default values for some params


### PR DESCRIPTION
Developers will be able to pass "-layered-sprites" when generating metasprites. This will allow multi-palette sprites to properly be converted and shown.

When enabled, the option should show a warning. So that developers are aware of the sprite/scanline limits.