### PR TITLE
Optimization of reverse.s for the sm83 port

### DIFF
--- a/gbdk-lib/include/asm/sm83/string.h
+++ b/gbdk-lib/include/asm/sm83/string.h
@@ -63,7 +63,7 @@ void *memset (void *s, int c, size_t n);
 
     Returns: Pointer to __s__
 */
-char *reverse(char *s) OLDCALL PRESERVES_REGS(b, c);
+char *reverse(char *s);
 
 /** Concatenate Strings. Appends string __s2__ to the end of string __s1__
 

--- a/gbdk-lib/libc/asm/sm83/reverse.s
+++ b/gbdk-lib/libc/asm/sm83/reverse.s
@@ -22,29 +22,27 @@ _reverse::
         ld a, (hl+)
         or a
         ret z                ; return if length == 1
-
+        
         ; determine the middle of the string
 0$:
-        inc de
-        ld a, (hl+)
-        or a
-        jr z, 1$
-        
         ld a, (hl+)
         or a
         jr nz, 0$
-        scf
-1$:
-        ld h, d
-        ld l, e
-        dec hl
-        jr nc, 2$
-        inc de
-2$:
 
+        add hl, de
+        rr h
+        rr l
+
+        ld d, h
+        ld e, l
+
+        jr c, 1$
+        dec hl
+1$:
+        dec hl
         ; swap pairs of characters starting from the middle of the string until the 0 terminator is found
         ld a, (de)
-3$:
+2$:
         ld c, (hl)
         ld (hl-), a
         ld a, c
@@ -53,7 +51,7 @@ _reverse::
         inc de
         ld a, (de)
         or a
-        jr nz, 3$                ; stop if 0 terminator
+        jr nz, 2$                ; stop if 0 terminator
 
         ; return the address of the string in BC
         inc l

--- a/gbdk-lib/libc/asm/sm83/reverse.s
+++ b/gbdk-lib/libc/asm/sm83/reverse.s
@@ -1,29 +1,8 @@
 ;--------------------------------------------------------------------------
 ;  reverse.s
 ;
-;  Copyright (C) 2020, Tony Pavlov
+;  Copyright (C) 2026, Phidias618
 ;
-;  This library is free software; you can redistribute it and/or modify it
-;  under the terms of the GNU General Public License as published by the
-;  Free Software Foundation; either version 2, or (at your option) any
-;  later version.
-;
-;  This library is distributed in the hope that it will be useful,
-;  but WITHOUT ANY WARRANTY; without even the implied warranty of
-;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-;  GNU General Public License for more details.
-;
-;  You should have received a copy of the GNU General Public License 
-;  along with this library; see the file COPYING. If not, write to the
-;  Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston,
-;   MA 02110-1301, USA.
-;
-;  As a special exception, if you link this library with other files,
-;  some of which are compiled with SDCC, to produce an executable,
-;  this library does not by itself cause the resulting executable to
-;  be covered by the GNU General Public License. This exception does
-;  not however invalidate any other reasons why the executable file
-;   might be covered by the GNU General Public License.
 ;--------------------------------------------------------------------------
 
         .module reverse
@@ -31,54 +10,54 @@
         .area   _HOME
 
 _reverse::
-        lda     HL, 2(SP)
-        ld      A, (HL+)
-        ld      H, (HL)
-        ld      L, A            ; HL: s
-        
-        push    BC
-        ld      B, H
-        ld      C, L            ; BC: s
-        
-        ld      DE, #0
-1$:     ld      A, (HL+)
-        or      A
-        jr      Z, 2$
-        inc     DE
-        jr      1$
+        ld h, d
+        ld l, e
 
+        ld b, d
+        ld c, e
+        
+        ld a, (hl+)
+        or a
+        ret z                ; return if length == 0
+        ld a, (hl+)
+        or a
+        ret z                ; return if length == 1
+
+        ; determine the middle of the string
+0$:
+        inc de
+        ld a, (hl+)
+        or a
+        jr z, 1$
+        
+        ld a, (hl+)
+        or a
+        jr nz, 0$
+        scf
+1$:
+        ld h, d
+        ld l, e
+        dec hl
+        jr nc, 2$
+        inc de
 2$:
-        srl     D
-        rr      E
-        
-        ld      A, E
-        or      D
-        jr      Z, 3$
 
-        dec     HL
-        dec     HL
-
-        inc     D
-        inc     E
-        jr      5$
-4$:
-        ld      A, (HL)
-        push    AF
-        ld      A, (BC)
-        ld      (HL-), A
-        pop     AF
-        ld      (BC), A
-        inc     BC
-5$:
-        dec     E
-        jr      NZ, 4$
-        dec     D
-        jr      NZ, 4$
-        
+        ; swap pairs of characters starting from the middle of the string until the 0 terminator is found
+        ld a, (de)
 3$:
-        pop     BC
-        lda     HL, 2(SP)
-        ld      E, (HL)
-        inc     HL
-        ld      D, (HL)
+        ld c, (hl)
+        ld (hl-), a
+        ld a, c
+        ld (de), a
+        
+        inc de
+        ld a, (de)
+        or a
+        jr nz, 3$                ; stop if 0 terminator
+
+        ; return the address of the string in BC
+        inc l
+        ld c, l
         ret
+
+        

--- a/gbdk-lib/libc/asm/z80/Makefile
+++ b/gbdk-lib/libc/asm/z80/Makefile
@@ -17,7 +17,8 @@ ASSRC = __strreverse.s strcpy.s strlen.s \
 	__sdcc_call_hl.s __sdcc_call_iy.s \
 	atomic_flag_test_and_set.s __sdcc_critical.s \
 	crtenter.s \
-	bcd.s
+	bcd.s \
+	reverse.s
 
 include $(TOPDIR)/Makefile.common
 

--- a/gbdk-lib/libc/asm/z80/reverse.s
+++ b/gbdk-lib/libc/asm/z80/reverse.s
@@ -20,6 +20,8 @@ _reverse::
         ret z      ; return if length == 1 
 
         ; determine the middle of the string
+        ld b, a
+        ld c, a
         cpir
         add hl, de
         rr h

--- a/gbdk-lib/libc/asm/z80/reverse.s
+++ b/gbdk-lib/libc/asm/z80/reverse.s
@@ -1,0 +1,50 @@
+;--------------------------------------------------------------------------
+;  reverse.s
+;
+;  Copyright (C) 2026, Phidias618
+;
+;--------------------------------------------------------------------------
+
+        .module reverse
+
+        .area   _CODE
+
+_reverse::
+        ld d, h
+        ld e, l
+
+        xor a
+        cpi
+        ret z      ; return if length == 0
+        cpi
+        ret z      ; return if length == 1 
+
+        ; determine the middle of the string
+        cpir
+        add hl, de
+        rr h
+        rr l
+        
+        ld b, h
+        ld c, l
+
+        jr c, 0$
+        dec hl
+0$:
+        ; swap pairs of characters starting from the middle of the string until the 0 terminator is found
+        ld a, (bc)
+1$:
+        dec hl
+        ld e, (hl)
+        ld (hl), a
+        ld a, e
+        ld (bc), a
+
+        inc bc
+        ld a, (bc)
+        or a
+        jp nz, 1$        ; exit if 0 terminator
+
+        ; return the address of the string in de
+        ex de, hl
+        ret


### PR DESCRIPTION
The new function is faster for every string length, it is 13 bytes smaller and it don't use the stack at all.
It also uses the calling convention __sdcccall(1) instead of OLDCALL