### PR TITLE
Optimization of setjump.s for both the z80 and the sm83 port

### DIFF
--- a/gbdk-lib/include/setjmp.h
+++ b/gbdk-lib/include/setjmp.h
@@ -63,14 +63,14 @@ typedef unsigned char jmp_buf[3]; /* 1 for the stack pointer, 2 for the return a
 typedef unsigned char jmp_buf[RET_SIZE + SP_SIZE + BP_SIZE + SPX_SIZE + BPX_SIZE];
 #endif
 
-int __setjmp (jmp_buf) OLDCALL;
+int __setjmp (jmp_buf);
 
 /* C99 might require setjmp to be a macro. The standard seems self-contradicting on this issue. */
 /* However, it is clear that the standards allow setjmp to be a macro. */
 #define setjmp(jump_buf) __setjmp(jump_buf)
 
 #ifndef __SDCC_HIDE_LONGJMP
-_Noreturn void longjmp(jmp_buf, int) OLDCALL;
+_Noreturn void longjmp(jmp_buf, int);
 #endif
 
 #undef RET_SIZE

--- a/gbdk-lib/libc/asm/sm83/setjmp.s
+++ b/gbdk-lib/libc/asm/sm83/setjmp.s
@@ -57,8 +57,8 @@ _longjmp:
 
         ; get return address
      	ld h, d
-	ld l, e
-	ld a, (hl+)
-	ld h, (hl)
-	ld l, a
-	jp (hl)
+		ld l, e
+		ld a, (hl+)
+		ld h, (hl)
+		ld l, a
+		jp (hl)

--- a/gbdk-lib/libc/asm/sm83/setjmp.s
+++ b/gbdk-lib/libc/asm/sm83/setjmp.s
@@ -40,8 +40,6 @@ ___setjmp:
 .globl _longjmp
 
 _longjmp:
-        pop af                       ; discard return address
-
         ; ensure that the return value is not zero
         ld a, b
         or c
@@ -58,13 +56,9 @@ _longjmp:
         ld sp, hl
 
         ; get return address
-        ld a, (de)
-        ld l, a
-        inc de
-        ld a, (de)
-        ld h, a
-
-        jp (hl)
-        
-        
-        
+     	ld h, d
+	ld l, e
+	ld a, (hl+)
+	ld h, (hl)
+	ld l, a
+	jp (hl)

--- a/gbdk-lib/libc/asm/sm83/setjmp.s
+++ b/gbdk-lib/libc/asm/sm83/setjmp.s
@@ -1,29 +1,8 @@
 ;--------------------------------------------------------------------------
 ;  setjmp.s
 ;
-;  Copyright (C) 2011-2014, Philipp Klaus Krause
+;  Copyright (C) 2026, Phidias618
 ;
-;  This library is free software; you can redistribute it and/or modify it
-;  under the terms of the GNU General Public License as published by the
-;  Free Software Foundation; either version 2, or (at your option) any
-;  later version.
-;
-;  This library is distributed in the hope that it will be useful,
-;  but WITHOUT ANY WARRANTY; without even the implied warranty of
-;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-;  GNU General Public License for more details.
-;
-;  You should have received a copy of the GNU General Public License
-;  along with this library; see the file COPYING. If not, write to the
-;  Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
-;   MA 02110-1301, USA.
-;
-;  As a special exception, if you link this library with other files,
-;  some of which are compiled with SDCC, to produce an executable,
-;  this library does not by itself cause the resulting executable to
-;  be covered by the GNU General Public License. This exception does
-;  not however invalidate any other reasons why the executable file
-;   might be covered by the GNU General Public License.
 ;--------------------------------------------------------------------------
 
         .module longjmp
@@ -33,73 +12,59 @@
         .globl ___setjmp
 
 ___setjmp:
