### PR TITLE
NES: Add support for various tilemap layout (mirroring) configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,9 @@ gbdk-lib-install-platforms:
 		for port in $(PORTS); do \
 			if [ -d "$(GBDKLIBDIR)/libc/targets/$$port/$$plat" ]; then \
 				cp $(GBDKLIBDIR)/libc/targets/$$port/$$plat/global.s $(BUILDDIR)/lib/$$plat/global.s; \
+				if [ -f "$(GBDKLIBDIR)/libc/targets/$$port/$$plat/platform_cfg.s" ]; then \
+					cp $(GBDKLIBDIR)/libc/targets/$$port/$$plat/platform_cfg.s $(BUILDDIR)/lib/$$plat/platform_cfg.s; \
+				fi \
 			fi \
 		done \
 	done

--- a/gbdk-lib/examples/cross-platform/large_map/src/large_map.c
+++ b/gbdk-lib/examples/cross-platform/large_map/src/large_map.c
@@ -9,18 +9,13 @@
 #define camera_max_y ((bigmap_mapHeight - DEVICE_SCREEN_HEIGHT) * 8) 
 #define camera_max_x ((bigmap_mapWidth - DEVICE_SCREEN_WIDTH) * 8) 
 
-#if defined(SEGA)
-  #define WRAP_SCROLL_Y(y) ((y) % 224u)
-  // For SMS, artifacts are already invisible as screen buffer size is larger than screen size
-  #define SCROLL_Y_OFFSET 0
-#elif defined(NINTENDO)
-  #define WRAP_SCROLL_Y(y) y
-  // For GB, artifacts are already invisible as screen buffer size is larger than screen size
-  #define SCROLL_Y_OFFSET 0
-#else
-  #define WRAP_SCROLL_Y(y) ((y) % 240u)
-  // For other systems assume height of 240 and adjust Y-scroll 4 pixels down to partly hide artifacts in NTSC overscan
+#define WRAP_SCROLL_Y(y) ((y) % (DEVICE_SCREEN_BUFFER_HEIGHT * 8))
+
+// For systems where screen buffer height is equal to screen height, adjust Y-scroll 4 pixels down to partly hide artifacts in NTSC overscan
+#if DEVICE_SCREEN_BUFFER_HEIGHT == DEVICE_SCREEN_HEIGHT
   #define SCROLL_Y_OFFSET 4
+#else
+  #define SCROLL_Y_OFFSET 0
 #endif
 
 #if defined(SEGA)

--- a/gbdk-lib/examples/cross-platform/rle_map/src/main.c
+++ b/gbdk-lib/examples/cross-platform/rle_map/src/main.c
@@ -16,7 +16,7 @@ INCBIN(map_compressed, "res/map.bin.rle")
 INCBIN_EXTERN(map_compressed)
 
 uint8_t data[MAP_DATA_HEIGHT];  // Collision map buffer
