### PR TITLE
Examples: fix some missing compile.bat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ VER = 4.4.0
 
 PORTS=sm83 z80 mos6502
 PLATFORMS=gb ap duck gg sms msxdos nes
+EXAMPLE_DIRS=$(PLATFORMS)
+EXAMPLE_DIRS+= cross-platform megaduck
 
 # Prefix to add to the standard tools.  Usefull for a standard gcc
 # cross-compile.
@@ -279,10 +281,10 @@ gbdk-lib-install-platforms:
 gbdk-lib-install-examples:
 	@echo Installing Examples
 	@cp -r $(GBDKLIBDIR)/include $(GBDKLIBDIR)/examples $(BUILDDIR)
-	@for plat in $(PLATFORMS); do \
-		if [ -d "$(BUILDDIR)/examples/$$plat" ]; then \
-			echo Generating Examples compile.bat for $$plat; \
-			$(MAKE) -C $(BUILDDIR)/examples/$$plat compile.bat --no-print-directory; \
+	@for example_dir in $(EXAMPLE_DIRS); do \
+		if [ -d "$(BUILDDIR)/examples/$$example_dir" ]; then \
+			echo Generating Examples compile.bat for $$example_dir; \
+			$(MAKE) -C $(BUILDDIR)/examples/$$example_dir compile.bat --no-print-directory; \
 			echo; \
 		fi \
 	done

--- a/gbdk-lib/examples/cross-platform/banks/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks/Makefile
@@ -50,6 +50,11 @@ OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(eval BOFLAG = $(shell echo "$<" | sed -n 's/.*\.bo\([0-9]\+\).*/\-Wf-bo\1/p'))

--- a/gbdk-lib/examples/cross-platform/banks_autobank/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_autobank/Makefile
@@ -52,6 +52,11 @@ OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/banks_farptr/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_farptr/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/banks_nonintrinsic/Makefile
+++ b/gbdk-lib/examples/cross-platform/banks_nonintrinsic/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/bcd/Makefile
+++ b/gbdk-lib/examples/cross-platform/bcd/Makefile
@@ -50,6 +50,11 @@ OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(eval BOFLAG = $(shell echo "$<" | sed -n 's/.*\.bo\([0-9]\+\).*/\-Wf-bo\1/p'))

--- a/gbdk-lib/examples/cross-platform/display_system/Makefile
+++ b/gbdk-lib/examples/cross-platform/display_system/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/emu_debug/Makefile
+++ b/gbdk-lib/examples/cross-platform/emu_debug/Makefile
@@ -47,6 +47,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/fonts/Makefile
+++ b/gbdk-lib/examples/cross-platform/fonts/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/gbdecompress/Makefile
+++ b/gbdk-lib/examples/cross-platform/gbdecompress/Makefile
@@ -58,6 +58,11 @@ OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Use png2asset to convert the png into C formatted metasprite data
 # -sh 48   : Sets sprite height to 48 (width remains automatic)
 # -spr8x16 : Use 8x16 hardware sprites

--- a/gbdk-lib/examples/cross-platform/gbprinter/Makefile
+++ b/gbdk-lib/examples/cross-platform/gbprinter/Makefile
@@ -61,6 +61,11 @@ CFLAGS += -I$(OBJDIR)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Use png2asset to convert the png into C formatted map data
 # -c ...   : Set C output file
 # Convert metasprite .pngs in res/ -> .c files in obj/<platform ext>/src/

--- a/gbdk-lib/examples/cross-platform/incbin/Makefile
+++ b/gbdk-lib/examples/cross-platform/incbin/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/irq/Makefile
+++ b/gbdk-lib/examples/cross-platform/irq/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/joytest/Makefile
+++ b/gbdk-lib/examples/cross-platform/joytest/Makefile
@@ -47,6 +47,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/large_map/Makefile
+++ b/gbdk-lib/examples/cross-platform/large_map/Makefile
@@ -71,6 +71,11 @@ CFLAGS += -I$(OBJDIR)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Use png2asset to convert the png into C formatted map data
 # -c ...   : Set C output file
 # Convert metasprite .pngs in res/ -> .c files in obj/<platform ext>/src/

--- a/gbdk-lib/examples/cross-platform/libc_memcpy/Makefile
+++ b/gbdk-lib/examples/cross-platform/libc_memcpy/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/libc_string/Makefile
+++ b/gbdk-lib/examples/cross-platform/libc_string/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/logo/Makefile
+++ b/gbdk-lib/examples/cross-platform/logo/Makefile
@@ -59,6 +59,11 @@ OBJS        = $(IMAGES:%.png=$(OBJDIR)/%.o) $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMS
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 .SECONDEXPANSION:
 $(OBJDIR)/%.c: $(RESDIR)/%.png $$(wildcard $(RESDIR)/gfx/$(PLAT)/backgrounds/%.png.meta)
 	$(PNG2ASSETS) $< `cat <$<.meta 2>/dev/null` -c $@

