### PR TITLE
lcc: fix sometimes incorrect detection of postproc step

### DIFF
--- a/.github/workflows/gbdk_build_examples.yml
+++ b/.github/workflows/gbdk_build_examples.yml
@@ -120,6 +120,7 @@ jobs:
         shell: bash
         run: |
           export SDCCDIR=`pwd`/sdcc
+          export GBDK_DEBUG=1
           cd gbdk-2020
           make
           # Now build the examples for all platforms
@@ -147,6 +148,7 @@ jobs:
         run: |
           # For Windows build Examples is a separate stage due to commands getting skipped(?) after calling msys make
           # Now build the examples
+          set GBDK_DEBUG=1
           cd gbdk-2020
           cd build
           cd gbdk

--- a/gbdk-support/lcc/gb.c
+++ b/gbdk-support/lcc/gb.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <assert.h>
 #include <ctype.h>
 
@@ -223,6 +224,7 @@ char *ld[256];
 char *bankpack[256];
 char *mkbin[256];
 char *postproc[256];
+bool has_postproc_stage;
 char *rom_extension;
 arg_entry *llist0_defaults;
 int llist0_defaults_len = 0;
@@ -321,7 +323,12 @@ void finalise(void)
 	buildArgs(ld, _class->ld);
 	buildArgs(ihxcheck, _class->ihxcheck);
 	buildArgs(mkbin, _class->mkbin);
-		if (strlen(_class->postproc) != 0) buildArgs(postproc, _class->postproc); else postproc[0] = '\0';
+	if (strlen(_class->postproc) != 0) {
+		buildArgs(postproc, _class->postproc);
+		has_postproc_stage = true;
+	} else {
+		has_postproc_stage = false;
+	}
 	rom_extension = strdup(_class->rom_extension);
 	llist0_defaults = _class->llist0_defaults;
 	llist0_defaults_len = _class->llist0_defaults_len;

--- a/gbdk-support/lcc/lcc.c
+++ b/gbdk-support/lcc/lcc.c
@@ -65,6 +65,7 @@ static void warn_obsolete_option(char * arg);
 
 // These get populated from _class using finalise() in gb.c
 extern char *cpp[], *include[], *com[], *as[], *bankpack[], *ld[], *ihxcheck[], *mkbin[], *postproc[], inputs[], *suffixes[], *rom_extension;
+extern bool has_postproc_stage;
 extern arg_entry *llist0_defaults;
 extern int llist0_defaults_len;
 
@@ -304,7 +305,7 @@ int main(int argc, char *argv[]) {
 			if(errcnt == 0)
 			{
 				// makebin - use output filename unless there is a post-process step
-				if (strlen(postproc) == 0)
+				if (has_postproc_stage == false)
 					sprintf(binFile, "%s", outfile);
 				else
 					sprintf(binFile, "%s", path_newext(outfile, EXT_ROM));
@@ -321,7 +322,7 @@ int main(int argc, char *argv[]) {
 
 				// Post-process step (such as makecom, makenes), if applicable
 				// This won't apply if the targets .postproc template entry is empty ("")
-				if ((strlen(postproc) != 0) && (errcnt == 0)) {
+				if (has_postproc_stage && (errcnt == 0)) {
 					compose(postproc, postproclist, append(binFile, 0), append(outfile, 0));
 					if (callsys(av))
 						errcnt++;


### PR DESCRIPTION
- Use bool to indicate postproc stage present instead of setting char pointer to null then later calling strlen on possible null pointer

- Was able to reproduce the issue somewhat reliably on Windows
- This change seems to resolve the issue

Also: turn on GBDK_DEBUG=1 for github example building