### PR TITLE
NES: Align coordinates and scanline counting in LCD ISR implementation with GB, add SCX / SCY / LYC defines

### DIFF
--- a/docs/pages/09_migrating_new_versions.md
+++ b/docs/pages/09_migrating_new_versions.md
@@ -4,6 +4,12 @@ This section contains information that may be useful to know or important when u
 
 # GBDK-2020 versions
 
+## Porting to GBDK-2020 4.4.0
+
+  - NES LCD bkg_scroll_y is now relative to the current scanline
+    - This change creates higher compatibility with GB's SCY_REG and makes it easier to re-use GB LCD handlers.
+    - This behaves differently to 4.3.0 and affects LCD handlers that change the y scrolling coordinate mid-frame.
+
 ## Porting to GBDK-2020 4.3.0
   - GBDK now requires ~SDCC 4.4.0 or higher with GBDK-2020 patches for the z80 and NES
   - Changed to new calling convention for @ref printf(), @ref sprintf(), @ref abs()

--- a/gbdk-lib/include/nes/hardware.h
+++ b/gbdk-lib/include/nes/hardware.h
@@ -55,9 +55,21 @@ __REG(0x4014) OAMDMA;
 // Scrolling coordinates (will be written to PPUSCROLL at end-of-vblank by NMI handler)
 __SHADOW_REG bkg_scroll_x;
 __SHADOW_REG bkg_scroll_y;
+// LCD scanline - a software-driven version of GB's incrasing 'LY' scanline counter
+__SHADOW_REG _lcd_scanline;
 
 extern volatile UBYTE TIMA_REG;
 extern volatile UBYTE TMA_REG;
 extern volatile UBYTE TAC_REG;
+
+// Compatibility defines for GB LY / LYC registers, to allow easier LCD ISR porting
+#define SCY_REG bkg_scroll_y    /**< Scroll Y */
+#define rSCY SCY_REG
+#define SCX_REG bkg_scroll_x    /**< Scroll X */
+#define rSCX SCX_REG
+#define LY_REG _lcd_scanline    /**< LCDC Y-coordinate */
+#define rLY LY_REG
+#define LYC_REG _lcd_scanline   /**< LY compare */
+#define rLYC LYC_REG
 
 #endif

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -180,29 +180,34 @@ ProcessDrawList:
 ;
 .define .acc "___SDCC_m6502_ret4"
 .delay_to_lcd_scanline::
-    jsr .delay_12_cycles
     jmp 2$
 1$:
     jsr .delay_28_cycles
     jsr .delay_28_cycles
     jsr .delay_12_cycles ; -> 28 + 28 + 12 = 68 cycles
+    clc
 2$:
 
-    jsr .delay_fractional   ; -> 40.666 NTSC cycles  33.5625 PAL cycles
-  
+    jsr .delay_fractional   ; -> 35.666 NTSC cycles  28.5625 PAL cycles
+    lda *0x00
+
     dex
     bne 1$      ; -> 5 cycles
     rts
 
 .delay_28_cycles:
     jsr .delay_12_cycles
+.delay_16_cycles:
     nop
+.delay_14_cycles:
     nop
 .delay_12_cycles:
     rts
 
 ;
-; Takes 40.666 NTSC cycles / 33.5626 PAL cycles
+; Takes 35.666 NTSC cycles / 28.5626 PAL cycles
+;
+; Note: does NOT clear carry - this needs to be handled by caller
 ;
 .delay_fractional:
     lda #144 ; Initialize A with PAL fractional cycle count
@@ -215,12 +220,10 @@ ProcessDrawList:
     nop
 3$:             ; -> 15 NTSC cycles / 8 PAL cycles
     ; Add fractional cycles and branch on carry
-    clc
     adc *.acc
-    sta *.acc
     bcs 4$
 4$:
-    sta *.acc   ; -> 13.666 NTSC cycles / 13.5625 PAL cycles
+    sta *.acc   ; -> 8.666 NTSC cycles / 8.5625 PAL cycles
     rts         ; -> 6 cycles for RTS, 6 cycles for JSR = 12 cycles
 
 __crt0_NMI:
@@ -441,7 +444,6 @@ _vsync::
     .define .lcd_scanline_previous "REGTEMP"
     .define .lcd_buf_index "REGTEMP+1"
     .define .lcd_buf_end "REGTEMP+2"
-    .define .plus_one_flag "REGTEMP+3"
 
     jsr _flush_shadow_attributes
     
@@ -461,9 +463,6 @@ _vsync::
     ; Set initial scanline value
     lda #0xFF
     sta *.lcd_scanline_previous
-    ; Init +0/+1 bits for simulated Y-increment between calls
-    lda #0x7F
-    sta *.plus_one_flag
 
     lda *__hblank_writes_index
     clc
@@ -477,16 +476,9 @@ _vsync::
     adc #.MAX_DEFERRED_ISR_CALLS
     sta *.lcd_buf_end
 
-    ; Special-case: LCD at scanline 0 should just directly replace first entry
-    lda *__lcd_scanline
-    bne 0$
-    jsr .jmp_to_LCD_isr
-    lda #0xFF
-    sta *.lcd_scanline_previous
-0$:
-
-    ; Write shadow registers as first LCD entry (VBL and LCD at scanline 0 are equal)
+    ; Write shadow registers as first LCD buffer entry (actually VBL)
     ldy *.lcd_buf_index