--- a/gbdk-lib/examples/cross-platform/metasprites/Makefile
+++ b/gbdk-lib/examples/cross-platform/metasprites/Makefile
@@ -59,6 +59,11 @@ OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Use png2asset to convert the png into C formatted metasprite data
 # -sh 48   : Sets sprite height to 48 (width remains automatic)
 # -spr8x16 : Use 8x16 hardware sprites

--- a/gbdk-lib/examples/cross-platform/multiplayer/Makefile
+++ b/gbdk-lib/examples/cross-platform/multiplayer/Makefile
@@ -47,6 +47,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/pong/Makefile
+++ b/gbdk-lib/examples/cross-platform/pong/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/randtest/Makefile
+++ b/gbdk-lib/examples/cross-platform/randtest/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/rle_map/Makefile
+++ b/gbdk-lib/examples/cross-platform/rle_map/Makefile
@@ -56,6 +56,11 @@ OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/scroller/Makefile
+++ b/gbdk-lib/examples/cross-platform/scroller/Makefile
@@ -48,6 +48,11 @@ OBJS       = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/simple_physics/Makefile
+++ b/gbdk-lib/examples/cross-platform/simple_physics/Makefile
@@ -59,6 +59,11 @@ OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Use png2asset to convert the png into C formatted metasprite data
 # -sh 48   : Sets sprite height to 48 (width remains automatic)
 # -spr8x16 : Use 8x16 hardware sprites

--- a/gbdk-lib/examples/cross-platform/sram_banks/Makefile
+++ b/gbdk-lib/examples/cross-platform/sram_banks/Makefile
@@ -50,6 +50,11 @@ OBJS        = $(CSOURCES:%.c=$(OBJDIR)/%.o) $(ASMSOURCES:%.s=$(OBJDIR)/%.o)
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/text_advanced_dialogue/Makefile
+++ b/gbdk-lib/examples/cross-platform/text_advanced_dialogue/Makefile
@@ -60,6 +60,11 @@ PNG2ASSET_BKG_SETTINGS_pocket=
 # Builds all targets sequentially
 all: $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -I$(GENDIR) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/text_basic/Makefile
+++ b/gbdk-lib/examples/cross-platform/text_basic/Makefile
@@ -62,6 +62,11 @@ PNG2ASSET_BKG_SETTINGS_pocket=
 # Builds all targets sequentially
 all:  $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -I$(GENDIR) -c -o $@ $<

--- a/gbdk-lib/examples/cross-platform/text_typewriter/Makefile
+++ b/gbdk-lib/examples/cross-platform/text_typewriter/Makefile
@@ -62,6 +62,11 @@ PNG2ASSET_BKG_SETTINGS_pocket=
 # Builds all targets sequentially
 all:  $(TARGETS)
 
+compile.bat: Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | grep -v make >> compile.bat
+
+
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c
 	$(LCC) $(LCCFLAGS) $(CFLAGS) -I$(GENDIR) -c -o $@ $<

--- a/gbdk-lib/examples/megaduck/laptop_keyboard/Makefile
+++ b/gbdk-lib/examples/megaduck/laptop_keyboard/Makefile
@@ -60,6 +60,10 @@ all: $(TARGETS)
 test:
 	echo $(CSOURCES)
 
+compile.bat:	Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
+
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/megaduck/laptop_printer/Makefile
+++ b/gbdk-lib/examples/megaduck/laptop_printer/Makefile
@@ -60,6 +60,10 @@ all: $(TARGETS)
 test:
 	echo $(CSOURCES)
 
+compile.bat:	Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
+
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/megaduck/laptop_rtc/Makefile
+++ b/gbdk-lib/examples/megaduck/laptop_rtc/Makefile
@@ -60,6 +60,10 @@ all: $(TARGETS)
 test:
 	echo $(CSOURCES)
 
+compile.bat:	Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
+
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c

--- a/gbdk-lib/examples/megaduck/laptop_speech/Makefile
+++ b/gbdk-lib/examples/megaduck/laptop_speech/Makefile
@@ -60,6 +60,10 @@ all: $(TARGETS)
 test:
 	echo $(CSOURCES)
 
+compile.bat:	Makefile
+	@echo "REM Automatically generated from Makefile" > compile.bat
+	@make -sn | sed y/\\//\\\\/ | sed s/mkdir\ -p\/mkdir\/ | grep -v make >> compile.bat
+
 
 # Compile .c files in "src/" to .o object files
 $(OBJDIR)/%.o:	$(SRCDIR)/%.c


### PR DESCRIPTION
- Add missing target to some makefiles
- Fix megaduck and cross-platform folders not in list of folders to process