### PR TITLE
romusage: sync upstream changes for 1.3.2

### DIFF
--- a/gbdk-support/romusage/src/banks.c
+++ b/gbdk-support/romusage/src/banks.c
@@ -536,7 +536,7 @@ void area_manual_apply_queued(void) {
 // Follow up call is area_manual_apply_queued()
 bool area_manual_queue(char * arg_str) {
 
-    char cols;
+    int cols;
     char * p_str;
     char * p_words[MAX_SPLIT_WORDS];
 

--- a/gbdk-support/romusage/src/banks_color.c
+++ b/gbdk-support/romusage/src/banks_color.c
@@ -150,7 +150,7 @@ void bank_render_color(bank_item * p_bank, int mode) {
 // Custom color scheme for output
 bool set_option_custom_bank_colors(char * arg_str) {
 
-    char cols;
+    int cols;
     char * p_str;
     char * p_words[MAX_SPLIT_WORDS];
     area_item area;

--- a/gbdk-support/romusage/src/cdb_file.c
+++ b/gbdk-support/romusage/src/cdb_file.c
@@ -227,7 +227,7 @@ static void cdb_add_record_symbol(char * addr_space, char * name, char * length,
 
 int cdb_file_process_symbols(char * filename_in) {
 
-    char cols;
+    int cols;
     char * p_str;
     char * p_words[CDB_MAX_SPLIT_WORDS];
     char strline_in[CDB_MAX_STR_LEN] = "";

--- a/gbdk-support/romusage/src/common.c
+++ b/gbdk-support/romusage/src/common.c
@@ -12,36 +12,75 @@
 #include "logging.h"
 #include "rom_file.h"
 
-bool banks_display_areas        = false;
-bool banks_display_headers      = false;
-bool banks_display_minigraph    = false;
-bool banks_display_largegraph   = false;
-bool option_compact_mode        = false;
-bool option_json_output         = false;
-bool option_summarized_mode     = false;
+bool banks_display_areas;
+bool banks_display_headers;
+bool banks_display_minigraph;
+bool banks_display_largegraph;
+bool option_compact_mode;
+bool option_json_output;
+bool option_summarized_mode;
 
 // -B
-unsigned int option_merged_banks = OPT_MERGED_BANKS_NONE;
+unsigned int option_merged_banks;
 // -F
-unsigned int option_forced_display_max_bank_ROM = 0;
-unsigned int option_forced_display_max_bank_SRAM = 0;
+unsigned int option_forced_display_max_bank_ROM;
+unsigned int option_forced_display_max_bank_SRAM;
 
-unsigned int option_platform    = OPT_PLAT_GAMEBOY;
-bool option_display_asciistyle  = false;
-bool option_all_areas_exclusive = false;
-bool option_quiet_mode          = false;
-bool option_suppress_duplicates = true;
-bool option_error_on_warning    = false;
-bool option_hide_banners        = false;
-int  option_input_source        = OPT_INPUT_SRC_NONE;
-int  option_area_sort           = OPT_AREA_SORT_DEFAULT;
-int  option_color_mode          = OPT_PRINT_COLOR_OFF;
-bool option_percentage_based_color = false;
-uint32_t option_area_hide_size  = OPT_AREA_HIDE_SIZE_DEFAULT;
-bool exit_error                 = false;
+unsigned int option_platform;
+bool option_display_asciistyle;
+bool option_all_areas_exclusive;
+bool option_quiet_mode;
+bool option_suppress_duplicates;
+bool option_error_on_warning;
+bool option_hide_banners;
+int  option_input_source;
+int  option_area_sort;
+int  option_color_mode;
+bool option_percentage_based_color;
+uint32_t option_area_hide_size;
+bool option_is_web_mode;
 
-int  banks_hide_count = 0;
+bool exit_error;
+
+int  banks_hide_count;
 char banks_hide_list[BANKS_HIDE_SZ][DEFAULT_STR_LEN];
+
+
+// Need a way to reset all options to default when running
+// as wasm and called multiple times
+void options_reset_all(void) {
+    banks_display_areas        = false;
+    banks_display_headers      = false;
+    banks_display_minigraph    = false;
+    banks_display_largegraph   = false;
+    option_compact_mode        = false;
+    option_json_output         = false;
+    option_summarized_mode     = false;
+
+    // -B
+    option_merged_banks = OPT_MERGED_BANKS_NONE;
+    // -F
+    option_forced_display_max_bank_ROM = 0;
+    option_forced_display_max_bank_SRAM = 0;
+
+    option_platform    = OPT_PLAT_GAMEBOY;
+    option_display_asciistyle  = false;
+    option_all_areas_exclusive = false;
+    option_quiet_mode          = false;
+    option_suppress_duplicates = true;
+    option_error_on_warning    = false;
+    option_hide_banners        = false;
+    option_input_source        = OPT_INPUT_SRC_NONE;
+    option_area_sort           = OPT_AREA_SORT_DEFAULT;
+    option_color_mode          = OPT_PRINT_COLOR_OFF;
+    option_percentage_based_color = false;
+    option_area_hide_size      = OPT_AREA_HIDE_SIZE_DEFAULT;
+    option_is_web_mode         = true;
+
+    exit_error                 = false;
+
+    banks_hide_count = 0;
+}
 
 
 // Turn on/off display of areas within bank
@@ -160,7 +199,7 @@ bool set_option_displayed_bank_range(char * arg_str) {
     #define MAX_SPLIT_WORDS 4
     #define EXPECTED_COLS   3
 
-    char cols;
+    int cols;
     char * p_str;
     char * p_words[MAX_SPLIT_WORDS];
 
@@ -250,7 +289,7 @@ bool set_option_binary_rom_empty_values(char * arg_str) {
     #define MAX_ROMFILE_ENTRIES     256
     #define MIN_EXPECTED_ENTRIES   1
 
-    char entries_found;
+    int entries_found;
     char * p_str;
     char * p_words[MAX_ROMFILE_ENTRIES];
 
@@ -308,3 +347,13 @@ uint32_t min(uint32_t a, uint32_t b) {
 uint32_t max(uint32_t a, uint32_t b) {
     return (a > b) ? a : b;
 }
+
+
+void set_option_is_web_mode(void) {
+    option_is_web_mode = true;
+}
+
+bool get_option_is_web_mode(void) {
+    return option_is_web_mode;
+}
+

--- a/gbdk-support/romusage/src/common.h
+++ b/gbdk-support/romusage/src/common.h
@@ -42,6 +42,7 @@
 #define BANKS_HIDE_SZ 30  // How many hide substrings to support
 #define BANKS_HIDE_MAX (BANKS_HIDE_SZ - 1)
 
+extern void options_reset_all(void);
 
 extern bool banks_display_areas;
 extern bool banks_display_headers;
@@ -107,6 +108,10 @@ uint32_t round_up_power_of_2(uint32_t val);
 
 uint32_t min(uint32_t a, uint32_t b);
 uint32_t max(uint32_t a, uint32_t b);
+
+void set_option_is_web_mode(void);
+bool get_option_is_web_mode(void);
+
 
 
 #endif // _COMMON_H

--- a/gbdk-support/romusage/src/logging.c
+++ b/gbdk-support/romusage/src/logging.c
@@ -2,7 +2,10 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
 
+#include "common.h"
 #include "logging.h"
 
 int output_level = OUTPUT_LEVEL_DEFAULT;
@@ -11,7 +14,7 @@ int output_level = OUTPUT_LEVEL_DEFAULT;
 #define VA_LIST_PRINT() \
     va_list args; \
     va_start (args, format); \
-    vfprintf (stderr, format, args); \
+    if (get_option_is_web_mode()) { vfprintf (stdout, format, args); } else { vfprintf (stderr, format, args);} \
     va_end (args);
 
 

--- a/gbdk-support/romusage/src/map_file.c
+++ b/gbdk-support/romusage/src/map_file.c
@@ -39,7 +39,7 @@ _HRAM10                00000000    00000001 =           1. bytes (ABS,CON)
 
 static int str_split(char * str_check, char * p_words[], const char * split_criteria) {
 
-    char cols;
+    int cols;
     char * p_str;
 
     cols = 0;

--- a/gbdk-support/romusage/src/noi_file.c
+++ b/gbdk-support/romusage/src/noi_file.c
@@ -118,7 +118,7 @@ static void noi_arealist_add(char * rec_type, char * name, char * value) {
 
 int noi_file_process_areas(char * filename_in) {
 
-    char cols;
+    int  cols;
     char * p_str;
     char * p_words[MAX_SPLIT_WORDS];
     char strline_in[MAX_STR_LEN] = "";

--- a/gbdk-support/romusage/src/romusage.c
+++ b/gbdk-support/romusage/src/romusage.c
@@ -19,7 +19,7 @@
 #include "cdb_file.h"
 #include "rom_file.h"
 
-#define VERSION "version 1.3.1"
+#define VERSION "version 1.3.2"
 
 enum {
     HELP_FULL = 0,
@@ -37,6 +37,9 @@ void cleanup(void);
 char filename_in[MAX_STR_LEN] = {'\0'};
 int  show_help_and_exit = false;
 
+static void main_init(void) {
+    show_help_and_exit = false;
+}
 
 static void display_cdb_warning() {
     printf("\n"
@@ -124,14 +127,15 @@ void set_drag_and_drop_mode_defaults(void) {
 int handle_args(int argc, char * argv[]) {
 
     int i;
+    bool filename_present = false;
 
     if( argc < 2 ) {
         display_help(HELP_FULL);
         return false;
     }
 
-    // Start at first optional argument, argc is zero based
-    for (i = 0; i <= (argc -1); i++ ) {
+    // Start at first optional argument ([0] is executable)
+    for (i = 1; i < argc; i++ ) {
 
         if (strstr(argv[i], "-h") == argv[i]) {
             display_help(HELP_FULL);
@@ -239,10 +243,17 @@ int handle_args(int argc, char * argv[]) {
         // Copy input filename (if not preceded with option dash)
         else if (argv[i][0] != '-') {
             snprintf(filename_in, sizeof(filename_in), "%s", argv[i]);
+            filename_present = true;
         }
     }
 
-    return true;
+    if (filename_present) {
+        return true;
+    } else {
+        display_help(HELP_FULL);
+        show_help_and_exit = true;
+        return false;
+    }
 }
 
 
@@ -260,6 +271,10 @@ static bool matches_extension(char * filename, char * extension) {
 
 
 static void init(void) {
+    // The first two are for web mode which needs a reset between runs
+    main_init();
+    options_reset_all();
+
     cdb_init();
     noi_init();
     banks_init();


### PR DESCRIPTION
- Use more appropriate type for strok split count
- Fix missing error when filename not present