-        pop     bc
-        pop     de
-        push    de
-        push    bc
+        ; save sp
+        ldhl sp, #2
+        ld a, l
+        ld l, e
+        ld e, h
+        ld h, d
+        
+        ld (hl+), a
+        ld a, e
+        ld (hl+), a
+        
+        ; save return address
+        pop de
+        ld a, e
+        ld (hl+), a
+        ld (hl), d
+        
+        ; return 0
+        ld l, e
+        ld h, d
+        ld de, #0
+        jp (hl)
 
-        ; Store stack pointer.
-        ldhl    sp, #0
-        push    de
-        push    hl
-        pop     de
-        pop     hl
-        ld      (hl), e
-        inc     hl
-        ld      (hl), d
-        inc     hl
-
-        ; Store return address.
-        ld      (hl), c
-        inc     hl
-        ld      (hl), b
-
-        ; Return 0.
-        xor     a, a
-        ld      e, a
-        ld      d, a
-        ret
+        
 
 .globl _longjmp
 
 _longjmp:
-        pop     af
-        pop     hl
-        pop     de
+        pop af                       ; discard return address
 
-        ; Ensure that return value is non-zero.
-        ld      a, e
-        or      a, d
-        jr      NZ, 0001$
-        inc     de
-0001$:
+        ; ensure that the return value is not zero
+        ld a, b
+        or c
+        jr nz, 0$
+        inc c
+0$:     
+        ; restore sp
+        ld a, (de)
+        ld l, a
+        inc de
+        ld a, (de)
+        ld h, a
+        inc de
+        ld sp, hl
 
-        ; Get stack pointer.
-        ld      c, (hl)
-        inc     hl
-        ld      b, (hl)
-        inc     hl
+        ; get return address
+        ld a, (de)
+        ld l, a
+        inc de
+        ld a, (de)
+        ld h, a
 
-        ; Adjust stack pointer.
-        push    hl
-        push    bc
-        pop     hl
-        pop     bc
-        ld      sp, hl
-        push    bc
-        pop     hl
-
-        ; Get return address.
-        ld      c, (hl)
-        inc     hl
-        ld      b, (hl)
-
-        ; Set return address.
-        pop     af
-        push    bc
-
-        ; Return value is in de.
-
-        ; Jump.
-        ret
-
+        jp (hl)
+        
+        
+        

--- a/gbdk-lib/libc/asm/sm83/setjmp.s
+++ b/gbdk-lib/libc/asm/sm83/setjmp.s
@@ -32,7 +32,7 @@ ___setjmp:
         ; return 0
         ld l, e
         ld h, d
-        ld de, #0
+        ld bc, #0
         jp (hl)
 
         

--- a/gbdk-lib/libc/asm/z80/setjmp.s
+++ b/gbdk-lib/libc/asm/z80/setjmp.s
@@ -1,29 +1,8 @@
 ;--------------------------------------------------------------------------
 ;  setjmp.s
 ;
-;  Copyright (C) 2011-2014, Philipp Klaus Krause
+;  Copyright (C) 2026, Phidias618
 ;
-;  This library is free software; you can redistribute it and/or modify it
-;  under the terms of the GNU General Public License as published by the
-;  Free Software Foundation; either version 2, or (at your option) any
-;  later version.
-;
-;  This library is distributed in the hope that it will be useful,
-;  but WITHOUT ANY WARRANTY; without even the implied warranty of
-;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-;  GNU General Public License for more details.
-;
-;  You should have received a copy of the GNU General Public License 
-;  along with this library; see the file COPYING. If not, write to the
-;  Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
-;   MA 02110-1301, USA.
-;
-;  As a special exception, if you link this library with other files,
-;  some of which are compiled with SDCC, to produce an executable,
-;  this library does not by itself cause the resulting executable to
-;  be covered by the GNU General Public License. This exception does
-;  not however invalidate any other reasons why the executable file
-;   might be covered by the GNU General Public License.
 ;--------------------------------------------------------------------------
 
 	.area   _CODE
