### PR TITLE
Bug fix + Further optimization of divisions (testing required)

### DIFF
--- a/gbdk-lib/libc/asm/sm83/div.s
+++ b/gbdk-lib/libc/asm/sm83/div.s
@@ -49,89 +49,104 @@ __divuchar:
         ld d, a
         ; Fall through .divmod_uint_bcde
 .divmod_uint_bcde:
-
-
-	    ; stores -Y in hl and check that -Y is not zero
+__divuint::
+		; computes the quotient and the remainder of X / Y
+        ; X is stored in de
+        ; Y is stored in bc
+        ; outputs the quotient in bc
+        ; outputs the remainder in de
+        ; if Y = 0 then the carry is set and quotient = 0 and remainder = 0
+        ; otherwise the carry is cleared
+		
+	    ; stores -Y in hl
         xor a
 		sub c
 		ld l, a
 		sbc a
 		sub b
 		ld h, a
+
+		inc a
+		jr z, small_y				; jump if 1 <= Y <= 256
 		
+		ld a, h
 		or l
-        jr z, .division_by_zero
+		jr z, division_by_zero
 
-
-		inc h
-		jr z, 0$
-		dec h
+		; if this part of the code is reached then Y > 256
+		; Thus the quotient will fit within 8 bits
 		xor a
-		;ld b, a
-4$:
+		ld b, a				; set the upper byte of the quotient to 0
+
+		; computes the largest K such that ((-Y) << K) fits within 16 bits
+		; ((-Y) << (K + 1)) will be stored in hl
+		; K will be placed as a base 1 number using the most significant bits of C
+0$:
 		rra
 		add hl, hl
-		jr c, 4$
-		;ld c, a
+		jr c, 0$
+		ld c, a
 
-		;;ld bc, hl
-		;;ld hl, de
-
-		;;ld e, a
-		;;ld d, #0
-		
-		;ld a, h
-		;ld h, d
-		;ld d, a
-
-		;ld a, l
-		;ld l, e
-		;ld e, a
-		
-		jr last_loop
-0$:
-		dec c
-		jr z, ...
-		
-		ld c, h			; c = 0
 		ld a, l
+		ld l, e
+		ld e, a
+
+		ld a, d
+		jr ld_dh_ha
+small_y:
+		jr c, division_by_256			; the algorithm below breaks if Y = 256
+		; It would have been possible to check for 0 <= Y < 256 when jumping to small_y
+		; However this would be slower by a few cycles
+		; Doing it this way also makes divisions by 256 extremely fast compared to other divisions
 		
-		;;cp #0xF0
-		;;jr c, 10$
-		;;ld c, #0xF0
-		;;swap a
-		;;and c
-10$:
-		;;ccf
-1$:
-		rr c
-		add a
+		dec c
+		jr z, division_by_one			; the algorithm below also breaks if Y = 1
+		
+		ld a, l
+		ld l, e
+		ld e, b			; e = 0
+
+		; performs 4 iterations of the next loop at once if possible
+		; a failed check costs 3 cycles
+		; a successful check saves 14 cycles
+		cp #0xF0
 		jr c, 1$
 
-		;;ld l, a
-		;ld c, a
-		ld a, d
-2$:
-		rr l
-		add l
-		jr c, 3$
-		sub l
-3$:
-		rl c
-		jr c, 2$
-
-		ld h, a
-		ld d, l
-		ld l, b		; l = 0
-
-		ld b, c
-		ld c, #0xFE
+		ld b, #0xE0
+		add a
+		add a
+		add a
+		add a
+0$:
+		rr b
+1$:
+		add a
+		jr c, 0$
 		
-last_loop:
+		ld h, a
+		ld a, d
+
+		; computes the high byte of the quotient and stores it in B
+loop_b:
+		rr h
+		add h
+		jr c, 0$
+		sub h
+0$:
+		rl b
+		jr c, loop_b
+		
+		ld c, #0xFE
+		scf
+ld_dh_ha:
+		ld d, h
+		ld h, a
+
+		; computes the low byte of the quotient and stores it in C
+loop_c:
 		rr d
 		rr e
 