+    ldx #.SCREENHEIGHT-1
     jsr .write_shadow_registers_to_buffer
     iny
     sty *.lcd_buf_index
@@ -522,13 +514,12 @@ _vsync::
     sec
     sbc *.lcd_scanline_previous
     sta __lcd_isr_delay_num_scanlines,y
-    ; Add number of delayed scanlines+1 to _bkg_scroll_y to simulate PPU increment
-    ; (but old _bkg_scroll_y needs to be treated as -1 in first simulated-PPU-increment)
-    asl *.plus_one_flag
-    adc *_bkg_scroll_y
-    sta *_bkg_scroll_y
     ; Call LCD isr
     jsr .jmp_to_LCD_isr
+    ; Grab previous LCD scanline value from stack and store in X
+    pla
+    tax
+    pha
     jsr .write_shadow_registers_to_buffer
        
     iny
@@ -574,6 +565,12 @@ _wait_vbl_done_waitForNextFrame_loop:
 
     rts
 
+;
+; Writes shadow registers to buffer
+;
+; Input:
+;  X: Scanline number
+;
 .write_shadow_registers_to_buffer:
     ; Copy shadow registers
     ldy *.lcd_buf_index
@@ -587,7 +584,17 @@ _wait_vbl_done_waitForNextFrame_loop:
     lsr
     lsr
     sta __lcd_isr_ppuaddr_lo,y
-    lda *_bkg_scroll_y
+    ; Add _bkg_scroll_y+1 to _lcd_scanline to generate final Y-scroll, with 239->0 wrap-around
+    txa
+    sec
+    adc *_bkg_scroll_y
+    bcc 1$
+    sbc #.SCREENHEIGHT
+1$:
+    cmp #.SCREENHEIGHT
+    bcc 2$
+    sbc #.SCREENHEIGHT
+2$:
     sta __lcd_isr_scroll_y,y
     and #0xF8
     asl
@@ -691,25 +698,38 @@ __crt0_RESET_bankSwitchValue:
 __crt0_waitForever:
     jmp __crt0_waitForever
 
+.bndry 0x100
 .do_hblank_writes:
     .define .reg_write_index    "__crt0_NMITEMP+1"
     .define .lda_PPUADDR        "__crt0_NMITEMP+2"
     .define .ldx_PPUMASK        "__crt0_NMITEMP+3"
     
-    jsr .delay_12_cycles
-    nop
-    
+    ; Delay to make hblank at end of scanline 0
+    ldx #10
+0$:
+    dex
+    bne 0$
+    clc
+
+    sty *.reg_write_index
+
     lda #0
     sta *.acc
 1$:
-    sty *.reg_write_index
     ldx __lcd_isr_delay_num_scanlines,y
     beq 2$      ; Exit if empty buffer (no calls were made within frame)
     dex
     beq 3$      ; Skip delay if next scanline
     jsr .delay_to_lcd_scanline
+    jsr .delay_12_cycles
+    jsr .delay_28_cycles
+    jsr .delay_12_cycles
+    lda *0x00
 3$:
-    ldy *.reg_write_index
+
+    ; Delay for 35.666 NTSC cycles / 28.5625 PAL cycles
+    jsr .delay_fractional
+
     ; Pre-write PPUADDR (1st write) and y-scroll
     sty PPUADDR
     lda __lcd_isr_scroll_y,y
@@ -741,17 +761,8 @@ __crt0_waitForever:
     stx PPUMASK
     sty PPUCTRL
 
-    ; Delay for 40.666 NTSC cycles / 33.5625 PAL cycles
-    jsr .delay_fractional
+    inc *.reg_write_index
     ldy *.reg_write_index
-    
-    ldx #6
-10$:
-    dex
-    bne 10$
-    nop
-
-    iny
     jmp 1$
 2$:
     rts

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -710,6 +710,7 @@ __crt0_waitForever:
     dex
     bne 0$
     clc
+    nop
 
     sty *.reg_write_index
 
@@ -717,13 +718,18 @@ __crt0_waitForever:
     sta *.acc
 1$:
     ldx __lcd_isr_delay_num_scanlines,y
+    cpx #1
+    beq 3$      ; Skip delay if next scanline
+    cpx #0
     beq 2$      ; Exit if empty buffer (no calls were made within frame)
     dex
-    beq 3$      ; Skip delay if next scanline
     jsr .delay_to_lcd_scanline
     jsr .delay_12_cycles
     jsr .delay_28_cycles
-    jsr .delay_12_cycles
+    nop
+    nop
+    nop
+    nop
     lda *0x00
 3$:
 


### PR DESCRIPTION
- Change definition of _lcd_scanline to be -1 less than current, aligning with GB LYC register

- Change definition of _bkg_scroll_y to match GB's SCY, being relative to current scanline

- Refactor do_hblank_writes, delay_fractional and delay_to_scanline subroutines in crt0

- Add "#define LYC_REG" and "#define LY_REG" as aliases of _lcd_scanline

- Add #defines for SCX and SCY to alias _bkg_scroll_x / _bkg_scroll_y shadow variables

- Change text scroller example to use LYC_REG / SCX / SCY instead of _lcd_scanline / move_bkg, remove redundant #ifdefs

- Add subtle shake in y direction to text scroller example, to check that GB / NES coordinates match