### PR TITLE
gbdk-lib: Fixed definition of NULL in include/types.h

### DIFF
--- a/gbdk-lib/include/types.h
+++ b/gbdk-lib/include/types.h
@@ -7,9 +7,9 @@
 
 #include <asm/types.h>
 
-/** Good 'ol NULL.
- */
-#define	NULL 0
+#ifndef NULL
+  #define NULL (void *)0
+#endif
 
 /** A 'false' value.
  */


### PR DESCRIPTION
NULL is defined as 0 if you include types.h first in a translation unit, or as (void *)0 if you include stddef.h first in a translation unit. types.h also redefines NULL without checking if it's already defined. This just replaces the types.h #define NULL 0 with the more accurate and safer stddef.h one which does guard against redefinition.