-		; 7/8
 		ld a, l
 		add e
 		ld a, h
@@ -140,152 +155,29 @@ last_loop:
 		add hl, de
 0$:		
 		rl c
-		jr c, last_loop
-
+		jr c, loop_c
+ret_hl_in_de:
 		ld d, h
 		ld e, l
 		ret
-
-__divuint::
-        ; computes the quotient and the remainder of X / Y
-        ; X is stored in de
-        ; Y is stored in bc
-        ; outputs the quotient in bc
-        ; outputs the remainder in de
-        ; if Y = 0 then the carry is set and quotient = 0 and remainder = 0
-        ; otherwise the carry is cleared
-		
-        
-        ; stores -Y in hl and check that -Y is not zero
-        xor a
-		sub c
-		ld l, a
-		sbc a
-		sub b
-		ld h, a
-		
-		or l
-        jr z, .division_by_zero
-
-		; computes a large K such that (Y << K) is still a 16 bit number
-		;   K will be stored in BC as a base 1 number
-		;   Y << (K + 1) will be stored in HL and the carry will be used to store its 17th bit
-		
-		ld a, h
-		inc a
-		jr z, 1$
-		xor a
-		ld c, a
-0$:
-		rra
-		add hl, hl
-		jr c, 0$
-		ld b, a
-		
-		jr 3$
-1$:
-		ld h, l
-		ld l, a			; l = 0
-		ld c, a			; c = 0
-		ld b, #0xFF
-		
-    	
-		ccf
-		jr c, 3$
-
-		ld a, h
-		cp #0xF0
-		jr c, 11$
-		ld c, #0xF0
-		swap a
-		and c
-		ld h, a
-11$:
+division_by_zero:
 		scf
-2$:
-		rr c
-		add a
-		jr c, 2$
-
-		ld h, a
-3$:	
-        ; swaps the content of hl and de
-        ld a, h
-        ld h, d
-        ld d, a
-        
-        ld a, l
-        ld l, e
-        ld e, a
-		
-10$:
-		rr d
-		rr e
-
-		sla c
-		rl  b
-		
-		ld a, e 
-        add l
-        ld a, d
-        adc h
-		jr nc, 10$
-11$:
-        ; computes X / Y one bit at a time using the following algorithm
-        ; r = X
-        ; q  = 0
-        ; while K >= 0
-        ;	b = 0
-        ;	if (Y << K) <= r then
-        ;		r += -(Y << K)
-        ;		b = 1
-        ;	q = (q << 1) | b
-        ;	K -= 1
-        ;
-        ; 
-        ; r is stored in hl
-        ; q is stored in bc
-        ; storing both q and K in bc will not create issue as they will not use the same bits at the same time
-        ; -(Y << K) is stored in de
-4$:
-        ; on the first iteration :
-        ;	this shifts DE such that DE now stores -(Y << K)
-        ; on every iteration but the first:
-        ;	transforms -(Y << K) into -(Y << (K-1))
-        ;	sra d is not used as the MSB should always be filled with a 1 when shifting de
-        ;	this works because the carry will always be set if this is not the first iteration
-        rr  d
-        rr  e
-        
-        ; compare remainder with (Y << K)
-        ld a, e 
-        add l
-        ld a, d
-        adc h
-        
-        jr nc, 5$
-        add hl, de
-5$:
-        ; fill bc with one bit of the result and decrements K at the same time
-        rl c
-        rl b
-        
-        jr c, 4$
-ret_hl_in_de:
-        ld d, h
-        ld e, l
-        ; status of the registers
-        ; bc = quotient
-        ; de = remainder
-        ; carry = 0 if Y != 0, 1 if Y == 0
-        
-        ret
-.division_by_zero:
-        ; returns both a quotient of 0 and a remainder of 0
-        ; if this is reached, then bc = 0
-        scf
+		; hl and bc are both expected to be 0
 		jr ret_hl_in_de