-uint8_t scrollpos = 0;              // Scroll position in pixels
+uint16_t scrollpos = 0;             // Scroll position in pixels
 uint8_t datapos = 0;                // x position in tiles inside the collision map
 
 void main(void) {

--- a/gbdk-lib/include/nes/hardware.h
+++ b/gbdk-lib/include/nes/hardware.h
@@ -61,14 +61,12 @@ typedef uint8_t scroll_y_t;
 #define DEVICE_SCREEN_BUFFER_HEIGHT 60
 typedef uint8_t scroll_x_t;
 typedef uint16_t scroll_y_t;
-#elif defined(NES_TILEMAP_S)
+#else
 // Single-screen tilemap
 #define DEVICE_SCREEN_BUFFER_WIDTH 32
 #define DEVICE_SCREEN_BUFFER_HEIGHT 30
 typedef uint8_t scroll_x_t;
 typedef uint8_t scroll_y_t;
-#else
-#error "Must define tilemap layout: NES_TILEMAP_[F|H|V|S]"
 #endif
 
 #define DEVICE_SCREEN_MAP_ENTRY_SIZE 1

--- a/gbdk-lib/include/nes/hardware.h
+++ b/gbdk-lib/include/nes/hardware.h
@@ -42,8 +42,35 @@ __REG(0x4014) OAMDMA;
 #define DEVICE_SCREEN_Y_OFFSET 0
 #define DEVICE_SCREEN_WIDTH 32
 #define DEVICE_SCREEN_HEIGHT 30
+
+#if defined(NES_TILEMAP_F)
+// Full tilemap
+#define DEVICE_SCREEN_BUFFER_WIDTH 64
+#define DEVICE_SCREEN_BUFFER_HEIGHT 60
+typedef uint16_t scroll_x_t;
+typedef uint16_t scroll_y_t;
+#elif defined(NES_TILEMAP_H)
+// Horizontally arranged tilemap
+#define DEVICE_SCREEN_BUFFER_WIDTH 64
+#define DEVICE_SCREEN_BUFFER_HEIGHT 30
+typedef uint16_t scroll_x_t;
+typedef uint8_t scroll_y_t;
+#elif defined(NES_TILEMAP_V)
+// Vertically arranged tilemap
+#define DEVICE_SCREEN_BUFFER_WIDTH 32
+#define DEVICE_SCREEN_BUFFER_HEIGHT 60
+typedef uint8_t scroll_x_t;
+typedef uint16_t scroll_y_t;
+#elif defined(NES_TILEMAP_S)
+// Single-screen tilemap
 #define DEVICE_SCREEN_BUFFER_WIDTH 32
 #define DEVICE_SCREEN_BUFFER_HEIGHT 30
+typedef uint8_t scroll_x_t;
+typedef uint8_t scroll_y_t;
+#else
+#error "Must define tilemap layout: NES_TILEMAP_[F|H|V|S]"
+#endif
+
 #define DEVICE_SCREEN_MAP_ENTRY_SIZE 1
 #define DEVICE_SPRITE_PX_OFFSET_X 0
 #define DEVICE_SPRITE_PX_OFFSET_Y -1

--- a/gbdk-lib/libc/targets/mos6502/nes/crt0.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/crt0.s
@@ -10,8 +10,6 @@
 
 ; OAM CPU page
 _shadow_OAM             = 0x200
-; Attribute shadow (64 bytes, leaving 56 bytes available for CPU stack)
-_attribute_shadow       = 0x188
 
 .macro WRITE_PALETTE_SHADOW
     lda #>0x3F00
@@ -68,8 +66,8 @@ _shadow_PPUCTRL::                       .ds 1
 _shadow_PPUMASK::                       .ds 1
 _bkg_scroll_x::                         .ds 1
 _bkg_scroll_y::                         .ds 1
-_attribute_row_dirty::                  .ds 1
-_attribute_column_dirty::               .ds 1
+_attribute_row_dirty::                  .ds NUM_NT
+_attribute_column_dirty::               .ds NUM_NT
 __oam_valid_display_on::                .ds 1
 __SYSTEM::                              .ds 1
 __hblank_writes_index::                 .ds 1
@@ -77,6 +75,13 @@ __hblank_writes_index::                 .ds 1
 .define __crt0_NMITEMP "___SDCC_m6502_ret4"
 
 .area _BSS
+.ifdef NES_LOMEM
+; For LOMEM configuration use part of stack page for attribute shadow, leaving 56 bytes for subroutine calls 
+_attribute_shadow                       = 0x188
+.else
+; Otherwise allocate attribute shadow in data segment, with 64 bytes for each NT/AT
+_attribute_shadow::                     .ds (64*NUM_NT)
+.endif
 __crt0_paletteShadow::                  .ds 25
 .mode::                                 .ds 1
 __lcd_isr_PPUCTRL::                     .ds (2*.MAX_DEFERRED_ISR_CALLS)

--- a/gbdk-lib/libc/targets/mos6502/nes/flush_attributes.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/flush_attributes.s
@@ -1,10 +1,41 @@
     .include    "global.s"
 
+    .area   GBDKOVR (PAG, OVR)
+    .x_save:                    .ds 1
+    .attribute_row_dirty:       .ds 1
+    .attribute_column_dirty:    .ds 1
+
     .area   _HOME
-    
+
 _flush_shadow_attributes::
+    ldx #0
+.ifndef NES_TILEMAP_S
+1$:
+.endif
+    stx *.x_save
+    lda *_attribute_row_dirty,x
+    beq 2$
+    sta *.attribute_row_dirty
+    ldy .xy_shift_tab,x
     jsr _flush_shadow_attributes_rows
-    jmp _flush_shadow_attributes_columns
+    ldx *.x_save
+2$:
+    lda *_attribute_column_dirty,x
+    beq 3$
+    sta *.attribute_column_dirty
+    ldy .xy_shift_tab,x
+    jsr _flush_shadow_attributes_columns
+3$:
+    ldx *.x_save
+    lda #0
+    sta _attribute_row_dirty,x
+    sta _attribute_column_dirty,x
+.ifndef NES_TILEMAP_S
+    inx
+    cpx #NUM_NT
+    bne 1$
+.endif
+    rts
 
 ;
 ; Writes every row of attributes from _shadow_attributes that's been marked
@@ -13,24 +44,23 @@ _flush_shadow_attributes::
 _flush_shadow_attributes_rows:
     lda #<PPU_AT0
     sta *.tmp
-    lda #>PPU_AT0
+    lda .ppu_hi_tab,x
     sta *.tmp+1
-    ldy #0
 _flush_shadow_attributes_row_loop:
-    lsr *_attribute_row_dirty
+    lsr *.attribute_row_dirty
     bcc 1$
     jmp _flush_shadow_attributes_update_row
 1$:
     beq _flush_shadow_attributes_end
 _flush_shadow_attributes_next_row:
-    ; Y += 8
+    ; Y += AT_SHADOW_WIDTH
     tya
     clc
-    adc #8
+    adc #AT_SHADOW_WIDTH
     tay
-    ; .tmp += 8
+    ; .tmp += ATTRIBUTE_PACKED_WIDTH
     lda *.tmp
-    adc #8
+    adc #ATTRIBUTE_PACKED_WIDTH
     sta *.tmp
     jmp _flush_shadow_attributes_row_loop
 _flush_shadow_attributes_end:
@@ -40,6 +70,7 @@ _flush_shadow_attributes_end:
 ; Flushes all dirty rows of _attribute_shadow by writing them to PPU memory
 ;
 _flush_shadow_attributes_update_row:
+    stx *REGTEMP+3
     ; Update all 8 bytes of row for now, as each row in _attribute_row_dirty only stores 1 bit
     ; TODO: Could store 8 bytes and update range, at expense of 7 more bytes.
     lda *.tmp+1
@@ -54,6 +85,7 @@ _flush_shadow_attributes_update_row:
     i = i + 1
     .endm
     jsr .ppu_stripe_end
+    ldx *REGTEMP+3
     jmp _flush_shadow_attributes_next_row
 
 ;
@@ -64,11 +96,10 @@ _flush_shadow_attributes_update_row:
 _flush_shadow_attributes_columns:
     lda #<PPU_AT0
     sta *.tmp
-    lda #>PPU_AT0
+    lda .ppu_hi_tab,x
     sta *.tmp+1
-    ldy #0
 _flush_shadow_attributes_columns_loop:
-    lsr *_attribute_column_dirty
+    lsr *.attribute_column_dirty
     bcc 1$
     jmp _flush_shadow_attributes_update_column
 1$:
@@ -87,11 +118,11 @@ _flush_shadow_attributes_columns_end:
     tax
     lda *.tmp
     clc
-    adc #(8*i)
+    adc #(ATTRIBUTE_PACKED_WIDTH*i)
     jsr .ppu_stripe_begin_vertical
-    lda _attribute_shadow+8*i,y
+    lda _attribute_shadow+AT_SHADOW_WIDTH*i,y
     jsr .ppu_stripe_write_byte
-    lda _attribute_shadow+8*i+32,y
+    lda _attribute_shadow+AT_SHADOW_WIDTH*i+(AT_SHADOW_WIDTH*4),y
     jsr .ppu_stripe_write_byte
     jsr .ppu_stripe_end
 .endm
@@ -100,6 +131,7 @@ _flush_shadow_attributes_columns_end:
 ; Flushes all dirty rows of _attribute_shadow by writing them to PPU memory
 ;
 _flush_shadow_attributes_update_column:
+    stx *REGTEMP+3
     ; Update all 8 bytes of column for now, as each column in _attribute_column_dirty only stores 1 bit
     ; As PPU has no increment-by-8 feature, split writes into 4 separate stripes 2 bytes each
     ; TODO: Could make a dedicated unrolled transfer routine in nmi handler that writes all 8 bytes as one stripe.
@@ -108,4 +140,57 @@ _flush_shadow_attributes_update_column:
     WRITEVERT
     i = i + 1
     .endm
+    ldx *REGTEMP+3
     jmp _flush_shadow_attributes_columns_next_column
+
+; Shift MSB of attribute X / Y (attribute table index) from bits 1 and 0 to 7 and 3
+.ifdef NES_TILEMAP_F
+.xy_shift_tab:
+.db 0b00000000
+.db 0b00001000
+.db 0b10000000
+.db 0b10001000
+.endif
+.ifdef NES_TILEMAP_S
+.xy_shift_tab:
+.db 0b00000000
+.db 0b00000000
+.db 0b00000000
+.db 0b00000000
+.endif
+.ifdef NES_TILEMAP_H
+.xy_shift_tab:
+.db 0b00000000
+.db 0b00001000
+.endif
+.ifdef NES_TILEMAP_V
+.xy_shift_tab:
+.db 0b00000000
+.db 0b01000000
+.endif
+
+; Get hi address of attribute table index
+.ifdef NES_TILEMAP_F
+.ppu_hi_tab:
+.db >PPU_AT0
+.db >PPU_AT1
+.db >PPU_AT2
+.db >PPU_AT3
+.endif
+.ifdef NES_TILEMAP_S
+.ppu_hi_tab:
+.db >PPU_AT0
+.db >PPU_AT0
+.db >PPU_AT0
+.db >PPU_AT0
+.endif
+.ifdef NES_TILEMAP_H
+.ppu_hi_tab:
+.db >PPU_AT0
+.db >PPU_AT1
+.endif
+.ifdef NES_TILEMAP_V
+.ppu_hi_tab:
+.db >PPU_AT0
+.db >PPU_AT2
+.endif

--- a/gbdk-lib/libc/targets/mos6502/nes/global.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/global.s
@@ -1,3 +1,5 @@
+        .include "platform_cfg.s"
+
         ;; Maximum number of times LCD ISR can be repeatedly called
         .MAX_LCD_ISR_CALLS = 4
         ;; Total number is +1 to support VBL ISR with the same logic
@@ -22,11 +24,49 @@
         .SELECT         = 0x20
         .START          = 0x10
 
-        ;;  Screen dimensions (in tiles)
+;;  Screen dimensions (in tiles)
         .DEVICE_SCREEN_WIDTH            = 32
         .DEVICE_SCREEN_HEIGHT           = 30
+
+;;  Buffer dimensions (in tiles)
+;;  Dependent on tilemap layout
+.ifdef NES_TILEMAP_F
+        NUM_NT                          = 4
+        NT_2W                           = 1
+        NT_2H                           = 1
+        AT_SHADOW_WIDTH                 = 16
+        AT_SHADOW_HEIGHT                = 16
+        .DEVICE_SCREEN_BUFFER_WIDTH     = 64
+        .DEVICE_SCREEN_BUFFER_HEIGHT    = 60
+.endif
+.ifdef NES_TILEMAP_H
+        NUM_NT                          = 2
+        NT_2W                           = 1
+        NT_2H                           = 0
+        AT_SHADOW_WIDTH                 = 16
+        AT_SHADOW_HEIGHT                = 8
+        .DEVICE_SCREEN_BUFFER_WIDTH     = 64
+        .DEVICE_SCREEN_BUFFER_HEIGHT    = 30
+.endif
+.ifdef NES_TILEMAP_V
+        NUM_NT                          = 2
+        NT_2W                           = 0
+        NT_2H                           = 1
+        AT_SHADOW_WIDTH                 = 8
+        AT_SHADOW_HEIGHT                = 16
+        .DEVICE_SCREEN_BUFFER_WIDTH     = 32
+        .DEVICE_SCREEN_BUFFER_HEIGHT    = 60
+.endif
+.ifdef NES_TILEMAP_S
+        NUM_NT                          = 1
+        NT_2W                           = 0
+        NT_2H                           = 0
+        AT_SHADOW_WIDTH                 = 8
+        AT_SHADOW_HEIGHT                = 8
         .DEVICE_SCREEN_BUFFER_WIDTH     = 32
         .DEVICE_SCREEN_BUFFER_HEIGHT    = 30
+.endif
+
         .MAXCURSPOSX    = 31
         .MAXCURSPOSY    = 29
 
@@ -36,6 +76,17 @@
         ;; NAMETABLES
         PPU_NT0         = 0x2000
         PPU_AT0         = 0x23C0
+        PPU_NT1         = 0x2400
+        PPU_AT1         = 0x27C0
+        PPU_NT2         = 0x2800
+        PPU_AT2         = 0x2BC0
+        PPU_NT3         = 0x2C00
+        PPU_AT3         = 0x2FC0
+
+        NT_WIDTH                       = 32
+        NT_HEIGHT                      = 30
+        AT_WIDTH                       = 8
+        AT_HEIGHT                      = 8
 
         ATTRIBUTE_WIDTH                = 16
         ATTRIBUTE_HEIGHT               = 15

--- a/gbdk-lib/libc/targets/mos6502/nes/platform_cfg.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/platform_cfg.s
@@ -1,0 +1,33 @@
+;;;
+;;; Platform/mapper specific configuration settings.
+;;;
+
+;
+; Tilemap layout (nametable mirroring) setting.
+;
+; Available settings:
+;
+;   S: Single-screen layout/mirroring.
+;   H: Horizontal layout (vertical mirroring)
+;   V: Vertical layout (horizontal mirroring)
+;   F: Four-screen layout no mirroring)
+;
+; Only *one* of these should be enabled.
+; The same define should also be passed to LCC for compile-time settings in the C include files.
+;
+
+NES_TILEMAP_S = 1
+;NES_TILEMAP_H = 1
+;NES_TILEMAP_V = 1
+;NES_TILEMAP_F = 1
+
+;
+; LOMEM setting
+;
+; This places the 64 bytes of attribute shadow (assuming single-screen layout) in the stack area
+; saving 64 bytes of RAM memory for user variables, at the expense of a reduced stack for function calls.
+;
+; This setting is *only* valid when NES_TILEMAP_S = 1 (using it with other tilmap layouts will corrupt the stack)
+;
+
+NES_LOMEM = 1

