### PR TITLE
Add fill_bkg_rect_attributes / fill_win_rect_attributes for GB / SMS / NES

### DIFF
--- a/gbdk-lib/include/gb/gb.h
+++ b/gbdk-lib/include/gb/gb.h
@@ -2300,6 +2300,21 @@ void vmemset (void *s, uint8_t c, size_t n) OLDCALL PRESERVES_REGS(b, c);
 void fill_bkg_rect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t tile) OLDCALL PRESERVES_REGS(b, c);
 #define fill_rect fill_bkg_rect
 
+/** Fills a rectangular region of Tile Map Attribute entries for the Background layer with attribute.
+
+    @param x      X Start position in Background Map tile coordinates. Range 0 - 31
+    @param y      Y Start position in Background Map tile coordinates. Range 0 - 31
+    @param w      Width of area to set in tiles. Range 1 - 32
+    @param h      Height of area to set in tiles. Range 1 - 32
+    @param tile   Fill value
+*/
+inline void fill_bkg_rect_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t attribute)
+{
+    VBK_REG = VBK_ATTRIBUTES;
+    fill_bkg_rect(x, y, w, h, attribute);
+    VBK_REG = VBK_TILES;
+}
+
 /** Fills a rectangular region of Tile Map entries for the Window layer with tile.
 
     @param x      X Start position in Window Map tile coordinates. Range 0 - 31
@@ -2309,5 +2324,20 @@ void fill_bkg_rect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t tile) OLD
     @param tile   Fill value
 */
 void fill_win_rect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t tile) OLDCALL PRESERVES_REGS(b, c);
+
+/** Fills a rectangular region of Tile Map Attribute entries for the Window layer with attribute.
+
+    @param x      X Start position in Window Map tile coordinates. Range 0 - 31
+    @param y      Y Start position in Window Map tile coordinates. Range 0 - 31
+    @param w      Width of area to set in tiles. Range 1 - 32
+    @param h      Height of area to set in tiles. Range 1 - 32
+    @param tile   Fill value
+*/
+inline void fill_win_rect_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t attribute)
+{
+    VBK_REG = VBK_ATTRIBUTES;
+    fill_win_rect(x, y, w, h, attribute);
+    VBK_REG = VBK_TILES;
+}
 
 #endif /* _GB_H */

--- a/gbdk-lib/include/nes/nes.h
+++ b/gbdk-lib/include/nes/nes.h
@@ -1643,6 +1643,16 @@ void vmemset (void *s, uint8_t c, size_t n) NO_OVERLAY_LOCALS;
 void fill_bkg_rect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t tile) NO_OVERLAY_LOCALS;
 #define fill_rect fill_bkg_rect
 
+/** Fills a rectangular region of Tile Map Attribute entries for the Background layer with attribute.
+
+    @param x      X Start position in Background Map tile coordinates. Range 0 - 31
+    @param y      Y Start position in Background Map tile coordinates. Range 0 - 31
+    @param w      Width of area to set in tiles. Range 1 - 32
+    @param h      Height of area to set in tiles. Range 1 - 32
+    @param tile   Fill value
+*/
+void fill_bkg_rect_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t attribute) NO_OVERLAY_LOCALS;
+
 /** Fills a rectangular region of Tile Map entries for the Window layer with tile.
 
     @param x      X Start position in Window Map tile coordinates. Range 0 - 31
@@ -1655,6 +1665,20 @@ void fill_bkg_rect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t tile) NO_
 void fill_win_rect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t tile) NO_OVERLAY_LOCALS;
 #else
 #define fill_win_rect fill_bkg_rect
+#endif
+
+/** Fills a rectangular region of Tile Map Attribute entries for the Window layer with attribute.
+
+    @param x      X Start position in Window Map tile coordinates. Range 0 - 31
+    @param y      Y Start position in Window Map tile coordinates. Range 0 - 31
+    @param w      Width of area to set in tiles. Range 1 - 32
+    @param h      Height of area to set in tiles. Range 1 - 32
+    @param tile   Fill value
+*/
+#if defined(NES_WINDOW_LAYER)
+void fill_win_rect_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t attribute) NO_OVERLAY_LOCALS;
+#else
+#define fill_win_rect_attributes fill_bkg_rect_attributes
 #endif
 
 /** "Flushes" the updates to the shadow attributes so they are written

--- a/gbdk-lib/include/sms/sms.h
+++ b/gbdk-lib/include/sms/sms.h
@@ -740,6 +740,12 @@ void fill_rect_compat(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint16_t
 #define fill_bkg_rect fill_rect_compat
 #define fill_win_rect fill_rect_compat
 
+inline void fill_bkg_rect_attributes(uint8_t x, uint8_t y, uint8_t w, uint8_t h, const uint16_t attribute) {
+    VBK_REG = VBK_ATTRIBUTES;
+    fill_bkg_rect(x, y, w, h, attribute);
+    VBK_REG = VBK_TILES;
+}
+
 /** Shadow OAM array in WRAM, that is transferred into the real OAM each VBlank
 */
 extern volatile uint8_t shadow_OAM[];

