### PR TITLE
Examples: Platformer: Remove redundant bankrefs (issue #915)

### DIFF
--- a/gbdk-lib/examples/cross-platform/platformer_template/src/level.c
+++ b/gbdk-lib/examples/cross-platform/platformer_template/src/level.c
@@ -10,12 +10,6 @@
 #define WORLD1_SOLID_TILE_COUNT 17
 #define WORLD2_SOLID_TILE_COUNT 68
 
-BANKREF_EXTERN(World1Tileset)
-BANKREF_EXTERN(World2Tileset)
-BANKREF_EXTERN(World1Area1)
-BANKREF_EXTERN(World1Area2)
-BANKREF_EXTERN(World1Area1)
-
 
 // Instead of directly referencing our map constants, camera and physica code will reference these which can be changed between levels
 uint16_t currentLevelWidth;

--- a/gbdk-lib/examples/cross-platform/platformer_template/src/main.c
+++ b/gbdk-lib/examples/cross-platform/platformer_template/src/main.c
@@ -7,9 +7,6 @@
 #include "NextLevel.h"
 #include "TitleScreen.h"
 
-BANKREF_EXTERN(NextLevel)
-BANKREF_EXTERN(TitleScreen)
-
 
 void main(void)
 {

--- a/gbdk-lib/examples/cross-platform/platformer_template/src/player.c
+++ b/gbdk-lib/examples/cross-platform/platformer_template/src/player.c
@@ -8,8 +8,6 @@
 #include "camera.h"
 #include "level.h"
 
-BANKREF_EXTERN(PlayerCharacterSprites)
-
 
 #define GRAVTY 45
 #define GROUND_FRICTION 15


### PR DESCRIPTION
- The bankref_externs are already available via the respective included header files