### PR TITLE
NES: Refactor fill_bkg_rect to call set_bkg_tile_xy

### DIFF
--- a/gbdk-lib/libc/targets/mos6502/nes/fill_rect_bk.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/fill_rect_bk.s
@@ -1,93 +1,47 @@
     .include    "global.s"
 
     .area   GBDKOVR (PAG, OVR)
+    .fill_bkg_rect_padding::    .ds 4   ; Padding to avoid clash with _set_bkg_tile_xy vars
     _fill_bkg_rect_PARM_3::     .ds 1
     _fill_bkg_rect_PARM_4::     .ds 1
     _fill_bkg_rect_PARM_5::     .ds 1
     .xpos:                      .ds 1
     .ypos:                      .ds 1
+    .xpos_save:                 .ds 1
+    .width_save:                .ds 1
 
     .area   _HOME
 
 _fill_bkg_rect::
-    ; TODO: Switch to use vram transfer buffer when screen not blanked
     .define .width  "_fill_bkg_rect_PARM_3"
     .define .height "_fill_bkg_rect_PARM_4"
     .define .tile   "_fill_bkg_rect_PARM_5"
     sta *.xpos
+    sta *.xpos_save
     stx *.ypos
-    ldy *.height
-    ; Prefer vertical stripes if height > width
-    cpy *.width
-    beq _fill_bkg_rect_horizontalStripes
-    bcs _fill_bkg_rect_verticalStripes
-_fill_bkg_rect_horizontalStripes:
-1$:
-    lda #0
-    sta *.tmp+1
-    lda *.ypos
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    ora *.xpos
-    sta *.tmp
-    ;
-    lda *.tmp+1
-    ora #0x20
-    tax
-    lda *.tmp
-    jsr .ppu_stripe_begin_horizontal
-    ldx *.width
-2$:
+    lda *.width
+    sta *.width_save
     lda *.tile
-    jsr .ppu_stripe_write_byte
-    dex
-    bne 2$
-    jsr .ppu_stripe_end
-    inc *.ypos
-    dey
-    bne 1$
-    rts
-
-_fill_bkg_rect_verticalStripes:
-    ldy *.width
+    sta *_set_bkg_tile_xy_PARM_3
 1$:
-    lda #0
-    sta *.tmp+1
-    lda *.ypos
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    asl
-    rol *.tmp+1
-    ora *.xpos
-    sta *.tmp
-    ;
-    lda *.tmp+1
-    ora #0x20
-    tax
-    lda *.tmp
-    jsr .ppu_stripe_begin_vertical
-    ldx *.height
-2$:
-    lda *.tile
-    jsr .ppu_stripe_write_byte
-    dex
-    bne 2$
-    jsr .ppu_stripe_end
+    lda *.xpos
+    and #.DEVICE_SCREEN_BUFFER_WIDTH-1
+    ldx *.ypos
+    jsr _set_bkg_tile_xy
     inc *.xpos
-    dey
+    dec *.width
+    bne 1$
+    lda *.xpos_save
+    sta *.xpos
+    lda *.width_save
+    sta *.width
+    inc *.ypos
+    lda *.ypos
+    cmp #.DEVICE_SCREEN_BUFFER_HEIGHT
+    bne 0$
+    lda #0
+0$:
+    sta *.ypos
+    dec *.height
     bne 1$
     rts


### PR DESCRIPTION
- Somewhat slower code, but smaller

- Enables correct wrap-around over screen edges

- Works for all nametable layouts