### PR TITLE
Minor optimisation of .MemsetSmall for the sm83

### DIFF
--- a/gbdk-lib/libc/targets/sm83/ap/crt0.s
+++ b/gbdk-lib/libc/targets/sm83/ap/crt0.s
@@ -24,6 +24,9 @@
 .MemsetSmall::
         LD      (HL+),A
         DEC     C
+        RET     Z
+        LD      (HL+),A
+        DEC     C
         JR      NZ,.MemsetSmall
         ret
 


### PR DESCRIPTION
The new implementation saves 1 M-cycle for each 2 bytes that are set, it also saves one more M-cycle if the number of bytes that are set is odd.
It still fits under the 8 byte limit of a rst handler.