### PR TITLE
Refactor cgb_palette.s to use new calling convention

### DIFF
--- a/gbdk-lib/include/gb/cgb.h
+++ b/gbdk-lib/include/gb/cgb.h
@@ -101,7 +101,7 @@ typedef uint16_t palette_color_t;   /**< 16 bit color entry */
     @see BKGF_CGB_PAL0, BKGF_CGB_PAL1, BKGF_CGB_PAL2, BKGF_CGB_PAL3
     @see BKGF_CGB_PAL4, BKGF_CGB_PAL5, BKGF_CGB_PAL6, BKGF_CGB_PAL7
  */
-void set_bkg_palette(uint8_t first_palette, uint8_t nb_palettes, const palette_color_t *rgb_data) OLDCALL;
+void set_bkg_palette(uint8_t first_palette, uint8_t nb_palettes, const palette_color_t *rgb_data) PRESERVES_REGS(b, c);
 
 /** Set CGB sprite palette(s).
 
@@ -120,7 +120,7 @@ void set_bkg_palette(uint8_t first_palette, uint8_t nb_palettes, const palette_c
     @see OAMF_CGB_PAL0, OAMF_CGB_PAL1, OAMF_CGB_PAL2, OAMF_CGB_PAL3
     @see OAMF_CGB_PAL4, OAMF_CGB_PAL5, OAMF_CGB_PAL6, OAMF_CGB_PAL7
  */
-void set_sprite_palette(uint8_t first_palette, uint8_t nb_palettes, const palette_color_t *rgb_data) OLDCALL;
+void set_sprite_palette(uint8_t first_palette, uint8_t nb_palettes, const palette_color_t *rgb_data) PRESERVES_REGS(b, c);
 
 /** Sets a single color in the specified CGB background palette.
 
@@ -133,7 +133,7 @@ void set_sprite_palette(uint8_t first_palette, uint8_t nb_palettes, const palett
     @see BKGF_CGB_PAL4, BKGF_CGB_PAL5, BKGF_CGB_PAL6, BKGF_CGB_PAL7
  */
 
-void set_bkg_palette_entry(uint8_t palette, uint8_t entry, uint16_t rgb_data) OLDCALL;
+void set_bkg_palette_entry(uint8_t palette, uint8_t entry, uint16_t rgb_data) PRESERVES_REGS(b, c);
 
 /** Sets a single color in the specified CGB sprite palette.
 
@@ -145,7 +145,7 @@ void set_bkg_palette_entry(uint8_t palette, uint8_t entry, uint16_t rgb_data) OL
     @see OAMF_CGB_PAL0, OAMF_CGB_PAL1, OAMF_CGB_PAL2, OAMF_CGB_PAL3
     @see OAMF_CGB_PAL4, OAMF_CGB_PAL5, OAMF_CGB_PAL6, OAMF_CGB_PAL7
  */
