### PR TITLE
Small optimization of memcpy for the z80 port

### DIFF
--- a/gbdk-lib/libc/asm/z80/memcpy.s
+++ b/gbdk-lib/libc/asm/z80/memcpy.s
@@ -12,11 +12,12 @@ ___memcpy:
     pop af
     pop bc
     push af
-    push de
 
     ld a, c
     or b
     ret z
+    
+    push de
 
     ld a, c
     add a

--- a/gbdk-lib/libc/asm/z80/memcpy.s
+++ b/gbdk-lib/libc/asm/z80/memcpy.s
@@ -7,24 +7,25 @@
 
 ; The Z80 has the ldir instruction, but the chain of ldi is faster.
 _memcpy:
-___memcpy:
+___memcpy:    
     ex de, hl
     pop af
     pop bc
     push af
-    ld a, b
-    or c
-    ret z
     push de
+
     ld a, c
-    and #15
+    or b
+    ret z
+
+    ld a, c
     add a
-    sub #32
     neg
-    ld iy, #1$
-    add iyl
+    and #31
+    
+    add #<1$
     ld iyl, a
-    adc iyh
+    adc #>1$
     sub iyl
     ld iyh, a
     xor a


### PR DESCRIPTION
The new function is 24 cycles faster.
If the length argument is a multiple of 16 then the function is faster by an additional 10 cycles.
The new function is also 6 bytes smaller