### PR TITLE
NES: Fix problem with screen being blank before first vsync() call

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -714,6 +714,9 @@ __crt0_RESET_bankSwitchValue:
     lda #(PPUCTRL_NMI | PPUCTRL_SPR_CHR)
     sta *_shadow_PPUCTRL
     sta PPUCTRL
+    ; Prepare VBL buffer data (need to start at scanline -1 = SCREENHEIGHT-1 for correct Y scroll)
+    ldx #.SCREENHEIGHT-1
+    jsr .write_shadow_registers_to_buffer
     ; Call main
     jsr _main
     ; main finished - loop forever


### PR DESCRIPTION
NES: Fix problem with screen being blank before first vsync() call

- Call .write_shadow_registers_to_buffer at reset, to initialize VBL buffer