--- a/gbdk-lib/libc/targets/mos6502/nes/set_bk_ts.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_bk_ts.s
@@ -1,134 +1,42 @@
     .include    "global.s"
 
+    ; NOTE: This overlay arrangement MUST match that of set_bkg_based_submap
     .area   GBDKOVR (PAG, OVR)
-    _set_bkg_tiles_PARM_3::     .ds 1
-    _set_bkg_tiles_PARM_4::     .ds 1
-    _set_bkg_tiles_PARM_5::     .ds 2
-    .xpos:                      .ds 1
-    .ypos:                      .ds 1
-    .num_rows:                  .ds 1
-    .src_tiles:                 .ds 2
+    _set_bkg_tiles_PARM_3::
+    _set_bkg_based_tiles_PARM_3::   .ds 1
+    _set_bkg_tiles_PARM_4::
+    _set_bkg_based_tiles_PARM_4::   .ds 1
+    _set_bkg_tiles_PARM_5::
+    _set_bkg_based_tiles_PARM_5::   .ds 2
+    _set_bkg_based_tiles_PARM_6::   .ds 1
+    .padding::                      .ds 1
+    .xpos:                          .ds 1
+    .ypos:                          .ds 1
+    .num_rows:                      .ds 1
+    .src_tiles:                     .ds 2
+    .remainder:                     .ds 1
+    .ppuhi:                         .ds 1
 
