### PR TITLE
NES: Improve TIMER interrupt emulation

### DIFF
--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -33,6 +33,9 @@ extern const uint8_t _SYSTEM;
 #define SYSTEM_60HZ    0x00
 #define SYSTEM_50HZ    0x01
 
+#define TIMER_VBLANK_PARITY_MODE_SYSTEM_60HZ    0x78
+#define TIMER_VBLANK_PARITY_MODE_SYSTEM_50HZ    0x5D
+
 #define RGB(r,g,b)        RGB_TO_NES(((r) | ((g) << 2) | ((b) << 4)))
 #define RGB8(r,g,b)       RGB_TO_NES((((r) >> 6) | (((g) >> 6) << 2) | (((b) >> 6) << 4)))
 #define RGBHTML(RGB24bit) RGB_TO_NES((((RGB24bit) >> 22) | ((((RGB24bit) & 0xFFFF) >> 14) << 2) | ((((RGB24bit) & 0xFF) >> 6) << 4)))

--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -20,7 +20,7 @@ ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	delay.s \
 	rle_decompress.s \
 	far_ptr.s sdcc_bcall.s mapper.s \
-	lcd.s deferred_isr.s \
+	lcd.s deferred_isr.s timer_isr.s \
 	crt0.s
 
 CRT0 =	crt0.s

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -113,6 +113,10 @@
         ;; Table of routines for modes
         .MODE_TABLE     = 0xFFE0
 
+        ;; Values for vblank parity mode when using timer emulation
+        .TIMER_VBLANK_PARITY_MODE_SYSTEM_60HZ = 0x78
+        .TIMER_VBLANK_PARITY_MODE_SYSTEM_50HZ = 0x5D
+
         ;; C related
         ;; Overheap of a banked call.  Used for parameters
         ;;  = ret + real ret + bank

--- a/gbdk-lib/libc/targets/mos6502/nes/timer_isr.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/timer_isr.s
@@ -1,0 +1,116 @@
+;
+; Emulation of GB's timer interrupt (TIM) via calls from NES's 60Hz / 50Hz vblank NMI
+;
+; Timer values are based on GBC running in double-speed mode
+;
+
+.include    "global.s"
+
+.area _DATA
+_TIMA_REG::                             .ds 2
+_TMA_REG::                              .ds 1
+_TAC_REG::                              .ds 1
+
+.area _XINIT
+.db 0x00
+.db 0x00
+.db .TIMER_VBLANK_PARITY_MODE_SYSTEM_60HZ
+.db 0x04
+
+.area   _HOME
+
+; Lookup tables for adjusted rates based on GB TAC register
+.TAC_lookup_lo:
+; PAL
+.db <163        ;    8192 / 50 =   163.84     ~=   164
+.db <10486      ;  524288 / 50 = 10485.76     ~= 10486
+.db <2621       ;  131072 / 50 =  2621.44     ~=  2621
+.db <655        ;   32768 / 50 =   655.36     ~=   655
+; NTSC
+.db <136        ;    8192 / 60 =  136.5333... ~=   136
+.db <8738       ;  524288 / 60 = 8738.1333... ~=  8378
+.db <2184       ;  131072 / 60 = 2184.5333... ~=  2184
+.db <546        ;   32768 / 60 =  546.1333... ~=   546
+;
+.TAC_lookup_hi:
+; PAL
+.db >163        ;    8192 / 50 =   163.84     ~=   164
+.db >10486      ;  524288 / 50 = 10485.76     ~= 10486 
+.db >2621       ;  131072 / 50 =  2621.44     ~=  2621 
+.db >655        ;   32768 / 50 =   655.36     ~=   655
+; NTSC
+.db >136        ;    8192 / 60 =  136.5333... ~=   136
+.db >8738       ;  524288 / 60 = 8738.1333... ~=  8378
+.db >2184       ;  131072 / 60 = 2184.5333... ~=  2184
+.db >546        ;   32768 / 60 =  546.1333... ~=   546
+
+;
+; Call timer interrupt repeatedly to emulate desired GB playback rate via vblank NMI.
+;
+.tim_emulation::
+    lda _TAC_REG
+    and #7
+    ; Early-out if timer enabled bit not set
+    cmp #4
+    bcs 1$
+    rts
+1$:
+    and #3
+    bit *__SYSTEM
+    bmi .tim_emulation_dendy
+    bvs .tim_emulation_pal
+    ; +4 to index NTSC table
+    ora #0x04
+.tim_emulation_dendy:
+.tim_emulation_pal:
+    pha     ; Save TAC lookup index to stack
+.tim_emulation_loop:
+    ; Finished when TIMA_REG <= 0
+    bit _TIMA_REG+1
+    bmi .tim_emulation_calls_done
+    lda _TIMA_REG
+    beq .tim_emulation_calls_done
+    ; Skip if handler disabled (check for RTS)
+    lda .jmp_to_TIM_isr
+    cmp #0x60
+    beq .tim_emulation_isr_disabled
+    ; Save REGTEMP to stack
+    ldx #17
+4$:
+    lda *ALL_REGTEMPS_BEGIN,x
+    pha
+    dex
+    bpl 4$
+    ; Call handler
+    jsr .jmp_to_TIM_isr
+    ; Restore REGTEMP from stack
+    ldx #0
+5$:
+    pla
+    sta *ALL_REGTEMPS_BEGIN,x
+    inx
+    cpx #18
+    bne 5$
+.tim_emulation_isr_disabled:
+    ; TIMA_REG += TMA_REG
+    lda _TIMA_REG
+    clc
+    adc _TMA_REG
+    sta _TIMA_REG
+    lda _TIMA_REG+1
+    adc #0xFF
+    sta _TIMA_REG+1
+    jmp .tim_emulation_loop
+;
+.tim_emulation_calls_done:
+    pla     ; Restore TAC lookup index from stack
+    tay
+    ; TIMA_REG += initial value
+    lda _TIMA_REG
+    clc
+    adc .TAC_lookup_lo,y
+    sta _TIMA_REG
+    lda _TIMA_REG+1
+    adc .TAC_lookup_hi,y
+    sta _TIMA_REG+1
+    rts


### PR DESCRIPTION
- Move TIM ISR emulation to dedicated function .tim_emulation and dedicated file timer_isr.s

- Make TIM ISR emulation save entirety of ALL_REGTEMPS_BEGIN to ALL_REGTEMPS_END

- Improve emulation to allow average TIM rate to be faster compared to vblank rate

- Add support for consistent average TIM rate on PAL, for a less system-dependent timer

- Add support for different base dividers defined by GB-like TAC_REG variable

- Add defines values for "vblank parity mode" to global.s and nes.h

- Update crt0 init code to set TMA_REG to vblank parity mode correctly for PAL/Dendy

- Update documentation, describing the improved GB TIM emulation and vblank parity mode

- Update cross-platform IRQ example to better showcase the emulation