### PR TITLE
NES: Refactor display_on / display_off and deferred isr code

### DIFF
--- a/docs/pages/06b_supported_consoles.md
+++ b/docs/pages/06b_supported_consoles.md
@@ -442,12 +442,6 @@ Direct mode also affects how (fake) interrupt handlers are processed. As long as
 
 The TIM handler will still be executed as normal.
 
-#### Caveat: Make sure the transfer buffer is emptied before switching to direct mode
-
-Because the switch to direct mode is instant and doesn't wait for the next invocation of the vblank, it is possible to create situations where there is still remaining data in the transfer buffer that would only get written once the system is switched back to buffered mode.
-
-To avoid this situation, make sure to always "drain" the buffer by doing a call to vsync when you expect your code to finish.
-
 #### Caveat: Only update the PPU palette during buffered mode
 
 The oddity that PPU palette values are accessed through the same mechanism as other PPU memory bytes comes with the side effect that the vblank NMI handler will only write the palette values in buffered mode.

--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -20,7 +20,7 @@ ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	delay.s \
 	rle_decompress.s \
 	far_ptr.s sdcc_bcall.s mapper.s \
-	lcd.s \
+	lcd.s deferred_isr.s \
 	crt0.s
 
 CRT0 =	crt0.s

--- a/gbdk-lib/libc/targets/mos6502/nes/deferred_isr.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/deferred_isr.s
@@ -1,0 +1,183 @@
+    .include    "global.s"
+
+    .area   _HOME
+
+    .define .lcd_scanline_previous "REGTEMP"
+    .define .lcd_buf_index "REGTEMP+1"
+    .define .lcd_buf_end "REGTEMP+2"
+
+;
+; Writes shadow registers to buffer
+;
+; Input:
+;  X: Scanline number
+;
+.write_shadow_registers_to_buffer::
+    ; Copy shadow registers
+    ldy *.lcd_buf_index
+    lda *_shadow_PPUMASK
+    sta __lcd_isr_PPUMASK,y
+    lda *_shadow_PPUCTRL
+    sta __lcd_isr_PPUCTRL,y
+    lda *_bkg_scroll_x
+    sta __lcd_isr_scroll_x,y
+    lsr
+    lsr
+    lsr
+    sta __lcd_isr_ppuaddr_lo,y
+    ; Add _bkg_scroll_y+1 to _lcd_scanline to generate final Y-scroll, with 239->0 wrap-around
+    txa
+    sec
+    adc *_bkg_scroll_y
+    bcc 1$
+    sbc #.SCREENHEIGHT
+1$:
+    cmp #.SCREENHEIGHT
+    bcc 2$
+    sbc #.SCREENHEIGHT
+2$:
+    sta __lcd_isr_scroll_y,y
+    and #0xF8
+    asl
+    asl
+    ora __lcd_isr_ppuaddr_lo,y
+    sta __lcd_isr_ppuaddr_lo,y
+    rts
+
+;
+; Resets the deferred ISR.
+;
+; This effectively omits the double-buffering delay and writes the shadow registers to the first buffer.
+; It is intended to be used when display is re-enabled after being turned off, to display with reasonable values.
+;
+; Note that in contrast to .run_deferred_isr_handlers, this will NOT actually run VBL / LCD handlers, so
+; can still cause glitches.
+;
+.deferred_isr_reset::
+    ; Prepare VBL buffer data (need to start at scanline -1 = SCREENHEIGHT-1 for correct Y scroll)
+    lda #0
+    sta *__hblank_writes_index
+    sta *.lcd_buf_index
+    sta __lcd_isr_delay_num_scanlines+1
+    ldx #.SCREENHEIGHT-1
+    jmp .write_shadow_registers_to_buffer
+
+;
+; Resets the deferred ISR, then runs VBL and LCD handlers twice to initialize buffers with valid data.
+;
+.deferred_isr_reset_and_init::
+    jsr .deferred_isr_reset
+    jsr .deferred_isr_run
+    jmp .deferred_isr_run
+
+;
+; Executes the deferred VBL/LCD handlers.
+;
+; After each ISR handler has run, PPU shadow registers are written to a buffer 
+; which is consumed by the vblank NMI handler.
+; Double-buffering is used to avoid buffer locking / race conditions.
+;
+.deferred_isr_run::
+    ; Save shadow registers that VBL or LCD isr could change
+    lda *_shadow_PPUMASK
+    pha
+    lda *_shadow_PPUCTRL
+    pha
+    lda *_bkg_scroll_x
+    pha
+    lda *_bkg_scroll_y
+    pha
+    
+    ; Allow VBL isr to modify shadow registers if present
+    jsr .jmp_to_VBL_isr
+
+    ; Set initial scanline value
+    lda #0xFF
+    sta *.lcd_scanline_previous
+
+    lda *__hblank_writes_index
+    clc
+    adc #.MAX_DEFERRED_ISR_CALLS
+    cmp #(2*.MAX_DEFERRED_ISR_CALLS)
+    bcc 20$
+    lda #0
+20$:
+    sta *.lcd_buf_index
+    clc
+    adc #.MAX_DEFERRED_ISR_CALLS
+    sta *.lcd_buf_end
+
+    ; Write shadow registers as first LCD buffer entry (actually VBL)
+    ldy *.lcd_buf_index
+    ldx #.SCREENHEIGHT-1
+    jsr .write_shadow_registers_to_buffer
+    iny
+    sty *.lcd_buf_index
+
+    ; Ensure second entry (actual LCD) starts off with zero (end-of-list)
+    lda #0
+    sta __lcd_isr_delay_num_scanlines,y
+    ; Skip to end if LCD isr functionality is disabled (0x60 = RTS means LCD isr disabled)
+    lda .jmp_to_LCD_isr
+    cmp #0x60
+    beq .deferred_isr_run_done
+
+    lda *.lcd_scanline_previous
+
+    jmp 2$
+1$:
+    pla
+    sta *.lcd_scanline_previous
+2$:
+    ; We are done if next scanline is <= the previous one
+    cmp #0xFF
+    beq 3$
+    cmp *__lcd_scanline
+    bcs .deferred_isr_run_done
+3$:
+    ;
+    ldy *.lcd_buf_index
+    lda *__lcd_scanline
+    ; We are done if next LCD scanline >= SCREENHEIGHT
+    cmp #.SCREENHEIGHT
+    bcs .deferred_isr_run_done
+    pha
+    sec
+    sbc *.lcd_scanline_previous
+    sta __lcd_isr_delay_num_scanlines,y
+    ; Call LCD isr
+    jsr .jmp_to_LCD_isr
+    ; Grab previous LCD scanline value from stack and store in X
+    pla
+    tax
+    pha
+    jsr .write_shadow_registers_to_buffer
+       
+    iny
+    sty *.lcd_buf_index
+    cpy *.lcd_buf_end
+    bne 1$
+    
+    ; Clear last-scanline-value from stack
+    pla
+
+.deferred_isr_run_done:
+    ; Flip __hblank_writes_index for NMI handler
+    ldy #0
+    lda *__hblank_writes_index
+    bne 21$
+    ldy #.MAX_DEFERRED_ISR_CALLS
+21$:
+    sty *__hblank_writes_index
+
+    ; Restore shadow registers
+    pla
+    sta *_bkg_scroll_y
+    pla
+    sta *_bkg_scroll_x
+    pla
+    sta *_shadow_PPUCTRL
+    pla
+    sta *_shadow_PPUMASK
+
+    rts

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -141,6 +141,9 @@
 
         ;; Symbols defined at link time
         .globl _shadow_OAM, __vram_transfer_buffer