-    .area   _ZP
-    __map_tile_offset::         .ds 1
+    .define .width          "_set_bkg_submap_PARM_3"
+    .define .height         "_set_bkg_submap_PARM_4"
+    .define .tiles          "_set_bkg_submap_PARM_5"
+    .define .map_width      "_set_bkg_submap_PARM_6"
+    .define .tile_offset    "_set_bkg_based_submap_PARM_7"
 
     .area   _HOME
 
 _set_bkg_tiles::
-    .define .width  "_set_bkg_tiles_PARM_3"
-    .define .height "_set_bkg_tiles_PARM_4"
-    .define .tiles  "_set_bkg_tiles_PARM_5"
+    ldy #0
+    sty *_set_bkg_based_tiles_PARM_6
+_set_bkg_based_tiles::
     sta *.xpos
     stx *.ypos
-    lda .tiles
-    sta *.src_tiles
-    lda .tiles+1
-    sta *.src_tiles+1
-    lda *.height
-    sta *.num_rows
-    ; Prefer vertical stripes if height > width
-    cmp *.width
-    beq _set_bkg_tiles_horizontalStripes
-    bcs _set_bkg_tiles_verticalStripes
-_set_bkg_tiles_horizontalStripes:
-1$:
-    lda #0
-    sta *.tmp+1
-    lda *.ypos
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    ora *.xpos
-    sta *.tmp
-    ;
-    lda *.tmp+1
-    ora #0x20
-    tax
-    lda *.tmp
-    jsr .ppu_stripe_begin_horizontal
-    ldx *.width
-    ldy #0
-2$:
-    lda [*.src_tiles],y
-    clc
-    adc *__map_tile_offset
-    iny
-    jsr .ppu_stripe_write_byte
-    dex
-    bne 2$
-    jsr .ppu_stripe_end
-    ; .src_tiles += y
-    tya
-    clc
-    adc *.src_tiles
-    sta *.src_tiles
-    lda #0
-    adc *.src_tiles+1
-    sta *.src_tiles+1
-    inc *.ypos
-    dec *.num_rows
-    bne 1$
-    rts
-
-.define .num_cols  ".num_rows"
-
-_set_bkg_tiles_verticalStripes::
+    lda *_set_bkg_based_tiles_PARM_6
+    sta *.tile_offset
     lda *.width
