### PR TITLE
Docs: preliminary updates for 4.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TOPDIR = $(shell pwd)
 # Package name, used for tarballs
 PKG = gbdk
 # Version, used for tarballs & docs
-VER = 4.4.0
+VER = 4.5.0
 
 PORTS=sm83 z80 mos6502
 PLATFORMS=gb ap duck gg sms msxdos nes

--- a/docs/config/gbdk-2020-doxyfile
+++ b/docs/config/gbdk-2020-doxyfile
@@ -13,6 +13,9 @@
 # TAG += value [value, ...]
 # Values that contain spaces should be placed between quotes (\" \").
 
+# Requires a patched build of doxygen (see patch in same folder)
+USE_READABLE_ANCHORS = YES
+
 #---------------------------------------------------------------------------
 # Project related configuration options
 #---------------------------------------------------------------------------

--- a/docs/pages/09_migrating_new_versions.md
+++ b/docs/pages/09_migrating_new_versions.md
@@ -4,6 +4,22 @@ This section contains information that may be useful to know or important when u
 
 # GBDK-2020 versions
 
+## Porting to GBDK-2020 4.5.0
+  - GBDK now requires ~SDCC 4.5.0 or higher with GBDK-2020 patches for the z80, sm83 and NES
+  - Build Host:
+    - Changed from building on MacOS 13 to MacOS 15 for 64 bit Intel
+    - Changed from building on Windows 2019 to 2022 for Intel
+  - SMS/GG
+    - Changed parameter order of @ref set_tile_submap(), @ref set_tile_submap_compat()
+    - Remove broken and unused `FAST_DIV8` macro
+    - Removed legacy `___sdcc_bcall trampoline`
+  - MegaDuck
+    - Renamed `DUCK_IO_CMD_PRINT_INIT_MAYBE_EXT_IO` to @ref DUCK_IO_CMD_PRINT_INIT_EXT_IO
+    - Removed`duck_io_printer_detected()`, `duck_io_printer_type()` and replaced them with  @ref duck_io_printer_query(), @ref duck_io_printer_last_status()
+  - png2asset
+    - Fixed missing error for `-bin` requiring `-map`
+
+
 ## Porting to GBDK-2020 4.4.0
   - GBDK now requires ~SDCC 4.5.0 or higher with GBDK-2020 patches for the z80 and NES
   - Build Host:

--- a/docs/pages/10_release_notes.md
+++ b/docs/pages/10_release_notes.md
@@ -6,6 +6,70 @@ https://github.com/gbdk-2020/gbdk-2020/releases
 
 # GBDK-2020 Release Notes
 
