### PR TITLE
Optimize memset small for ALL of the sm83 ports

### DIFF
--- a/gbdk-lib/libc/targets/sm83/duck/crt0.s
+++ b/gbdk-lib/libc/targets/sm83/duck/crt0.s
@@ -25,6 +25,9 @@
 .MemsetSmall::
         LD      (HL+),A
         DEC     C
+        RET     Z
+        LD      (HL+), A
+        DEC     C
         JR      NZ,.MemsetSmall
         ret
 

--- a/gbdk-lib/libc/targets/sm83/gb/crt0.s
+++ b/gbdk-lib/libc/targets/sm83/gb/crt0.s
@@ -24,6 +24,9 @@
 .MemsetSmall::
         LD      (HL+),A
         DEC     C
+        RET     Z
+        LD      (HL+),A
+        DEC     C
         JR      NZ,.MemsetSmall
         ret
 


### PR DESCRIPTION
I realized i only optimized the MemsetSmall function for the Analogue Pocket and not for the gameboy and neither for the megaduck ports.