### PR TITLE
Fix typo loose to lose

### DIFF
--- a/docs/pages/04_coding_guidelines.md
+++ b/docs/pages/04_coding_guidelines.md
@@ -60,7 +60,7 @@ https://gbdev.io/pandocs/STAT.html#stat-modes
 
   - Global and local static variables are generally more efficient than local non-static variables (which go on the stack and are slower and can result in slower code).
     - An exception to this when there are a small number of local variables (one or two) and the code is not complex. Then the compiler may allocate those variables to CPU registers instead which may be faster.
-    - Functions which use global or static local variables will loose re-entrancy. In most cases it is not a problem, but important to keep in mind.
+    - Functions which use global or static local variables will lose re-entrancy. In most cases it is not a problem, but important to keep in mind.
     - In particular avoid putting big arrays on the stack, consider static local or global.
 
   - Keep the number of arguments passed to functions small (ideally one or two arguments at most). When there are a large number of arguments they get pushed onto the stack and result in more overhead for function calls. See the Calling Conventions in the SDCC compiler manual for details.

--- a/gbdk-lib/examples/cross-platform/platformer_template/Readme.md
+++ b/gbdk-lib/examples/cross-platform/platformer_template/Readme.md
@@ -46,4 +46,4 @@ Make sure to set their level tile data into vram.
 
 Make sure to set the number of solid tiles. These should always come first. This should include duplicates and flipped tiles.
 
-> As an optimizatation you could remove adjust your tileset, tilemap, and png2asset to handle duplicates/tile-flipping, but you would lose some DMG compatibility
+> As an optimizatation you could adjust your tileset, tilemap, and png2asset to handle duplicates/tile-flipping, but you would lose some DMG compatibility

--- a/gbdk-lib/examples/cross-platform/platformer_template/Readme.md
+++ b/gbdk-lib/examples/cross-platform/platformer_template/Readme.md
@@ -46,4 +46,4 @@ Make sure to set their level tile data into vram.
 
 Make sure to set the number of solid tiles. These should always come first. This should include duplicates and flipped tiles.
 
-> As an optimizatation you could remove adjust your tileset, tilemap, and png2asset to handle duplicates/tile-flipping, but you would loose some DMG compatibility
+> As an optimizatation you could remove adjust your tileset, tilemap, and png2asset to handle duplicates/tile-flipping, but you would lose some DMG compatibility


### PR DESCRIPTION
Fix common typo of loose instead of lose.