@@ -31,65 +10,73 @@
 	.globl ___setjmp
 
 ___setjmp:
-	pop	hl
-	pop	iy
-	push	af
-	push	hl
-
-	; Store return address.
-	ld	0(iy), l
-	ld	1(iy), h
+	; Store frame pointer.
+	push ix
+	pop de
+	ld (hl), e
+	inc hl
+	ld (hl), d
+	inc hl
 
 	; Store stack pointer.
-	xor	a, a
-	ld	l, a
-	ld	h, a
-	add	hl, sp
-	ld	2(iy), l
-	ld	3(iy), h
+	ex hl, de
+	ld hl, #2
+	add hl, sp
+	ex hl, de
 
-	; Store frame pointer.
-	push	ix
-	pop	hl
-	ld	4(iy), l
-	ld	5(iy), h
+	ld (hl), e
+	inc hl
+	ld (hl), d
+	inc hl
 
-	; Return 0.
-	ld	l, a
-	ld	h, a
-	ret
+	pop de		; pop return address
 
+	; Store return address.
+	ld (hl), e
+	inc hl
+	ld (hl), d
+
+	; return 0
+	ex hl, de
+	ld de, #0
+	jp (hl)
+	
 .globl _longjmp
-
 _longjmp:
-	pop	af
-	pop	iy
-	pop	de
+	pop af				; Discard return address.
 
 	; Ensure that return value is non-zero.
-	ld	a, e
-	or	a, d
-	jr	NZ, jump
-	inc	de
-jump:
+	ld a, d
+	or e
+	jr nz, 0$
+	inc d
+0$:
+	ld b, d
+	ld c, e
 
 	; Restore frame pointer.
-	ld	l, 4(iy)
-	ld	h, 5(iy)
-	push	hl
-	pop	ix
+	ld e, (hl)
+	inc hl
+	ld d, (hl)
+	inc hl
+	push de
+	pop ix
 
-	; Adjust stack pointer.
-	ld	l, 2(iy)
-	ld	h, 3(iy)
-	ld	sp, hl
-	pop	hl
+	; Restore stack pointer.
+	ld e, (hl)
+	inc hl
+	ld d, (hl)
+	inc hl
+	ex hl, de
+	ld sp, hl
+	ex hl, de
 
-	; Move return value into hl.
-	ex	de, hl
-
-	; Jump.
-	ld	c, 0(iy)
-	ld	b, 1(iy)
-	push	bc
-	ret
+	ld e, (hl)
+	inc hl
+	ld d, (hl)
+	
+	ex hl, de
+	ld d, b
+	ld e, c
+	jp (hl)
+	

--- a/gbdk-lib/libc/asm/z80/setjmp.s
+++ b/gbdk-lib/libc/asm/z80/setjmp.s
@@ -19,10 +19,10 @@ ___setjmp:
 	inc hl
 
 	; Store stack pointer.
-	ex hl, de
+	ex de, hl
 	ld hl, #2
 	add hl, sp
-	ex hl, de
+	ex de, hl
 
 	ld (hl), e
 	inc hl
@@ -37,7 +37,7 @@ ___setjmp:
 	ld (hl), d
 
 	; return 0
-	ex hl, de
+	ex de, hl
 	ld de, #0
 	jp (hl)
 	
@@ -67,15 +67,15 @@ _longjmp:
 	inc hl
 	ld d, (hl)
 	inc hl
-	ex hl, de
+	ex de, hl
 	ld sp, hl
-	ex hl, de
+	ex de, hl
 
 	ld e, (hl)
 	inc hl
 	ld d, (hl)
 	
-	ex hl, de
+	ex de, hl
 	ld d, b
 	ld e, c
 	jp (hl)


### PR DESCRIPTION
The new functions are both smaller and faster (precise figure can be seen in the description of each commit)
The new functions now uses the calling convention __sdccall(1)