+        .globl __lcd_isr_PPUCTRL, __lcd_isr_PPUMASK
+        .globl __lcd_isr_scroll_x, __lcd_isr_scroll_y, __lcd_isr_ppuaddr_lo
+        .globl __lcd_isr_delay_num_scanlines
 
         ;; Main user routine
         .globl  _main


### PR DESCRIPTION
- Move code for deferred isr buffer building to separate function .deferred_isr_run in file deferred_isr.s

- Introduce function .deferred_isr_reset to write shadow regs as first (VBL) buffer entry

- Add new subroutine .deferred_isr_reset_and_init that runs .deferred_isr_reset and .deferred_isr_run twice

- Drain buffer when DISPLAY_OFF is called, by making sure a single NMI execution happens before screen is turned off in vblank

- Change DISPLAY_OFF to write only DISPLAY_OFF flag and PPUMASK, but leave shadow_PPU_MASK unchanged

- Call .deferred_isr_reset_and_init in DISPLAY_ON when display changes from off to on

- Make DISPLAY_ON run run VBL / LCD handlers to reinitialize buffers when display switches from off to on

- Change early-out in NMI handler to rely on DISPLAY_OFF flag instead of shadow_PPUMASK

- Remove mentioned of manual-draining caveat in docs, as it no longer applies

- Add minor size/speed optimization of frame counter increment in NMI, to prevent branch penalties / incorrect system detection