-    sta *.num_cols
-    ldy #0
-1$:
+    sta *.map_width
     lda *.tiles
     sta *.src_tiles
     lda *.tiles+1
     sta *.src_tiles+1
-    ;
-    lda #0
-    sta *.tmp+1
-    lda *.ypos
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    ora *.xpos
-    sta *.tmp
-    ;
-    lda *.tmp+1
-    ora #0x20
-    tax
-    lda *.tmp
-    jsr .ppu_stripe_begin_vertical
-    ldx *.height
-2$:
-    lda [*.src_tiles],y
-    clc
-    adc *__map_tile_offset
-    jsr .ppu_stripe_write_byte
-    ; .src_tiles += width
-    lda *.width
-    clc
-    adc *.src_tiles
-    sta *.src_tiles
-    lda #0
-    adc *.src_tiles+1
-    sta *.src_tiles+1
-    dex
-    bne 2$
-    jsr .ppu_stripe_end
-    iny
-    inc *.xpos
-    dec *.num_cols
-    bne 1$
-    rts
+    jmp .set_bkg_common

--- a/gbdk-lib/libc/targets/mos6502/nes/set_tile.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_tile.s
@@ -3,13 +3,57 @@
     .area   GBDKOVR (PAG, OVR)
     _set_bkg_tile_xy_PARM_3::   .ds 1   ; (shared with _set_vram_byte_PARM_2)
     .bkg_tile_ppu_addr::        .ds 2
+    .ppuhi:                     .ds 1
 
     .area   _HOME
+
+.ifdef NES_TILEMAP_S
+.define PPUHI_MASK "#>PPU_NT0"
+.else
+.define PPUHI_MASK "*.ppuhi"
+.endif
 
 _get_bkg_xy_addr::
     ; XA = (PPU_NT0) | (X << 5) | A
     ; (A = x_pos, X = y_pos)
+.ifne NT_2W
+    tay
+.endif
+    and #NT_WIDTH-1
     sta *.bkg_tile_ppu_addr
+.ifne NT_2W
+    tya
+    ; .ppuhi = (xpos >> 3) & 0b00000100
+    lsr
+    lsr
+    lsr
+    and #0b00000100
+    ora #>PPU_NT0
+    sta *.ppuhi
+.else
+.ifne NT_2H
+    lda #>PPU_NT0
+    sta *.ppuhi
+.endif
+.endif
+.ifne NT_2H
+    ; .ppuhi |= ((ypos / DEVICE_SCREEN_BUFFER_HEIGHT) << 3) & 0b00001000
+    ldy #0
+    txa
+    cmp #NT_HEIGHT
+    bcc 1$
+    sbc #NT_HEIGHT  ; Assumes carry set by cmp
+    iny
+1$:
+    tax
+    tya
+    asl
+    asl
+    asl
+    and #0b00001000
+    ora *.ppuhi
+    sta *.ppuhi
+.endif
     txa
     asl
     asl
@@ -22,7 +66,7 @@ _get_bkg_xy_addr::
     lda *.bkg_tile_ppu_addr+1
     rol
     and #0x03
-    ora #(PPU_NT0 >> 8)
+    ora PPUHI_MASK
     tax
     lda *.bkg_tile_ppu_addr
     rts

--- a/gbdk-lib/libc/targets/mos6502/nes/set_tile_submap.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/set_tile_submap.s
@@ -1,31 +1,49 @@
     .include    "global.s"
 
     .area   GBDKOVR (PAG, OVR)
