### PR TITLE
Small optimization of ___move_metasprite for the sm83 port

### DIFF
--- a/gbdk-lib/libc/targets/sm83/metasprites.s
+++ b/gbdk-lib/libc/targets/sm83/metasprites.s
@@ -27,10 +27,8 @@ ___render_shadow_OAM::
 
 ___move_metasprite::
         cp      #40
-        jr      c, 0$
-        xor     a
-        ret
-0$:
+        jr      nc, .sprite_limit
+
         push    af
         add     a
         add     a
@@ -64,7 +62,7 @@ ___move_metasprite::
         ld      (bc), a
         inc     c
 
-	ld      a, (___current_base_prop)
+		ld      a, (___current_base_prop)
         add     (hl)        ; props
         inc     hl
         ld      (bc), a
@@ -75,9 +73,12 @@ ___move_metasprite::
         jr      c, 1$
 2$:
         ld      a, c
-        srl     a
-        srl     a
+		rrca
+		rrca
         pop     de
         sub     d
 
         ret
+.sprite_limit:
+		xor a
+		ret


### PR DESCRIPTION
The new function is 3 M-cycles faster per call when the sprite limit is not reached.
It is however 1 M-cycle slower when the sprite limit is reached.


Here are the 2 changes
- Two "srl a" instructions were replaced with two "rrca" instructions as A will always be a multiple of 4 when these instructions are run. This saves 2 M-cycles
 - The order code that returns 0 if the sprite limit is reached when calling this function is now at the end of the function, in order to save 1 M-cycle when the sprite limit is not reached.