### PR TITLE
Improvement of fill_rect.s for the sm83 port

### DIFF
--- a/gbdk-lib/libc/targets/sm83/fill_rect.s
+++ b/gbdk-lib/libc/targets/sm83/fill_rect.s
@@ -15,71 +15,60 @@
         AND     #LCDCF_BG9C00
         JR      NZ,.is9c
 .is98:
-        LD      HL,#0x9800      ; HL = origin
+        LD      H, #0x98        ; HL = origin
         JR      .fill_rect
 .is9c:
-        LD      HL,#0x9C00      ; HL = origin
+        LD      H, #0x9C        ; HL = origin
 
-        ;; fills rectangle area with tile B at XY = DE, size WH on stack, to vram from address (HL)
+        ;; fills rectangle area with tile B at XY = DE, size WH on stack, to vram from address (H << 8)
 .fill_rect:
-        PUSH    BC              ; Store source
-
-        SWAP    E
-        RLC     E
-        LD      A,E
-        AND     #0x03
-        ADD     H
-        LD      B,A
-        LD      A,#0xE0
-        AND     E
-        ADD     D
-        LD      C,A             ; dest BC = HL + 0x20 * Y + X
-
-        POP     HL              ; H = Tile
-        POP     DE              ; DE = WH
-        PUSH    DE              ; store WH
-        PUSH    BC              ; store dest
-
-3$:                             ; Copy W tiles
-
+        ld l, d
+        swap e
+        ld a, e
+        res 0, e
+        and #1
+        ld d, a
+        add hl, de
+        add hl, de              ; dest HL = (H << 8) + 0x20 * Y + X
+        
+        pop de                  ; DE = WH
+        ld c, d                 ; C = W
+0$:
+        push hl                 ; store dest
+1$:                             ; Copy W tiles
         WAIT_STAT
-        LD      A, H
-        LD      (BC), A
+        ld (hl), b
+
+        ; inc dest and wrap around
+        inc l
+        ld a, l
+        and #0x1F
+        jr nz, 2$
+        ld a, l
+        sub #0x20
+        ld l, a
+2$:
+        dec d
+        jr nz, 1$
         
-        LD      A, C            ; inc dest and wrap around
-        AND     #0xE0
-        LD      E, A
-        LD      A, C
-        INC     A
-        AND     #0x1F
-        OR      E
-        LD      C, A
+        pop hl
 
-        DEC     D
-        JR      NZ, 3$
+        dec e
+        ret z
 
-        POP     BC
-        POP     DE
-
-        DEC     E
-        RET     Z
-
-        PUSH    DE
-
-        LD      A, B            ; next row and wrap around
-        AND     #0xFC
-        LD      E, A            ; save high bits
-
-        LD      A,#0x20
-
-        ADD     C
-        LD      C, A
-        ADC     B
-        SUB     C
-        AND     #0x03
-        OR      E               ; restore high bits
-        LD      B, A
-
-        PUSH    BC
+        ld d, c        ; D = W
         
-        JR      3$
+        ; next row and wrap around
+        ld a, l
+        add #0x20
+        ld l, a
+        jr nc, 0$
+        ld a, h
+        rrca
+        rrca
+        add #0x40
+        rlca
+        rlca
+        ld h, a
+        
+        jr 0$


### PR DESCRIPTION
The new code is better is every way :

- It is faster
- It is smaller by 10 bytes
- It uses less stack
- there is less delay between checking whether vram is available and accessing vram