-    _set_bkg_submap_PARM_3::    .ds 1
-    _set_bkg_submap_PARM_4::    .ds 1
-    _set_bkg_submap_PARM_5::    .ds 2
-    _set_bkg_submap_PARM_6::    .ds 1
-    .xpos:                      .ds 1
-    .ypos:                      .ds 1
-    .num_rows:                  .ds 1
-    .src_tiles:                 .ds 2
-    .remainder:                 .ds 1
+    _set_bkg_submap_PARM_3::
+    _set_bkg_based_submap_PARM_3::  .ds 1
+    _set_bkg_submap_PARM_4::
+    _set_bkg_based_submap_PARM_4::  .ds 1
+    _set_bkg_submap_PARM_5::
+    _set_bkg_based_submap_PARM_5::  .ds 2
+    _set_bkg_submap_PARM_6::
+    _set_bkg_based_submap_PARM_6::  .ds 1
+    _set_bkg_based_submap_PARM_7::  .ds 1
+    .xpos:                          .ds 1
+    .ypos:                          .ds 1
+    .num_rows:                      .ds 1
+    .src_tiles:                     .ds 2
+    .remainder:                     .ds 1
+    .ppuhi:                         .ds 1
+    .stripe_loop_counter:           .ds 1
+
+    .define .width          "_set_bkg_submap_PARM_3"
+    .define .height         "_set_bkg_submap_PARM_4"
+    .define .tiles          "_set_bkg_submap_PARM_5"
+    .define .map_width      "_set_bkg_submap_PARM_6"
+    .define .tile_offset    "_set_bkg_based_submap_PARM_7"
 
     .area   _HOME
 
+.ifdef NES_TILEMAP_S
+.define PPUHI_MASK "#>PPU_NT0"
+.else
+.define PPUHI_MASK "*.ppuhi"
+.endif
+
 _set_bkg_submap::
-    .define .width      "_set_bkg_submap_PARM_3"
-    .define .height     "_set_bkg_submap_PARM_4"
-    .define .tiles      "_set_bkg_submap_PARM_5"
-    .define .map_width  "_set_bkg_submap_PARM_6"
+    ldy #0
+    sty *.tile_offset
+_set_bkg_based_submap::
     sta *.xpos
     stx *.ypos
     lda .tiles
-    CLC
-    ADC *.xpos
+    clc
+    adc *.xpos
     sta *.src_tiles
     lda .tiles+1
-    ADC #0
+    adc #0
     sta *.src_tiles+1
     ; += ypos * map_width
     lda *.ypos
@@ -37,18 +55,44 @@ _set_bkg_submap::
     txa
     adc *.src_tiles+1
     sta *.src_tiles+1
+.set_bkg_common::
     ;
     lda *.height
     sta *.num_rows
-    ; xpos %= DEVICE_SCREEN_WIDTH
+.ifne NT_2W
+    ; .ppuhi = (xpos >> 3) & 0b00000100
     lda *.xpos
-    and #.DEVICE_SCREEN_WIDTH-1
+    lsr
+    lsr
+    lsr
+    and #0b00000100
+    ora #>PPU_NT0
+    sta *.ppuhi
+.else
+.ifne NT_2H
+    lda #>PPU_NT0
+    sta *.ppuhi
+.endif
+.endif
+    ; xpos %= NT_WIDTH
+    lda *.xpos
+    and #NT_WIDTH-1
     sta *.xpos
-    ; ypos %= DEVICE_SCREEN_HEIGHT
-    lda #0
-    clc
-    FAST_MOD8 *.ypos #.DEVICE_SCREEN_HEIGHT
+    ldx *.ypos
+    ; ypos %= NT_HEIGHT
+    lda *.ypos
+    jsr .div_mod_height
     sta *.ypos
+.ifne NT_2H
+    ; .ppuhi |= (ypos % DEVICE_SCREEN_BUFFER_HEIGHT) & 0b00001000
+    txa
+    asl
+    asl
+    asl
+    and #0b00001000
+    ora *.ppuhi
+    sta *.ppuhi
+.endif
     ; Prefer vertical stripes if height > width
     lda *.height
     cmp *.width
@@ -61,7 +105,7 @@ _set_bkg_submap_horizontalStripes:
     clc
     adc *.width
     sec
-    sbc #.DEVICE_SCREEN_WIDTH
+    sbc #NT_WIDTH
     sta *.remainder
     bmi 1$
     lda *.width
@@ -69,81 +113,63 @@ _set_bkg_submap_horizontalStripes:
     sbc *.remainder
     sta *.width
 1$:
-    ; Decrement to allow treating 0-case same as negative 
-    dec *.remainder
 _set_bkg_submap_horizontalStripes_rowLoop:
-    ; tmp = PPU_NT0 | (ypos << 5) | xpos 
-    lda #0
-    sta *.tmp+1
-    lda *.ypos
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    ora *.xpos
-    sta *.tmp
-    ;
-    lda *.tmp+1
-    ora #>PPU_NT0
-    tax
-    lda *.tmp
-    jsr .ppu_stripe_begin_horizontal
-    ldy #0
     ldx *.width
-1$:
-    lda [*.src_tiles],y
-    iny
-    jsr .ppu_stripe_write_byte
-    dex
-    bne 1$
-    jsr .ppu_stripe_end
+    stx *.stripe_loop_counter
+    jsr .setup_stripe_address
+    ldy #0
+    ldx *.tmp+1
+    lda *.tmp
+    jsr .write_horizontal_stripe
     ; if wrapped around, write remainder
     lda *.remainder
-    bpl _set_bkg_submap_horizontalStripes_remainder
+    bmi _set_bkg_submap_horizontalStripes_rowLoopEnd
+    bne _set_bkg_submap_horizontalStripes_remainder
 _set_bkg_submap_horizontalStripes_rowLoopEnd:
     ; .src_tiles += .map_width
     lda *.map_width
     clc
     adc *.src_tiles
     sta *.src_tiles
-    lda #0
-    adc *.src_tiles+1
-    sta *.src_tiles+1
-    ;inc *.ypos
+    bcc 2$
+    inc *.src_tiles+1
+2$:
     ; ypos += 1, with wrap back to 0 if gone past bottom of nametable
     lda *.ypos
     clc
     adc #1
