### PR TITLE
Updated the calling convention of memset and small optimization of memset for the sm83 port

### DIFF
--- a/gbdk-lib/include/asm/sm83/string.h
+++ b/gbdk-lib/include/asm/sm83/string.h
@@ -51,7 +51,7 @@ void *memmove (void *dest, const void *src, size_t n);
     @param c         char value to fill with (truncated from int)
     @param n         Number of bytes to fill
 */
-void *memset (void *s, int c, size_t n) OLDCALL PRESERVES_REGS(b, c);
+void *memset (void *s, int c, size_t n);
 
 /** Reverses the characters in a string
 

--- a/gbdk-lib/libc/asm/sm83/_memset.s
+++ b/gbdk-lib/libc/asm/sm83/_memset.s
@@ -4,49 +4,40 @@
 
 ; void *memset (void *s, int c, size_t n)
 _memset::
-        lda     hl,7(sp)
-        ld      a,(hl-)
-        ld      d, a
-        ld      a,(hl-)
-        ld      e, a
-        or      d
-        jr      z,6$
+        ld a, c
+
+        pop hl                ; pop return address
+        pop bc                ; pop n
+        push hl               ; push return address
         
-        dec     hl
-        ld      a,(hl-)
-        push    af
-        ld      a,(hl-)
-        ld      l,(hl)
-        ld      h,a
-        pop     af
+        ld h, d
+        ld l, e
         
-        srl     d
-        rr      e
-        jr      nc,4$
+        srl     b
+        rr      c
+        jr      nc,0$
         ld      (hl+),a
-4$:     
-        srl     d
-        rr      e
-        jr      nc,5$
-        ld      (hl+),a
-        ld      (hl+),a
-5$:             
-        inc     d
-        inc     e
-        jr      2$
+0$:     
+        srl     b
+        inc     b
+        rr      c
+        
+        jr      c,2$
+        jr      z,3$
 1$:     
-        ld      (hl+),a
-        ld      (hl+),a
+        dec     c
         ld      (hl+),a
         ld      (hl+),a
 2$:
-        dec     e
+        ld      (hl+),a
+        ld      (hl+),a
         jr      nz,1$
-        dec     d
+3$:
+        dec     b
         jr      nz,1$
-6$:
-        lda     hl,2(sp)
-        ld      a,(hl+)
-        ld      e,a
-        ld      d,(hl)
+
+        ; return s in bc
+        ld b, d
+        ld c, e
+        
         ret


### PR DESCRIPTION
I updated the calling convention of memset from __sdcccall(0) to __sdcccall(1)
I also optimized a tiny bit the function itself, it is now a few bytes smaller and it is faster by a few cycles.
I removed the code that checked for a length of 0 because it was not needed, the code without that check already handle well a length of 0.