### PR TITLE
png2asset: workaround for recent linker errors

### DIFF
--- a/gbdk-support/png2asset/Makefile
+++ b/gbdk-support/png2asset/Makefile
@@ -10,6 +10,9 @@ LFLAGS = -g
 
 ifeq ($(OS),Windows_NT)
 	BUILD_OS := Windows_NT
+	# Hopefully temporary fix for Windows build linker errors (2026-05-30)
+	# Ref: https://github.com/PurpleI2P/i2pd/issues/2385
+	CXXFLAGS += -std=c++17 
 else
 	BUILD_OS := $(shell uname -s)
 endif


### PR DESCRIPTION
Hopefully temporary workaround for linker errors on Windows that started happening with no code and build settings changes. Possibly from runner or msys2 build tooling changes.

Errors such as:
C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/16.1.0/../../../../i686-w64-mingw32/bin/ld.exe: main.o: in function `ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EOS4_': 56
C:/msys64/mingw32/include/c++/16.1.0/bits/basic_string.h:787:(.text+0x92): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&)'