-
+division_by_one:
+		ld b, d
+		ld c, e
+		; a is expected to be 0
+		ld d, a
+		ld e, a
+		; the carry is expected to be clear
+		ret
+division_by_256:
+		xor a			; clears the carry
+		ld c, d
+		ld d, a
+		ld b, a
+		ret
 
 ; mixed sign division
 

--- a/gbdk-lib/libc/asm/sm83/div.s
+++ b/gbdk-lib/libc/asm/sm83/div.s
@@ -92,37 +92,6 @@ __divuint::
 		
 		ld c, a
 3$:	
-        ; if X < Y then
-        ;	return quotient = 0 and remainder = X
-        ; else
-        ;	computes the largest (Y << K) such that (Y << K) <= X
-        ; 	put the 17 bit value -(Y << (K + 1)) into hl with the MSB stored using the carry
-        ; 	put K, using a base 1 representation, using the most significant bits of bc
-        ld bc, #0
-        
-        ld a, e
-        add l
-        ld a, d
-        adc h
-        jr c, 10$
-        ; X < Y
-        ; bc already stores 0
-        ret
-0$:
-        rr b
-        rr c
-10$:	
-        add hl, hl
-        jr nc, 1$
-        
-        ld a, e
-        add l
-        ld a, d
-        adc h
-        jr c, 0$
-        scf
-1$:
-
         ; swaps the content of hl and de
         ld a, h
         ld h, d
@@ -148,7 +117,7 @@ __divuint::
         ; q is stored in bc
         ; storing both q and K in bc will not create issue as they will not use the same bits at the same time
         ; -(Y << K) is stored in de
-2$:
+4$:
         ; on the first iteration :
         ;	this shifts DE such that DE now stores -(Y << K)
         ; on every iteration but the first:
@@ -164,14 +133,14 @@ __divuint::
         ld a, d
         adc h
         
-        jr nc, 3$
+        jr nc, 5$
         add hl, de
-3$:
+5$:
         ; fill bc with one bit of the result and decrements K at the same time
         rl c
         rl b
         
-        jr c, 2$
+        jr c, 4$
 ret_hl_in_de:
         ld d, h
         ld e, l

--- a/gbdk-lib/libc/asm/sm83/div.s
+++ b/gbdk-lib/libc/asm/sm83/div.s
@@ -49,6 +49,103 @@ __divuchar:
         ld d, a
         ; Fall through .divmod_uint_bcde
 .divmod_uint_bcde:
+
+
+	    ; stores -Y in hl and check that -Y is not zero
+        xor a
+		sub c
+		ld l, a
+		sbc a
+		sub b
+		ld h, a
+		
+		or l
+        jr z, .division_by_zero
+
+
+		inc h
+		jr z, 0$
+		dec h
+		xor a
+		;ld b, a
+4$:
+		rra
+		add hl, hl
+		jr c, 4$
+		;ld c, a
+
+		;;ld bc, hl
+		;;ld hl, de
+
+		;;ld e, a
+		;;ld d, #0
+		
+		;ld a, h
+		;ld h, d
+		;ld d, a
+
+		;ld a, l
+		;ld l, e
+		;ld e, a
+		
+		jr last_loop
+0$:
+		dec c
+		jr z, ...
+		
+		ld c, h			; c = 0
+		ld a, l
+		
+		;;cp #0xF0
+		;;jr c, 10$
+		;;ld c, #0xF0
+		;;swap a
+		;;and c
+10$:
+		;;ccf
+1$:
+		rr c
+		add a
+		jr c, 1$
+
+		;;ld l, a
+		;ld c, a
+		ld a, d
+2$:
+		rr l
+		add l
+		jr c, 3$
+		sub l
+3$:
+		rl c
+		jr c, 2$
+
+		ld h, a
+		ld d, l
+		ld l, b		; l = 0
+
+		ld b, c
+		ld c, #0xFE
+		
+last_loop:
+		rr d
+		rr e
+
+		; 7/8
+		ld a, l
+		add e
+		ld a, h
+		adc d
+		jr nc, 0$
+		add hl, de
+0$:		
+		rl c
+		jr c, last_loop
+
+		ld d, h
+		ld e, l
+		ret
+
 __divuint::
         ; computes the quotient and the remainder of X / Y
         ; X is stored in de