--- a/gbdk-lib/libc/targets/mos6502/nes/Makefile
+++ b/gbdk-lib/libc/targets/mos6502/nes/Makefile
@@ -13,7 +13,7 @@ ASSRC =	f_ibm_full.s f_ibm_sh.s f_italic.s f_min.s f_spect.s \
 	metasprites_common.s \
 	metasprites_hide.s metasprites_hide_spr.s set_sprite.s \
 	vram_transfer_buffer.s \
-	set_tile.s set_bk_ts.s set_tile_submap.s fill_rect_bk.s \
+	set_tile.s set_bk_ts.s set_tile_submap.s fill_rect_bk.s fill_rect_bk_attributes.s \
 	set_attribute.s set_bk_attributes.s set_tile_submap_attributes.s flush_attributes.s \
 	nes_palettes.s \
 	pad.s pad_ex.s \

--- a/gbdk-lib/libc/targets/mos6502/nes/fill_rect_bk_attributes.s
+++ b/gbdk-lib/libc/targets/mos6502/nes/fill_rect_bk_attributes.s
@@ -1,0 +1,84 @@
+    .include    "global.s"
+
+    .area   GBDKOVR (PAG, OVR)
+    .fill_bkg_rect_attributes_padding::    .ds 5   ; Padding to avoid clash with _set_bkg_attribute_xy_nes16x16
+    _fill_bkg_rect_attributes_PARM_3::
+    _fill_win_rect_attributes_PARM_3::     .ds 1
+    _fill_bkg_rect_attributes_PARM_4::
+    _fill_win_rect_attributes_PARM_4::     .ds 1
+    _fill_bkg_rect_attributes_PARM_5::
+    _fill_win_rect_attributes_PARM_5::     .ds 1
+    .xpos:                      .ds 1
+    .ypos:                      .ds 1
+    .xpos_save:                 .ds 1
+    .width_save:                .ds 1
+
+    .area   _HOME
+
+.ifdef NES_WINDOW_LAYER
+_fill_win_rect_attributes::
+    tay
+    lda *__current_vram_cfg_write
+    pha
+    ora #PPUHI_WIN
+    sta *__current_vram_cfg_write
+    tya
+    jsr _fill_bkg_rect_attributes
+    pla
+    sta *__current_vram_cfg_write
+    rts
+.endif
+
+_fill_bkg_rect_attributes::
+    .define .width     "_fill_bkg_rect_attributes_PARM_3"
+    .define .height    "_fill_bkg_rect_attributes_PARM_4"
+    .define .attribute "_fill_bkg_rect_attributes_PARM_5"
+    lsr
+    sta *.xpos
+    sta *.xpos_save
+    txa
+    lsr
+    sta *.ypos
+    ; width /= 2, round up
+    lda *.width
+    lsr
+    adc #0
+    sta *.width
+    sta *.width_save
+    ; height /= 2, round up
+    lda *.height
+    lsr
+    adc #0
+    sta *.height
+    lda *.attribute
+    sta *_set_bkg_attribute_xy_nes16x16_PARM_3
+1$:
+    lda *.xpos
+    and #(.DEVICE_SCREEN_BUFFER_WIDTH/2)-1
+    ldx *.ypos
+.ifdef NES_WINDOW_LAYER
+    bit *__current_vram_cfg_write    ; Note: Assumes PPUHI_WIN = 0x80
+    bpl 2$
+    jsr _set_win_attribute_xy_nes16x16
+    jmp 3$
+2$:
+.endif
+    jsr _set_bkg_attribute_xy_nes16x16
+3$:
+    inc *.xpos
+    dec *.width
+    bne 1$
+    lda *.xpos_save
+    sta *.xpos
+    lda *.width_save
+    sta *.width
+    inc *.ypos
+    lda *.ypos
+    cmp #(.DEVICE_SCREEN_BUFFER_HEIGHT/2)
+    bne 0$
+    lda #0
+0$:
+    sta *.ypos
+    dec *.height
+    bne 1$
+    rts


### PR DESCRIPTION
- Add inline VBK_REG-setting functions fill_bkg/win_rect_attributes in gb.h

- Add inline VBK_REG-setting function fill_bkg_rect_attributes in sms.h

- Add asm fill_bkg/win_rect_attributes nes implementation in fill_rect_bk_attributes.s