-    cmp #.DEVICE_SCREEN_HEIGHT
+    cmp #NT_HEIGHT
     bcc 1$
-    lda #0
+    adc #0xE1 ; 0x02-0x20-C   ; (carry assumed set)
+.ifne NT_2H
+    ; Flip nametable Y bit after storing wrapped ypos
+    sta *.ypos
+    lda *.ppuhi
+    eor #0b00001000
+    sta *.ppuhi
+    bcs 3$   ; Carry still set, use BCS in place of JMP
+.endif
 1$:
     sta *.ypos
+3$:
     dec *.num_rows
     bne _set_bkg_submap_horizontalStripes_rowLoop
     rts
 
 _set_bkg_submap_horizontalStripes_remainder:
+    ldx *.remainder
+    stx *.stripe_loop_counter
+.ifne NT_2W + NT_2H
     lda *.tmp+1
-    ora #>PPU_NT0
+    ora *.ppuhi
+    eor #0b00000100
     tax
+.else
+    ldx *.tmp+1
+.endif
     lda *.tmp
     and #0xE0   ; Always start remainder at X=0
-    jsr .ppu_stripe_begin_horizontal
-    ldx *.remainder
-1$:
-    lda [*.src_tiles],y
-    iny
-    jsr .ppu_stripe_write_byte
-    dex
-    bpl 1$
-    jsr .ppu_stripe_end
+    jsr .write_horizontal_stripe
     jmp _set_bkg_submap_horizontalStripes_rowLoopEnd
 
 
@@ -155,7 +181,7 @@ _set_bkg_submap_verticalStripes:
     clc
     adc *.height
     sec
-    sbc #.DEVICE_SCREEN_HEIGHT
+    sbc #NT_HEIGHT
     sta *.remainder
     bmi 1$
     lda *.height
@@ -163,9 +189,6 @@ _set_bkg_submap_verticalStripes:
     sbc *.remainder
     sta *.height
 1$:
-    ; Decrement to allow treating 0-case same as negative 
-    dec *.remainder
-    ;
     lda *.src_tiles
     sta *.tiles
     lda *.src_tiles+1
@@ -175,12 +198,58 @@ _set_bkg_submap_verticalStripes:
     sta *.num_cols
     ldy #0
 _set_bkg_submap_verticalStripes_columnLoop:
+    ldx *.height
+    stx *.stripe_loop_counter
     lda *.tiles
     sta *.src_tiles
     lda *.tiles+1
     sta *.src_tiles+1
     ;
-    lda #0
+    jsr .setup_stripe_address
+    ldx *.tmp+1
+    lda *.tmp
+    jsr .write_vertical_stripe
+    ; if wrapped around, write remainder
+    lda *.remainder
+    bmi _set_bkg_submap_verticalStripes_columnLoopEnd
+    bne _set_bkg_submap_verticalStripes_remainder
+_set_bkg_submap_verticalStripes_columnLoopEnd:
+    iny
+    inc *.xpos
+    dec *.num_cols
+    bne _set_bkg_submap_verticalStripes_columnLoop
+    rts
+
+_set_bkg_submap_verticalStripes_remainder:
+    ldx *.remainder
+    stx *.stripe_loop_counter
+.ifne NT_2H
+    lda *.ppuhi
+    eor #0b00001000
+    tax
+.else
+    ldx PPUHI_MASK
+.endif
+    lda *.tmp
+    and #NT_WIDTH-1   ; Always start remainder at Y=0
+    jsr .write_vertical_stripe
+    jmp _set_bkg_submap_verticalStripes_columnLoopEnd
+
+.div_mod_height:
+    ldx #0
+    sec
+1$:
+    sbc #NT_HEIGHT
+    bcc 2$
+    inx
+    jmp 1$
+2$:
+    adc #NT_HEIGHT
+    rts
+
+.setup_stripe_address:
+    ; tmp = ppuhi | (ypos << 5) | xpos
+    lda #(PPU_NT0 >> 13)
     sta *.tmp+1
     lda *.ypos
     asl
@@ -197,53 +266,39 @@ _set_bkg_submap_verticalStripes_columnLoop:
     sta *.tmp
     ;
     lda *.tmp+1
-    ora #>PPU_NT0
-    tax
-    lda *.tmp
-    jsr .ppu_stripe_begin_vertical
-    ldx *.height
-1$:
-    lda [*.src_tiles],y
-    jsr .ppu_stripe_write_byte
-    ; .src_tiles += width
-    lda *.map_width
-    clc
-    adc *.src_tiles
-    sta *.src_tiles
-    lda #0
-    adc *.src_tiles+1
-    sta *.src_tiles+1
-    dex
-    bne 1$
-    jsr .ppu_stripe_end
-    ; if wrapped around, write remainder
-    lda *.remainder
-    bpl _set_bkg_submap_verticalStripes_remainder
-_set_bkg_submap_verticalStripes_columnLoopEnd:
-    iny
-    inc *.xpos
-    dec *.num_cols
-    bne _set_bkg_submap_verticalStripes_columnLoop
+.ifne NT_2W + NT_2H
+    ora PPUHI_MASK
+.endif
+    sta *.tmp+1
     rts
 