+## GBDK-2020 4.5.0
+  202x/xx
+  - SDCC
+    - Added HRAM area access for sm83
+    - Added `#pragma dataseg DATA_<N>` support for sm83 and z80 platforms
+    - [Patched SDCC Builds](https://github.com/gbdk-2020/gbdk-2020-sdcc/releases) with support for all platforms are used.
+    - See the [github workflow](https://github.com/gbdk-2020/gbdk-2020-sdcc/tree/main/.github/workflows) for details.
+  - Library
+    - Added ability to dynamically allocate HRAM variables for GB/AP/Duck
+    - Added zx0 decompression support: @ref zx0_decompress()
+    - Changed NULL definition in @ref types.h to match @ref stddef.h
+    - Fixed escaping `%` symbol in printf() and sprintf()
+    - GB/AP/Duck
+      - Improved @ref get_bkg_xy_addr(), @ref get_win_xy_addr()
+      - Improved performance for banked calls
+    - SMS/GG
+      - Changed GG "not interrrupt" link port control bit constant from `GGEXT_NINIT` to @ref GGEXT_NINT
+      - Remove broken and unused `FAST_DIV8` macro
+      - Removed legacy `___sdcc_bcall` trampoline
+      - Fixed parameter order of @ref set_tile_submap(), @ref set_tile_submap_compat()
+      - Fixed tilemap width not set correctly in @ref set_tile_submap_compat()
+    - NES
+      - Remove broken and unused `FAST_DIV8` macro
+  - Examples
+    - Added HRAM variable example for GB/AP/Duck
+    - Added SRAM bank example for new `#pragma dataseg DATA_<N>`
+    - Added MegaDuck and Game Gear support to Game Boy Printer example
+    - Added missing compile.bat for some examples
+    - Improved the Text Scroller example
+    - Improved RLE compress example to convert and compress map at build time
+    - Fixed Platformer example incorrectly using `-keep_duplicate_tiles` flag
+    - Fixed Text Advanced Dialogue example printing (Rodrigo Card)
+    - Game Boy
+      - Added MBC5 Rumble example (Ev3)
+      - Improved Rand example with fast modulo, triangle and bell curve distributions
+      - Fixed Sound example not writing length when length bit enabled and triggering channel
+    - MegaDuck
+      - Added MegaDuck Laptop Printer example
+    - SMS
+      - Added NMI handler example
+  - Toolchain / Utilities
+    - @ref utility_png2asset "png2asset"
+      - Added binary palette export for `-bin` mode
+      - Added logging of conversion arguments to `.c` and `.h` output files
+        - Path is stripped to avoid potential unwanted username/etc disclosure
+      - Added `-use_metafile` option to load arguments from `<inputfile>.meta`
+      - Changed to separate attribute array for `-use_map_attributes` + `-use_structs`  with SMS/GG
+      - Fixed broken transparency for SGB borders with more than one 16 color palette
+      - Fixed missing error for `-bin` requiring `-map`
+      - Fixed incorrect line breaks and trailing spaces in output
+    - @ref bankpack
+      - Changed Linkerfile output order to match packing order for use with asm .bndry alignment in rom banks
+        - First non-banked, then fixed bank, then auto-banked. Banknum ascending, size descending
+      - Improved bank assignment printout
+    - @ref utility_gbcompress "gbcompress"
+      - Added include guards for header file output (Rodrigo Card)
+      - Added zx0 compression and decompression mode: `--alg=zx0`
+    - @ref utility_romusage "romusage"
+      - Fixed missing error when filename not present
+  - Docs:
+    - Improved html style and mobile web formatting
+    - Various updates and improvements
+
+
 ## GBDK-2020 4.4.0
   2025/05
   - Includes SDCC version ~4.5.0 (15267) with GBDK-2020 patches for Z80 and NES
@@ -81,6 +145,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - Added MegaDuck Laptop model examples for keyboard, RTC and speech
   - Docs:
     - Added Cart SRAM Max Size to MBC Chart and clarify battery/save meaning
+    - Various updates and improvements
 
 
 ## GBDK-2020 4.3.0
@@ -124,7 +189,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
       - Added Game Gear registers and definitions
         - `GG_STATE`: @ref GGSTATE_STT, @ref GGSTATE_NJAP, @ref GGSTATE_NNTS
         - `GG_EXT_7BIT`
-        - `GG_EXT_CTL`: @ref GGEXT_NINIT
+        - `GG_EXT_CTL`: `GGEXT_NINIT`
         - `GG_SIO_SEND`
         - `GG_SIO_RECV`
         - `GG_SIO_CTL`: @ref SIOCTL_TXFL, @ref SIOCTL_RXRD, @ref SIOCTL_FRER, @ref SIOCTL_INT, @ref SIOCTL_TON, @ref SIOCTL_RON, @ref SIOCTL_BS0, @ref SIOCTL_BS1
@@ -359,7 +424,7 @@ https://github.com/gbdk-2020/gbdk-2020/releases
   - Building GBDK
     - Changed to target older version of macOS (10.10) when building for better compatibility
   - Platforms
-    - Added support for Mega Duck / Cougar Boy (`duck`). See @ref docs_supported_consoles
+    - Added support for MegaDuck / Cougar Boy (`duck`). See @ref docs_supported_consoles
   - Library
     - Added @ref memcmp()
     - Added @ref add_low_priority_TIM() function for timer interrupts which allow nesting for GB/CGB

--- a/docs/pages/20_toolchain_settings.md
+++ b/docs/pages/20_toolchain_settings.md
@@ -542,6 +542,10 @@ Options:
                               0: vertical arrangement / horizontal mirroring
                               1: horizontal arrangement / vertical mirroring
   -b   Battery bit set (default: 0)
+  -a   Alternative nametable layout (default: 0)
+Arguments:
+  <in_file>      optional binary input file, '-' means stdin. (default: stdin)
+  <out_file>     optional .nes output file, '-' means stdout. (default: stdout)
 ```
 @anchor gbcompress-settings
 # gbcompress settings
@@ -556,7 +560,7 @@ Options
 --cin    : Read input as .c source format (8 bit char ONLY, uses first array found)
 --cout   : Write output in .c / .h source format (8 bit char ONLY) 
 --varname=<NAME> : specify variable name for c source output
---alg=<type>     : specify compression type: 'rle', 'gb' (default)
+--alg=<type>     : specify compression type: 'zx0', 'rle', 'gb' (default)
 --bank=<num>     : Add Bank Ref: 1 - 511 (default is none, with --cout only)
 Example: "gbcompress binaryfile.bin compressed.bin"
 Example: "gbcompress -d compressedfile.bin decompressed.bin"
@@ -604,9 +608,10 @@ usage: png2asset    <file>.png [options]
 -entity_tileset     (maps only) mark matching tiles counting from 255 down, entity patterns not exported
 -keep_duplicate_tiles   do not remove duplicate tiles (default: not enabled)
 -no_palettes        do not export palette data
--bin                export to binary format
+-bin                export to binary format (requires -map)
 -transposed         export transposed (column-by-column instead of row-by-row)
 -rel_paths          paths to tilesets are relative to the input file path
+-use_metafile       Read extra options from file <inputfile>.meta (file missing not an error)
 decoder error empty input buffer given to decoder. Maybe caused by non-existing file?
 ```
 @anchor png2hicolorgb-settings
@@ -659,7 +664,7 @@ Historical credits and info:
 # romusage settings
 ```
 romusage input_file.[map|noi|ihx|cdb|.gb[c]|.pocket|.duck|.gg|.sms] [options]
-version 1.3.1, by bbbbbr
+version 1.3.2, by bbbbbr
 
 Options
 -h  : Show this help

--- a/gbdk-lib/include/duck/laptop_io.h
+++ b/gbdk-lib/include/duck/laptop_io.h
@@ -89,7 +89,7 @@
 
 
 // Printer init reply related
-// Init Reply Bit.0
+// Init Reply Bits:1..0
 #define DUCK_IO_PRINTER_FAIL        0x00u
 #define DUCK_IO_PRINTER_TYPE_2_PASS 0x01u // Bit.1 = 0  // 13 x 12 byte packets + 1 x 5 or 6 byte packet (with CR and/or LF)
 #define DUCK_IO_PRINTER_TYPE_1_PASS 0x02u // Bit.1 = 1  // 3 x 12 byte packets + 118 non-packet bytes
@@ -165,11 +165,16 @@ bool duck_io_laptop_init(void);
 
 /** Returns status of MegaDuck Printer as last detected by duck_io_laptop_init() or duck_io_printer_query()
 
-    Returned unsigned 8 bit value will have:
-    \li @ref Bit 0: Printer Status. Mask with @ref DUCK_IO_PRINTER_INIT_OK
-    \li @ref Bit 1: Printer Type. Mask with @ref DUCK_IO_PRINTER_TYPE_MASK
+    Should be called immediately before trying to print
+
+    Returned unsigned 8 bit value will have Printer Type
+    and Status in bits 1..0
+
+    The resulting value will be cached and used for
+    any subsequent duck_io_printer_last_status() calls.
 
     @ref duck_io_laptop_init() must be called first
+    @see DUCK_IO_PRINTER_FAIL, DUCK_IO_PRINTER_TYPE_2_PASS, DUCK_IO_PRINTER_TYPE_1_PASS, DUCK_IO_PRINTER_MAYBE_BUSY    
 */
 uint8_t duck_io_printer_last_status(void);
 
@@ -178,15 +183,14 @@ uint8_t duck_io_printer_last_status(void);
 
     Should be called immediately before trying to print
 
-    Returned unsigned 8 bit value will have:
-    \li @ref Bit 0: Printer Status. Mask with @ref DUCK_IO_PRINTER_INIT_OK
-    \li @ref Bit 1: Printer Type. Mask with @ref DUCK_IO_PRINTER_TYPE_MASK
+    Returned unsigned 8 bit value will have Printer Type
+    and Status in bits 1..0
 
     The resulting value will be cached and used for
-    any subsequent duck_io_printer_detected() and 
-    duck_io_printer_type() calls.
+    any subsequent duck_io_printer_last_status() calls.
 
     @ref duck_io_laptop_init() must be called first
+    @see duck_io_printer_last_status(), DUCK_IO_PRINTER_FAIL, DUCK_IO_PRINTER_TYPE_2_PASS, DUCK_IO_PRINTER_TYPE_1_PASS, DUCK_IO_PRINTER_MAYBE_BUSY    
 */
 uint8_t duck_io_printer_query(void);
 

--- a/gbdk-lib/include/gbdk/zx0decompress.h
+++ b/gbdk-lib/include/gbdk/zx0decompress.h
@@ -3,6 +3,18 @@
 
 #if defined(__TARGET_gb) || defined(__TARGET_ap) || defined(__TARGET_duck) || defined(__TARGET_sms) || defined(__TARGET_gg) || defined(__TARGET_msx)
 
+/** Decompress zx0 compressed data from sour into dest
+
+    @param sour   Pointer to source zx0 compressed data
+    @param dest   Pointer to destination buffer/address
+
+    Will decompress __all__ of it's data to destination without
+    stopping until the end of compressed data is reached. It is
+    not possible to set a limit, so ensure the destination buffer
+    has sufficient space to avoid an overflow.
+
+    Decompresses data which has been compressed with @ref utility_gbcompress "gbcompress" using the `--alg=zx0` argument.
+*/
 void zx0_decompress(void * sour, void * dest);
 
 #endif


### PR DESCRIPTION
Docs: Update changelog / migration through Dec 5, 2025 / 29e436c835bbee0b1acc88bddebbd0f6f7a7a5f8
- Enable readable anchors in doxyfile
- Minor MegaDuck printer docs updates
- ZX0 compression updates
- update doxygen version to 4.5.0
- toolchain settings update