-void set_sprite_palette_entry(uint8_t palette, uint8_t entry, uint16_t rgb_data) OLDCALL;
+void set_sprite_palette_entry(uint8_t palette, uint8_t entry, uint16_t rgb_data) PRESERVES_REGS(b, c);
 
 /** Set CPU speed to slow (Normal Speed) operation.
 

--- a/gbdk-lib/libc/targets/sm83/cgb_compat.s
+++ b/gbdk-lib/libc/targets/sm83/cgb_compat.s
@@ -9,13 +9,16 @@
         
 _cgb_compatibility::
 _set_default_palette::
-	LD	HL, #1$
-	PUSH	HL
-	LD	HL, #0x0100
-	PUSH 	HL
-	CALL	_set_sprite_palette
-	CALL	_set_bkg_palette
-	ADD	SP, #4
-	RET
+	ld bc, #1$
+	xor a
+	ld e, #1
+	push bc
+	call _set_sprite_palette	; preserve BC
+	
+	xor a
+	ld e, #1
+	push bc
+	call _set_bkg_palette
+	ret
 1$:
 	.DW	0x7FFF, 0x56B5, 0x294A, 0x0000

--- a/gbdk-lib/libc/targets/sm83/cgb_palettes.s
+++ b/gbdk-lib/libc/targets/sm83/cgb_palettes.s
@@ -5,74 +5,88 @@
 
 	.area	_CODE
 
+; void set_sprite_palette(uint8_t first_palette, uint8_t nb_palettes, const palette_color_t *rgb_data) PRESERVES_REGS(b, c);
 _set_sprite_palette::		; Non-banked
-	PUSH	BC
-	LD	C,#.OCPS
-	JR	.set_palette
+	ld d, c					; save C
+	ld c, #.OCPS
+	jr .set_palette
 
+; void set_bkg_palette(uint8_t first_palette, uint8_t nb_palettes, const palette_color_t *rgb_data) PRESERVES_REGS(b, c);
 _set_bkg_palette::		; Non-banked
-	PUSH	BC
-	LD	C,#.BCPS
-
+	ld d, c					; save C
+	ld c, #.BCPS
+	
+	; first_palette is in A
+	; nb_palettes is in E
+	; rgb_data is on the stack
 .set_palette::
-	LDA	HL,4(SP)	; Skip return address and registers
-	LD	A,(HL+)		; first_palette
-	ADD	A		; A *= 8
-	ADD	A
-	ADD	A
-	OR	#0x80		; Set auto-increment
-	LDH	(C),A
-	INC	C
-	LD	A,(HL+)		; D = nb_palettes
-	ADD	A		; A *= 8
-	ADD	A
-	ADD	A
-	LD	B,A		; Number of bytes
-	LD	A,(HL+)		; rgb_data
-	LD	H,(HL)
-	LD	L,A
-1$:	
+	add a
+	add a
+	add a
+	or #0x80		; Set auto-increment
+	ldh (c), a
+	inc c
+	
+	; E = nb_palettes * 8
+	ld a, e
+	add a
+	add a
+	add a
+	ld e, a			
+
+	; hl = rgb_data
+	ldhl sp, #2
+	ld a, (hl+)
+	ld h, (hl)
+	ld l, a
+0$:
 	WAIT_STAT
+	
+	ld a, (hl+)
+	ldh (c), a
+	dec e
+	jr nz, 0$
 
-	LD	A,(HL+)
-	LDH	(C),A
-	DEC	B
-	JR	NZ,1$
+	ld c, d			; restore C
+	pop hl			; get return address
+	pop af			; dummy pop
+	jp (hl)
 
-	POP	BC
-	RET
-
+; void set_sprite_palette_entry(uint8_t palette, uint8_t entry, uint16_t rgb_data) PRESERVES_REGS(b, c);
 _set_sprite_palette_entry::	; Banked
-	PUSH	BC
-	LD	C,#.OCPS
-	JR	.set_palette_entry
+	ld d, c					; save C
+	ld c, #.OCPS
+	jr .set_palette_entry
 
+; void set_bkg_palette_entry(uint8_t palette, uint8_t entry, uint16_t rgb_data) PRESERVES_REGS(b, c);
 _set_bkg_palette_entry::	; Banked
-	PUSH	BC
-	LD	C,#.BCPS
+	ld d, c					; save C
+	ld c, #.BCPS
 
+	; palette is in A
+	; entry is in E
+	; rgb_data is on the stack
 .set_palette_entry::
-	LDA	HL,4(SP); Skip return address and registers
-	LD	A,(HL+)		; first_palette
-	ADD	A		; A *= 4
-	ADD	A
-	LD	B,A
-	LD	A,(HL+)		; pal_entry
-	ADD	B		; A += first_palette * 4
-	ADD	A		; A *= 2
-	OR	#0x80		; Set auto-increment
-	LDH	(C),A
-	INC	C
+	; A = palette * 8 + entry * 2
+	add	a
+	add	a
+	add e
+	add	a
+	or #0x80		; Set auto-increment
+	ldh (c), a
+	inc c
+	
+	ldhl sp, #2
 	LD	A,(HL+)		; rgb_data
-	LD	H,(HL)
-	LD	L,A
+	LD	E,(HL)
 
-	WAIT_STAT
+	WAIT_STAT_HL
 
-	LD	A,L
-	LDH	(C),A
-	LD	A,H
-	LDH	(C),A
+	ldh (c), a
+	ld a, e
+	ldh (c), a
 
-	POP	BC
-	RET
+	ld c, d			; restore C
+	pop hl			; get return address
+	pop af			; dummy pop
+	jp (hl)


### PR DESCRIPTION
Even though the previous code preserved the value of the register pair BC, it was not specified using PRESERVES_REGS(b, c), the new code still preserves BC and it is now specified in the right header file.
There is much less delay between checking for VRAM access and accessing VRAM in .set_palette_entry (the delay has been reduced by 3 cycles).
The new code also use less the stack.
The new code should be faster (it probably won't.
The new code is not larger.