### PR TITLE
Platformer example: remove flag -keep_duplicate_tiles

### DIFF
--- a/gbdk-lib/examples/cross-platform/platformer_template/Makefile
+++ b/gbdk-lib/examples/cross-platform/platformer_template/Makefile
@@ -79,8 +79,8 @@ PNG2ASSET_SPRITE_SETTINGS_pocket=
 
 png2asset:
 	$(PNG2ASSET) res/graphics/player-character-$(SPRITES)-sprites.png -c $(GENDIR)/PlayerCharacterSprites.c -px 12 -py 6 -spr8x16 -keep_palette_order -sw 24 -sh 32 $(PNG2ASSET_SPRITE_SETTINGS_$(EXT)) -b 255
-	$(PNG2ASSET) res/graphics/world1-tileset.png -c $(GENDIR)/World1Tileset.c -keep_palette_order -noflip -map -keep_duplicate_tiles $(PNG2ASSET_BKG_SETTINGS_$(EXT)) -b 255
-	$(PNG2ASSET) res/graphics/world2-tileset.png -c $(GENDIR)/World2Tileset.c -keep_palette_order -noflip -map -keep_duplicate_tiles $(PNG2ASSET_BKG_SETTINGS_$(EXT)) -b 255
+	$(PNG2ASSET) res/graphics/world1-tileset.png -c $(GENDIR)/World1Tileset.c -keep_palette_order -noflip -map $(PNG2ASSET_BKG_SETTINGS_$(EXT)) -b 255
+	$(PNG2ASSET) res/graphics/world2-tileset.png -c $(GENDIR)/World2Tileset.c -keep_palette_order -noflip -map $(PNG2ASSET_BKG_SETTINGS_$(EXT)) -b 255
 	$(PNG2ASSET) res/graphics/world1-area1.png -c $(GENDIR)/World1Area1.c -noflip -map -maps_only -source_tileset res/graphics/world1-tileset.png $(PNG2ASSET_BKG_SETTINGS_$(EXT))  -b 255
 	$(PNG2ASSET) res/graphics/world1-area2.png -c $(GENDIR)/World1Area2.c -noflip -map -maps_only -source_tileset res/graphics/world1-tileset.png $(PNG2ASSET_BKG_SETTINGS_$(EXT)) -b 255
 	$(PNG2ASSET) res/graphics/world2-area1.png -c $(GENDIR)/World2Area1.c -noflip -map -maps_only -source_tileset res/graphics/world2-tileset.png $(PNG2ASSET_BKG_SETTINGS_$(EXT)) -b 255

--- a/gbdk-lib/examples/cross-platform/platformer_template/src/level.c
+++ b/gbdk-lib/examples/cross-platform/platformer_template/src/level.c
@@ -87,15 +87,13 @@ void SetupCurrentLevel(void) NONBANKED{
 
 
 
-            // Switch to whichever bank our song is in
-            // Not neccessary if the song is in bank 0
+            // Switch to whichever bank source tileset is in
             SWITCH_ROM(( BANK(World1Tileset)));
 
             set_native_tile_data(0,World1Tileset_TILE_COUNT,World1Tileset_tiles);
             setBKGPalettes(World1Tileset_PALETTE_COUNT,World1Tileset_palettes);
             
-            // Switch to whichever bank our song is in
-            // Not neccessary if the song is in bank 0
+            // Switch to whichever the map data is in
             SWITCH_ROM((currentAreaBank = BANK(World1Area1)));
 
             currentLevelNonSolidTileCount=WORLD1_SOLID_TILE_COUNT;
@@ -110,17 +108,14 @@ void SetupCurrentLevel(void) NONBANKED{
         case 1:
 
 
-            // Switch to whichever bank our song is in
-            // Not neccessary if the song is in bank 0
+            // Switch to whichever bank source tileset is in
             SWITCH_ROM((currentAreaBank = BANK(World1Tileset)));
-
 
             set_native_tile_data(0,World1Tileset_TILE_COUNT,World1Tileset_tiles);
             setBKGPalettes(World1Tileset_PALETTE_COUNT,World1Tileset_palettes);
 
             
-            // Switch to whichever bank our song is in
-            // Not neccessary if the song is in bank 0
+            // Switch to whichever the map data is in
             SWITCH_ROM((currentAreaBank = BANK(World1Area2)));
 
             currentLevelNonSolidTileCount=WORLD1_SOLID_TILE_COUNT;
@@ -134,16 +129,14 @@ void SetupCurrentLevel(void) NONBANKED{
         case 2:
 
 
-            // Switch to whichever bank our song is in
-            // Not neccessary if the song is in bank 0
+            // Switch to whichever bank source tileset is in
             SWITCH_ROM((BANK(World2Tileset)));
 
             set_native_tile_data(0,World2Tileset_TILE_COUNT,World2Tileset_tiles);
             setBKGPalettes(World2Tileset_PALETTE_COUNT,World2Tileset_palettes);
 
             
-            // Switch to whichever bank our song is in
-            // Not neccessary if the song is in bank 0
+            // Switch to whichever the map data is in
             SWITCH_ROM((currentAreaBank = BANK(World2Area1)));
 
             currentLevelNonSolidTileCount=WORLD2_SOLID_TILE_COUNT;


### PR DESCRIPTION
- Flag should not be there since the map conversion does not have the flag enabled and if there are duplicate tiles in the source tileset the tile numbering gets scrambled
- Also fix incorrect comment