@@ -76,31 +173,41 @@ __divuint::
 		
 		ld a, h
 		inc a
-		ld bc, #0xFF00
-		ld a, c
 		jr z, 1$
+		xor a
+		ld c, a
 0$:
 		rra
 		add hl, hl
 		jr c, 0$
-		
 		ld b, a
+		
 		jr 3$
 1$:
 		ld h, l
-		ld l, c			; l = 0
-
-        ld a, d
-        adc h
+		ld l, a			; l = 0
+		ld c, a			; c = 0
+		ld b, #0xFF
+		
+    	
 		ccf
 		jr c, 3$
-		xor a
+
+		ld a, h
+		cp #0xF0
+		jr c, 11$
+		ld c, #0xF0
+		swap a
+		and c
+		ld h, a
+11$:
+		scf
 2$:
-		rra
-		add hl, hl
+		rr c
+		add a
 		jr c, 2$
-		
-		ld c, a
+
+		ld h, a
 3$:	
         ; swaps the content of hl and de
         ld a, h

--- a/gbdk-lib/libc/asm/sm83/div.s
+++ b/gbdk-lib/libc/asm/sm83/div.s
@@ -69,7 +69,29 @@ __divuint::
 		
 		or l
         jr z, .division_by_zero
-        
+		
+		ld a, h
+		inc a
+		ld bc, #0xFF00
+		ld a, c
+		jr z, 1$
+0$:
+		rra
+		add hl, hl
+		jr c, 0$
+		
+		ld b, a
+		jr 3$
+1$:
+		ld h, l
+		ld l, c			; l = 0
+2$:
+		rra
+		add hl, hl
+		jr c, 2$
+		
+		ld c, a
+3$:	
         ; if X < Y then
         ;	return quotient = 0 and remainder = X
         ; else

--- a/gbdk-lib/libc/asm/sm83/div.s
+++ b/gbdk-lib/libc/asm/sm83/div.s
@@ -69,6 +69,10 @@ __divuint::
 		
 		or l
         jr z, .division_by_zero
+
+		; computes a large K such that (Y << K) is still a 16 bit number
+		;   K will be stored in BC as a base 1 number
+		;   Y << (K + 1) will be stored in HL and the carry will be used to store its 17th bit
 		
 		ld a, h
 		inc a
@@ -85,6 +89,12 @@ __divuint::
 1$:
 		ld h, l
 		ld l, c			; l = 0
+
+        ld a, d
+        adc h
+		ccf
+		jr c, 3$
+		xor a
 2$:
 		rra
 		add hl, hl
@@ -100,7 +110,20 @@ __divuint::
         ld a, l
         ld l, e
         ld e, a
-        
+		
+10$:
+		rr d
+		rr e
+
+		sla c
+		rl  b
+		
+		ld a, e 
+        add l
+        ld a, d
+        adc h
+		jr nc, 10$
+11$:
         ; computes X / Y one bit at a time using the following algorithm
         ; r = X
         ; q  = 0


### PR DESCRIPTION
The worst case for this code runs in about 280 M-cycles, as opposed to a worst case that runs in about 580 M-cycles for the previous division code.
It also fixes a bug where a division by one could make the program run endlessly if the dividend is large enough.