### PR TITLE
Fix divisions by one

### DIFF
--- a/gbdk-lib/libc/asm/sm83/div.s
+++ b/gbdk-lib/libc/asm/sm83/div.s
@@ -69,7 +69,12 @@ __divuint::
 		
 		or l
         jr z, .division_by_zero
-        
+
+		ld a, l
+		and h
+		inc a
+		jr z, .division_by_one
+		
         ; if X < Y then
         ;	return quotient = 0 and remainder = X
         ; else
@@ -164,6 +169,16 @@ ret_hl_in_de:
         ; if this is reached, then bc = 0
         scf
 		jr ret_hl_in_de
+.division_by_one:
+		; returns a remainder of 0 and a quotient of X
+		ld c, e
+		ld b, d
+		
+		; a is assumed to store 0
+		ld d, a
+		ld e, a
+		
+		ret
 
 
 ; mixed sign division


### PR DESCRIPTION
Computing 65535 / 1 would make the program run into an endless loop
Computing X / 1 with a large enough X would return a wrong answer