### PR TITLE
Optimization of rand for both the sm83 and the z80

### DIFF
--- a/gbdk-lib/libc/asm/sm83/rand.s
+++ b/gbdk-lib/libc/asm/sm83/rand.s
@@ -47,7 +47,7 @@ ___rand_seed::
 
 	;; Random number generator using the linear congruential method
 	;;  X(n+1) = (a*X(n)+c) mod m
-	;; with a = 17, m = 16 and c = $5c93 (arbitrarily)
+	;; with a = 17, m = 65536 and c = $5c93 (arbitrarily)
 	;; The seed value is also chosen arbitrarily as $a27e
 	;; Ref : D. E. Knuth, "The Art of Computer Programming" , Volume 2
 	;;
@@ -60,43 +60,35 @@ ___rand_seed::
 
 _rand::				; Banked
 _randw::			; Banked
-	LD	A,(.randlo)
-	LD	L,A
-	LD	E,A		; Save randlo
-	LD	A,(.randhi)
-	LD	D,A		; Save randhi
+	ld hl, #.randlo
+	ld a, (hl+)
+	ld e, e
+	ld d, (hl)		; D = randhi
 
-	SLA	L		; * 16
-	RLA
-	SLA	L
-	RLA
-	SLA	L
-	RLA
-	SLA	L
-	RLA
-	LD	H,A		; Save randhi*16
+	; HL = 17 * DE + 0x5C93
+	ld h, d
+	ld l, e
 
-	LD	A,E		; Old randlo
-	ADD	A,L		; Add randlo*16
-	LD	L,A		; Save randlo*17
+	add hl, hl
+	add hl, hl
+	add hl, hl
+	add hl, hl
+	add hl, de
+	ld de, #0x5C93
+	add hl, de
+	
+	ld d, l
+	ld e, h			; de = return value
 
-	LD	A,H		; randhi*16
-	ADC	A,D		; Add old randhi
-	LD	H,A		; Save randhi*17
-
-	LD	A,L		; randlo*17
-	ADD	A,#0x93
-	LD	(.randlo),A
-	LD	D,A		; Return register
-	LD	A,H		; randhi*17
-	ADC	A,#0x5c
-	LD	(.randhi),A
-	LD	E,A		; Return register
-
+	ld hl, #.randlo
+	ld a, d
+	ld (hl+), a
+	ld (hl), e
+	
 	;; Note D is the low byte,E the high byte. This is intentional because
 	;; the high byte can be slightly 'more random' than the low byte, and I presume
 	;; most will cast the return value to a uint8_t. As if someone will use this, tha!
-	RET
+	ret
 
 	;; This sets the seed value. Call it whenever you like
 	;;

--- a/gbdk-lib/libc/asm/sm83/rand.s
+++ b/gbdk-lib/libc/asm/sm83/rand.s
@@ -62,7 +62,7 @@ _rand::				; Banked
 _randw::			; Banked
 	ld hl, #.randlo
 	ld a, (hl+)
-	ld e, e
+	ld e, a
 	ld d, (hl)		; D = randhi
 
 	; HL = 17 * DE + 0x5C93

--- a/gbdk-lib/libc/asm/z80/rand.s
+++ b/gbdk-lib/libc/asm/z80/rand.s
@@ -11,38 +11,22 @@ ___rand_seed::
 _rand::	
 _randw::
 
-        LD HL, (.randval)
-        EX DE, HL
-        LD L, E
-        LD A, D
+        ld hl, (.randval)
+        LD d, h
+        ld e, l
 
-        SLA L                   ; * 16
-        RLA
-        SLA L
-        RLA
-        SLA L
-        RLA
-        SLA L
-        RLA
-        LD H, A                 ; Save randhi*16
+        add hl, hl
+        add hl, hl
+        add hl, hl
+        add hl, hl
+        add hl, de
+        ld de, #0x5C93
+        add hl, de
+        ld (.randval), hl
 
-        LD A, E                 ; Old randlo
-        ADD A, L                ; Add randlo*16
-        LD L, A                 ; Save randlo*17
-
-        LD A, H                 ; randhi*16
-        ADC A, D                ; Add old randhi
-        LD H, A                 ; Save randhi*17
-
-        LD A, L                 ; randlo*17
-        ADD A, #0x93
-        LD L, A
-        LD A, H                 ; randhi*17
-        ADC A, #0x5c
-        LD H, A
-        LD (.randval), HL
-        LD H, L
-        LD L, A
+        ld a, h
+        ld h, l
+        ld l, a
 
         RET
 


### PR DESCRIPTION
I used the few instructions that works on 16 bit numbers of the sm83 and the z80 in order to improve the speed and the size of rand.
Overall the code is 18 bytes smaller for both ports, it is 11 M-cycles faster for the sm83 and it is 26 T-cycles faster for the z80

Here are the explanation of the changes i made²
The 16 bit left shift
`
sla l
`
`
rla
`
have been replaced by
`
add hl, hl
`
which is 1 M-cycle faster on an sm83 and 1 T-cycle faster on a z80.
This is also 1 byte smaller

The 16 bit additions
`
ld a, l
`
`
add  x
`
`
ld l, a
`
`
ld a, h
`
`
adc y
`
`
ld h, l
`
have been replaced by
`
ld de, yx
`
`
add hl, de
`
This is twice as small and is 3 M-cycles faster on an sm83 and 9 T-cycles faster on a z80.