-_set_bkg_submap_verticalStripes_remainder:
-    ldx #>PPU_NT0
-    lda *.tmp
-    and #.DEVICE_SCREEN_WIDTH-1   ; Always start remainder at Y=0
-    jsr .ppu_stripe_begin_vertical
-    ldx *.remainder
+.write_horizontal_stripe:
+    jsr .ppu_stripe_begin_horizontal
 1$:
     lda [*.src_tiles],y
+    iny
+    clc
+    adc *.tile_offset
+    jsr .ppu_stripe_write_byte
+    dec *.stripe_loop_counter
+    bne 1$
+    jmp .ppu_stripe_end
+
+.write_vertical_stripe:
+    jsr .ppu_stripe_begin_vertical
+1$:
+    lda [*.src_tiles],y
+    clc
+    adc *.tile_offset
     jsr .ppu_stripe_write_byte
     ; .src_tiles += width
     lda *.map_width
     clc
     adc *.src_tiles
     sta *.src_tiles
-    lda #0
-    adc *.src_tiles+1
-    sta *.src_tiles+1
-    dex
-    bpl 1$
-    jsr .ppu_stripe_end
-    jmp _set_bkg_submap_verticalStripes_columnLoopEnd
+    bcc 2$
+    inc *.src_tiles+1
+2$:
+    dec *.stripe_loop_counter
+    bne 1$
+    jmp .ppu_stripe_end

--- a/gbdk-support/lcc/targets.c
+++ b/gbdk-support/lcc/targets.c
@@ -160,7 +160,7 @@ CLASS classes[] = {
       .rom_extension=  EXT_NES,
       .cpp          = "%cpp% %cppdefault% $1 $2 $3",
       .include      = "%includedefault%",
-      .com          = "%com% %comdefault% -DNES_TILEMAP_S=1 -Wa%asdefault% $1 %comflag% $2 -o $3",
+      .com          = "%com% %comdefault% -Wa%asdefault% $1 %comflag% $2 -o $3",
       .as           = "%as_6500% %asdefault% $1 $3 $2",
       .bankpack     = "%bankpack% -plat=nes -mapper=30 $1 $2",
       .ld           = "%ld_6808% -a nes -n -i -j $1 %libs_include% $3 %crt0dir% $2",

--- a/gbdk-support/lcc/targets.c
+++ b/gbdk-support/lcc/targets.c
@@ -160,7 +160,7 @@ CLASS classes[] = {
       .rom_extension=  EXT_NES,
       .cpp          = "%cpp% %cppdefault% $1 $2 $3",
       .include      = "%includedefault%",
-      .com          = "%com% %comdefault% -Wa%asdefault% $1 %comflag% $2 -o $3",
+      .com          = "%com% %comdefault% -DNES_TILEMAP_S=1 -Wa%asdefault% $1 %comflag% $2 -o $3",
       .as           = "%as_6500% %asdefault% $1 $3 $2",
       .bankpack     = "%bankpack% -plat=nes -mapper=30 $1 $2",
       .ld           = "%ld_6808% -a nes -n -i -j $1 %libs_include% $3 %crt0dir% $2",


### PR DESCRIPTION
- Introduce platform configuration, mainly to define tilemap layout NES_TILEMAP_[F|H|V|S] in platform_cfg.s
  + Add NES_TILEMAP_S|H|V|F setting for tilemap layout, and hard-code to NES_TILEMAP_S for now
  + Add NES_LOMEM setting to enable current default of using part of stack instead of BSS for attribute shadow buffer
  + Edit Makefile to copy platform_cfg.s (if it exists) to platform directory after build

- Updates to attribute shadow buffer and dirty bits:
  + Add NUM_NT define for number of nametables used by a layout, and AT_SHADOW_WIDTH/_HEIGHT to denote the variable dimensions
  + Add convenience defines NT_2W / NT_2H to quickly test whether tilemap layout is two screens wide / high
  + Define _attribute_shadow and _attribute_row/_column_dirty in terms of NUM_NT
  + Update flush_attributes to support all layouts
  + Update get_bkg_xy_addr / set_bkg_tile_xy to support all layouts
  + Update set_bkg_attribute_xy[_nes16x16] to support all layouts
  + Update set_bkg_attributes[_nes16x16] to support all layouts, and correctly wrap to next AT in both directions
  + Update set_bkg_submap_attributes[_nes16x16] to support all layouts
  + Update set_bkg_submap to support all layouts, and contain common inner subroutine .set_bkg_common
  + Replace set_bkg_tiles with simpler implementation calling .set_bkg_common, and correctly wraps to next NT in both directions
  + Add set_bkg_based_tiles / set_bkg_based_submap implementations using the new common subroutine

- Updates to C include files:
  + Define DEVICE_SCREEN_BUFFER_WIDTH/_HEIGHT based on NES_TILEMAP_ setting, doubling high-level size of WIDTH / HEIGHT conditionally
  + Add typedefs scroll_x_t / scroll_y_t as uint8_t or uint16_t based on NES_TILEMAP_ setting
  + Make move_bkg use scroll_x/y_t typedefs, set 9th scroll bit in shadow_PPUCTRL where needed, and compensate for 239->0 y wrapping

- Updates to LCC targets.c:
  + Update C compiler stage to pass -DNES_TILEMAP_S=1, for compile-time #ifdefs to match assembly-time .ifdefs

- Updates to examples:
  + Update large_map example to use platform-agnostic settings for scroll wrapping and offset
  + Update rle_map to use a uint16_t for scroll position, to support NES_TILEMAP_H and NES_TILEMAP_F settings