### PR TITLE
png2asset: fix header output for -use_structs -tiles_only

### DIFF
--- a/gbdk-support/png2asset/export_h_file.cpp
+++ b/gbdk-support/png2asset/export_h_file.cpp
@@ -93,8 +93,16 @@ static void export_h_use_structs(PNG2AssetData* assetData, FILE* file) {
         fprintf(file, "#include \"TilesInfo.h\"\n");
         fprintf(file, "#include \"MapInfo.h\"\n");
         fprintf(file, "\n");
-        fprintf(file, "extern const struct TilesInfo %s_tiles_info;\n", assetData->args->data_name.c_str());
-        fprintf(file, "extern const struct MapInfo %s;\n", assetData->args->data_name.c_str());
+        // Analogous to "(output_mode == ZGB_TILES_MODE_TILESONLY)" in the C output
+        if ((assetData->args->includeTileData) && (!assetData->args->includedMapOrMetaspriteData)) {
+            // ZGB Tiles-only mode doesn't append "_tiles_info" to the struct name (and lacks a BANKREF output in the C output)
+            fprintf(file, "extern const struct TilesInfo %s;\n", assetData->args->data_name.c_str());
+        }
+        else { // implied (output_mode == ZGB_TILES_MODE_NORMAL)
+            fprintf(file, "extern const struct TilesInfo %s_tiles_info;\n", assetData->args->data_name.c_str());
+            fprintf(file, "extern const struct MapInfo %s;\n", assetData->args->data_name.c_str());
+        }
+
     }
     else {
         fprintf(file, "#include \"MetaSpriteInfo.h\"\n");

--- a/gbdk-support/png2asset/testing/ref/zgb_sushi_tiles.h
+++ b/gbdk-support/png2asset/testing/ref/zgb_sushi_tiles.h
@@ -11,7 +11,6 @@
 #include "TilesInfo.h"
 #include "MapInfo.h"
 
-extern const struct TilesInfo zgb_sushi_tiles_tiles_info;
-extern const struct MapInfo zgb_sushi_tiles;
+extern const struct TilesInfo zgb_sushi_tiles;
 
 #endif

--- a/gbdk-support/png2asset/testing/ref/zgb_sushi_tiles_lit.h
+++ b/gbdk-support/png2asset/testing/ref/zgb_sushi_tiles_lit.h
@@ -11,7 +11,6 @@
 #include "TilesInfo.h"
 #include "MapInfo.h"
 
-extern const struct TilesInfo zgb_sushi_tiles_lit_tiles_info;
-extern const struct MapInfo zgb_sushi_tiles_lit;
+extern const struct TilesInfo zgb_sushi_tiles_lit;
 
 #endif


### PR DESCRIPTION
- MapInfo should not be emitted
- TilesInfo should have name shortened
- Update test output